### PR TITLE
Add narrative and storylet node types

### DIFF
--- a/src/components/PlayView.tsx
+++ b/src/components/PlayView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useRef } from 'react';
 import { DialogueTree } from '../types';
+import { FLAG_TYPE } from '../types/constants';
 import { FlagSchema, FlagType } from '../types/flags';
 import { GameFlagState, DialogueResult, FlagState } from '../types/game-state';
 import { initializeFlags } from '../lib/flag-manager';
@@ -68,17 +69,17 @@ export function PlayView({ dialogue, startNodeId, flagSchema, initialFlags }: Pl
   // Get all non-dialogue flags from schema
   const gameFlagsList = useMemo(() => {
     if (!flagSchema) return [];
-    return flagSchema.flags.filter(f => f.type !== 'dialogue');
+    return flagSchema.flags.filter(f => f.type !== FLAG_TYPE.DIALOGUE);
   }, [flagSchema]);
   
   const flagTypeColors: Record<FlagType, string> = {
-    dialogue: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
-    quest: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-    achievement: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
-    item: 'bg-green-500/20 text-green-400 border-green-500/30',
-    stat: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
-    title: 'bg-pink-500/20 text-pink-400 border-pink-500/30',
-    global: 'bg-orange-500/20 text-orange-400 border-orange-500/30',
+    [FLAG_TYPE.DIALOGUE]: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
+    [FLAG_TYPE.QUEST]: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+    [FLAG_TYPE.ACHIEVEMENT]: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
+    [FLAG_TYPE.ITEM]: 'bg-green-500/20 text-green-400 border-green-500/30',
+    [FLAG_TYPE.STAT]: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
+    [FLAG_TYPE.TITLE]: 'bg-pink-500/20 text-pink-400 border-pink-500/30',
+    [FLAG_TYPE.GLOBAL]: 'bg-orange-500/20 text-orange-400 border-orange-500/30',
   };
 
   return (

--- a/src/types/conditionals.ts
+++ b/src/types/conditionals.ts
@@ -1,37 +1,31 @@
-import { ConditionOperator } from './constants';
+import { CONDITION_OPERATOR, type ConditionOperator } from './constants';
+
+export const CONDITIONAL_BLOCK_TYPE = {
+  IF: 'if',
+  ELSE_IF: 'elseif',
+  ELSE: 'else',
+} as const;
+
+export type ConditionalBlockType =
+  typeof CONDITIONAL_BLOCK_TYPE[keyof typeof CONDITIONAL_BLOCK_TYPE];
+
+export interface Condition {
+  flag: string;
+  operator: ConditionOperator;
+  value?: boolean | number | string;
+}
 
 /**
- * Conditional block for Yarn Spinner if/elseif/else/endif
+ * Conditional content block for if/elseif/else statements
  */
 export interface ConditionalBlock {
-  type: 'if' | 'elseif' | 'else';
-  condition?: {
-    flag: string;
-    operator: ConditionOperator | 'equals' | 'not_equals' | 'greater_than' | 'less_than' | 'greater_equal' | 'less_equal';
-    value?: boolean | number | string;
-  };
-  content: string; // Dialogue content within this block
-  nextNodeId?: string; // Optional jump after this block
-}
-
-/**
- * Extended DialogueNode with conditional support
- */
-export interface ConditionalDialogueNode {
   id: string;
-  type: 'npc' | 'player' | 'conditional';
-  speaker?: string;
+  type: ConditionalBlockType;
+  condition?: Condition[]; // Required for 'if' and 'elseif', undefined for 'else'
   content: string;
-  choices?: any[];
-  nextNodeId?: string;
-  setFlags?: string[];
-  conditionals?: ConditionalBlock[]; // For conditional nodes
-  x: number;
-  y: number;
+  speaker?: string; // Legacy: text speaker name (deprecated, use characterId)
+  characterId?: string; // Character ID from game state
+  nextNodeId?: string; // Optional: where to go after this block's content
 }
 
-
-
-
-
-
+export const CONDITION_OPERATORS = CONDITION_OPERATOR;

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -21,6 +21,9 @@ export const NODE_TYPE = {
   NPC: 'npc',
   PLAYER: 'player',
   CONDITIONAL: 'conditional',
+  STORYLET: 'storylet',
+  STORYLET_POOL: 'storylet_pool',
+  RANDOMIZER: 'randomizer',
 } as const;
 
 export type NodeType = typeof NODE_TYPE[keyof typeof NODE_TYPE];

--- a/src/types/game-state.ts
+++ b/src/types/game-state.ts
@@ -31,7 +31,7 @@ import type { Character } from './characters';
  * Must have a 'flags' property, but can have any other structure
  */
 export interface BaseGameState {
-  flags?: FlagState;
+  flags: FlagState;
   characters?: Record<string, Character>; // Character definitions
   // Users extend this with their own properties:
   // player?: PlayerState;
@@ -41,25 +41,29 @@ export interface BaseGameState {
 /**
  * Convenience type for extending game state
  */
-export type GameState<T extends Record<string, any> = {}> = BaseGameState & T;
+export type GameState<T extends Record<string, unknown> = Record<string, never>> =
+  BaseGameState & T;
 
 /**
  * Updated flags after dialogue completes
  */
-export interface DialogueResult {
+export interface DialogueResult<TGameState extends BaseGameState = BaseGameState> {
   updatedFlags: FlagState;
   dialogueTree: DialogueTree;
   completedNodeIds: string[]; // Nodes that were visited
+  gameState: TGameState;
 }
 
 /**
  * Props for running a dialogue (simulation/play mode)
  */
-export interface DialogueRunProps {
+export interface DialogueRunProps<
+  TGameState extends BaseGameState = BaseGameState,
+> {
   dialogue: DialogueTree;
-  gameState: Record<string, any>; // Any JSON game state (will be flattened)
+  gameState: TGameState; // Any JSON game state (will be flattened)
   startNodeId?: string;
-  onComplete?: (result: DialogueResult) => void;
+  onComplete?: (result: DialogueResult<TGameState>) => void;
   onFlagUpdate?: (flags: FlagState) => void;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,19 @@
-import { ConditionOperator, NodeType } from './constants';
+import { NodeType } from './constants';
+import type { Condition, ConditionalBlock } from './conditionals';
+import type { RandomizerBranch, StoryletPool } from './narrative';
 export type { ViewMode } from './constants';
+export type { Condition, ConditionalBlock } from './conditionals';
+export type {
+  NarrativeAct,
+  NarrativeChapter,
+  NarrativeElement,
+  NarrativePage,
+  RandomizerBranch,
+  StoryThread,
+  Storylet,
+  StoryletPool,
+  StoryletSelectionMode,
+} from './narrative';
 
 export interface Choice {
   id: string;
@@ -7,25 +21,6 @@ export interface Choice {
   nextNodeId?: string; // Optional - choice can end the dialogue
   conditions?: Condition[];
   setFlags?: string[];
-}
-
-export interface Condition {
-  flag: string;
-  operator: ConditionOperator;
-  value?: boolean | number | string; // Required for comparison operators
-}
-
-/**
- * Conditional content block for if/elseif/else statements
- */
-export interface ConditionalBlock {
-  id: string;
-  type: 'if' | 'elseif' | 'else';
-  condition?: Condition[]; // Required for 'if' and 'elseif', undefined for 'else'
-  content: string;
-  speaker?: string; // Legacy: text speaker name (deprecated, use characterId)
-  characterId?: string; // Character ID from game state
-  nextNodeId?: string; // Optional: where to go after this block's content
 }
 
 export interface DialogueNode {
@@ -38,6 +33,10 @@ export interface DialogueNode {
   nextNodeId?: string;
   setFlags?: string[];
   conditionalBlocks?: ConditionalBlock[]; // For conditional nodes (if/elseif/else/endif)
+  randomizerBranches?: RandomizerBranch[]; // For randomizer nodes
+  storyletPoolId?: string; // For storylet nodes
+  storyletId?: string; // For storylet nodes targeting a specific storylet
+  storyletPool?: StoryletPool; // Inline pool data for storylet pool nodes
   x: number;
   y: number;
 }

--- a/src/types/narrative.ts
+++ b/src/types/narrative.ts
@@ -1,0 +1,80 @@
+import type { Condition } from './conditionals';
+
+export const NARRATIVE_ELEMENT = {
+  THREAD: 'thread',
+  ACT: 'act',
+  CHAPTER: 'chapter',
+  PAGE: 'page',
+  STORYLET: 'storylet',
+} as const;
+
+export type NarrativeElement = typeof NARRATIVE_ELEMENT[keyof typeof NARRATIVE_ELEMENT];
+
+export const STORYLET_SELECTION_MODE = {
+  WEIGHTED: 'weighted',
+  SEQUENTIAL: 'sequential',
+  RANDOM: 'random',
+} as const;
+
+export type StoryletSelectionMode =
+  typeof STORYLET_SELECTION_MODE[keyof typeof STORYLET_SELECTION_MODE];
+
+export interface NarrativePage {
+  id: string;
+  title?: string;
+  summary?: string;
+  nodeIds: string[];
+  type?: typeof NARRATIVE_ELEMENT.PAGE;
+}
+
+export interface NarrativeChapter {
+  id: string;
+  title?: string;
+  summary?: string;
+  pages: NarrativePage[];
+  storyletPools?: StoryletPool[];
+  type?: typeof NARRATIVE_ELEMENT.CHAPTER;
+}
+
+export interface NarrativeAct {
+  id: string;
+  title?: string;
+  summary?: string;
+  chapters: NarrativeChapter[];
+  type?: typeof NARRATIVE_ELEMENT.ACT;
+}
+
+export interface StoryThread {
+  id: string;
+  title?: string;
+  summary?: string;
+  acts: NarrativeAct[];
+  type?: typeof NARRATIVE_ELEMENT.THREAD;
+}
+
+export interface Storylet {
+  id: string;
+  title?: string;
+  summary?: string;
+  conditions?: Condition[];
+  weight?: number;
+  nextNodeId?: string;
+  type?: typeof NARRATIVE_ELEMENT.STORYLET;
+}
+
+export interface StoryletPool {
+  id: string;
+  title?: string;
+  summary?: string;
+  selectionMode?: StoryletSelectionMode;
+  storylets: Storylet[];
+  fallbackNodeId?: string;
+}
+
+export interface RandomizerBranch {
+  id: string;
+  label?: string;
+  weight?: number;
+  nextNodeId?: string;
+  storyletPoolId?: string;
+}


### PR DESCRIPTION
## Summary
- add narrative hierarchy types for threads, acts, chapters, pages, and storylets
- expand node and constant definitions to support storylet, storylet pool, and randomizer nodes
- consolidate conditional typings and tighten game state generics with required flags

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d86365e60832daa4ff79209730a3f)