### PR TITLE
Expose view mode constants and programmatic authoring docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,89 @@ See [DATA_STRUCTURES.md](./DATA_STRUCTURES.md) for complete type documentation a
 - `GameFlagState` - Current flag values `{ [flagId]: value }`
 - `DialogueResult` - Result from running dialogue (updated flags, visited nodes)
 
+### Dialogue Editor V2 with View Modes
+
+`DialogueEditorV2` supports graph, yarn, and play views. Use the exported `VIEW_MODE` constant (instead of string literals) alongside the `ViewMode` type so consumers get auto-complete and type safety when switching views.
+
+```tsx
+import { DialogueEditorV2, VIEW_MODE, type DialogueTree, type ViewMode } from '@magicborn/dialogue-forge';
+import { useState } from 'react';
+
+export function DialogueEditorDemo() {
+  const [dialogue, setDialogue] = useState<DialogueTree | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>(VIEW_MODE.GRAPH);
+
+  return (
+    <DialogueEditorV2
+      dialogue={dialogue}
+      onChange={setDialogue}
+      viewMode={viewMode}
+      onViewModeChange={setViewMode}
+    />
+  );
+}
+```
+
+### Authoring dialogue data programmatically
+
+You can build dialogue content without the editor and still take advantage of the types and constants that power the scene player. This makes it easy to script nonlinear stories, export them, or feed them directly into `ScenePlayer`.
+
+```ts
+import {
+  NODE_TYPE,
+  type DialogueTree,
+  type DialogueNode,
+  ScenePlayer,
+} from '@magicborn/dialogue-forge';
+
+const nodes: Record<string, DialogueNode> = {
+  npc_1: {
+    id: 'npc_1',
+    type: NODE_TYPE.NPC,
+    speaker: 'Merchant',
+    content: 'Welcome, traveler! Looking for supplies?',
+    nextNodeId: 'player_1',
+    x: 0,
+    y: 0,
+  },
+  player_1: {
+    id: 'player_1',
+    type: NODE_TYPE.PLAYER,
+    content: ' ',
+    choices: [
+      { id: 'buy', text: 'Show me your wares.', nextNodeId: 'npc_2' },
+      { id: 'chat', text: 'Any rumors?', nextNodeId: 'npc_3' },
+    ],
+    x: 320,
+    y: 0,
+  },
+  npc_2: {
+    id: 'npc_2',
+    type: NODE_TYPE.NPC,
+    content: 'Take a look! Fresh stock just arrived.',
+    x: 640,
+    y: -120,
+  },
+  npc_3: {
+    id: 'npc_3',
+    type: NODE_TYPE.NPC,
+    content: 'Bandits have been spotted near the bridge—stay sharp.',
+    x: 640,
+    y: 120,
+  },
+};
+
+const merchantIntro: DialogueTree = {
+  id: 'merchant_intro',
+  title: 'Merchant Greeting',
+  startNodeId: 'npc_1',
+  nodes,
+};
+
+// Render or test the dialogue without the editor
+// <ScenePlayer dialogue={merchantIntro} gameState={yourGameState} onComplete={...} />
+```
+
 ## Complete Example
 
 ```typescript

--- a/src/components/DialogueEditorV2.tsx
+++ b/src/components/DialogueEditorV2.tsx
@@ -45,6 +45,7 @@ import { NPCEdgeV2 } from './NPCEdgeV2';
 import { FlagSchema } from '../types/flags';
 import { Character } from '../types/characters';
 import { NODE_WIDTH } from '../utils/constants';
+import { VIEW_MODE } from '../types/constants';
 
 // Define node and edge types outside component for stability
 const nodeTypes = {
@@ -82,7 +83,7 @@ function DialogueEditorV2Internal({
   showTitleEditor = true,
   flagSchema,
   characters = {},
-  initialViewMode = 'graph',
+  initialViewMode = VIEW_MODE.GRAPH,
   viewMode: controlledViewMode,
   onViewModeChange,
   layoutStrategy: propLayoutStrategy = 'dagre', // Accept from parent
@@ -1015,7 +1016,7 @@ function DialogueEditorV2Internal({
 
   return (
     <div className={`dialogue-editor-v2 ${className} w-full h-full flex flex-col`}>
-      {viewMode === 'graph' && (
+      {viewMode === VIEW_MODE.GRAPH && (
         <div className="flex-1 flex overflow-hidden">
           {/* React Flow Graph */}
           <div className="flex-1 relative w-full h-full" ref={reactFlowWrapperRef} style={{ minHeight: 0 }}>
@@ -1623,7 +1624,7 @@ function DialogueEditorV2Internal({
         </div>
       )}
 
-      {viewMode === 'yarn' && (
+      {viewMode === VIEW_MODE.YARN && (
         <YarnView
           dialogue={dialogue}
           onExport={() => {
@@ -1653,7 +1654,7 @@ function DialogueEditorV2Internal({
         />
       )}
 
-      {viewMode === 'play' && (
+      {viewMode === VIEW_MODE.PLAY && (
         <PlayView
           dialogue={dialogue}
           flagSchema={flagSchema}

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -4,6 +4,17 @@
  */
 
 /**
+ * View modes for DialogueEditorV2
+ */
+export const VIEW_MODE = {
+  GRAPH: 'graph',
+  YARN: 'yarn',
+  PLAY: 'play',
+} as const;
+
+export type ViewMode = typeof VIEW_MODE[keyof typeof VIEW_MODE];
+
+/**
  * Node types in a dialogue tree
  */
 export const NODE_TYPE = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import { ConditionOperator, NodeType } from './constants';
+export type { ViewMode } from './constants';
 
 export interface Choice {
   id: string;
@@ -49,8 +50,6 @@ export interface DialogueTree {
 }
 
 import { FlagSchema } from './flags';
-
-export type ViewMode = 'graph' | 'yarn' | 'play';
 
 export interface DialogueEditorProps {
   dialogue: DialogueTree | null;


### PR DESCRIPTION
## Summary
- add an exported VIEW_MODE constant alongside the ViewMode type and wire DialogueEditorV2 defaults to it
- document constant-based view switching and show how to author DialogueTree data programmatically with the exported node types
- keep type exports aligned for ScenePlayer and editor consumers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951c5c3cdf8832d82b05fa1583189c2)