### PR TITLE
Copy styles into build output

### DIFF
--- a/bin/postbuild.js
+++ b/bin/postbuild.js
@@ -1,0 +1,69 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcStylesDir = path.join(__dirname, '..', 'src', 'styles');
+const distStylesDir = path.join(__dirname, '..', 'dist', 'styles');
+
+function copyStyles() {
+  if (!fs.existsSync(srcStylesDir)) return;
+  fs.mkdirSync(distStylesDir, { recursive: true });
+  const files = fs.readdirSync(srcStylesDir).filter((file) => file.endsWith('.css'));
+  files.forEach((file) => {
+    fs.copyFileSync(path.join(srcStylesDir, file), path.join(distStylesDir, file));
+  });
+}
+
+function updateEsmEntryPoints() {
+  const esmEntries = [
+    path.join(__dirname, '..', 'dist', 'esm', 'index.js'),
+    path.join(__dirname, '..', 'dist', 'esm', 'index.d.ts')
+  ];
+
+  esmEntries.forEach((filePath) => {
+    if (!fs.existsSync(filePath)) return;
+    const content = fs.readFileSync(filePath, 'utf8');
+    const updated = content.replace(/\.\/styles\//g, '../styles/');
+    fs.writeFileSync(filePath, updated);
+  });
+}
+
+function verifyCssPaths() {
+  const checks = [
+    {
+      filePath: path.join(__dirname, '..', 'dist', 'index.js'),
+      cssImports: ['./styles/scrollbar.css', './styles/theme.css']
+    },
+    {
+      filePath: path.join(__dirname, '..', 'dist', 'index.d.ts'),
+      cssImports: ['./styles/scrollbar.css', './styles/theme.css']
+    },
+    {
+      filePath: path.join(__dirname, '..', 'dist', 'esm', 'index.js'),
+      cssImports: ['../styles/scrollbar.css', '../styles/theme.css']
+    },
+    {
+      filePath: path.join(__dirname, '..', 'dist', 'esm', 'index.d.ts'),
+      cssImports: ['../styles/scrollbar.css', '../styles/theme.css']
+    }
+  ];
+
+  checks.forEach(({ filePath, cssImports }) => {
+    if (!fs.existsSync(filePath)) return;
+    const content = fs.readFileSync(filePath, 'utf8');
+
+    cssImports.forEach((cssPath) => {
+      if (!content.includes(cssPath)) {
+        throw new Error(`Missing CSS import ${cssPath} in ${path.relative(process.cwd(), filePath)}`);
+      }
+
+      const resolved = path.resolve(path.dirname(filePath), cssPath);
+      if (!fs.existsSync(resolved)) {
+        throw new Error(`CSS asset not found for ${cssPath} referenced by ${path.relative(process.cwd(), filePath)}`);
+      }
+    });
+  });
+}
+
+copyStyles();
+updateEsmEntryPoints();
+verifyCssPaths();

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
   },
   "files": [
     "dist",
+    "dist/styles",
     "demo",
     "bin",
     "README.md"
   ],
   "scripts": {
-    "build": "tsc && tsc --module esnext --outDir dist/esm",
+    "build": "tsc && tsc --module esnext --outDir dist/esm && node ./bin/postbuild.js",
     "dev": "cd demo && npm install && npm run dev",
     "dev:watch": "tsc --watch",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- copy CSS assets into dist/styles during the build process and align ESM entry imports to the shared location
- add a postbuild script to keep style assets in the published package via the files list
- add build-time verification to ensure entry points reference the emitted CSS assets

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951cfe721e8832db4b5af2afdcdfd0e)