### PR TITLE
Add GamePlayer experience and dialogue traversal hooks

### DIFF
--- a/src/components/GamePlayer/ReadingPane.tsx
+++ b/src/components/GamePlayer/ReadingPane.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { DialogueHistoryEntry, DialogueStep } from '../../hooks/useDialogueRunner';
+import { NODE_TYPE } from '../../types/constants';
+
+interface ReadingPaneProps {
+  history: DialogueHistoryEntry[];
+  currentStep: DialogueStep | null;
+  currentPage: number;
+  status: 'running' | 'completed';
+}
+
+export function ReadingPane({ history, currentStep, currentPage, status }: ReadingPaneProps) {
+  const visibleHistory = history.slice(0, Math.max(currentPage + 1, 0));
+
+  return (
+    <section className="flex-1 flex flex-col bg-[#0d0d14]">
+      <div className="flex-1 overflow-y-auto p-6 space-y-4">
+        {visibleHistory.length === 0 && (
+          <div className="text-gray-500 text-sm">Use the storylets on the right to begin the scene.</div>
+        )}
+
+        {visibleHistory.map(entry => (
+          <div
+            key={`${entry.nodeId}-${entry.content}`}
+            className={`flex ${entry.type === NODE_TYPE.PLAYER ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`max-w-[80%] rounded-2xl px-4 py-3 shadow-lg ${
+                entry.type === NODE_TYPE.PLAYER
+                  ? 'bg-[#e94560] text-white rounded-br-md'
+                  : 'bg-[#1a1a2e] text-gray-100 rounded-bl-md'
+              }`}
+            >
+              {entry.type !== NODE_TYPE.PLAYER && entry.speaker && (
+                <div className="text-xs text-[#e94560] font-medium mb-1">{entry.speaker}</div>
+              )}
+              <div className="whitespace-pre-wrap leading-relaxed">{entry.content}</div>
+            </div>
+          </div>
+        ))}
+
+        {currentStep && currentStep.isChoice && currentStep.content && (
+          <div className="text-gray-400 text-sm border border-dashed border-[#2a2a3e] rounded-lg p-3">
+            <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Prompt</p>
+            <p>{currentStep.content}</p>
+          </div>
+        )}
+
+        {status === 'completed' && (
+          <div className="text-center text-gray-500 text-sm pt-4">Dialogue complete.</div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/GamePlayer/StoryletSidebar.tsx
+++ b/src/components/GamePlayer/StoryletSidebar.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { DialogueStep } from '../../hooks/useDialogueRunner';
+
+interface StoryletSidebarProps {
+  currentStep: DialogueStep | null;
+  onContinue: () => void;
+  onChoose: (choiceId: string) => void;
+  status: 'running' | 'completed';
+}
+
+export function StoryletSidebar({ currentStep, onContinue, onChoose, status }: StoryletSidebarProps) {
+  const isChoice = currentStep?.isChoice;
+  const noAvailableChoices = isChoice && currentStep?.choices.length === 0;
+
+  return (
+    <aside className="w-80 bg-[#0b0b14] border-l border-[#1a1a2e] flex-shrink-0 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-[10px] uppercase tracking-wide text-gray-500">Storylets</p>
+          <h3 className="text-white font-semibold">What happens next?</h3>
+        </div>
+        <span className="text-[10px] px-2 py-1 rounded-full bg-[#12121f] border border-[#1f1f2e] text-gray-400">
+          {isChoice ? 'Choice' : 'Narrative'}
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        {isChoice && currentStep?.choices.map(choice => (
+          <button
+            key={choice.id}
+            onClick={() => onChoose(choice.id)}
+            className="w-full text-left px-4 py-3 rounded-lg border border-[#2a2a3e] hover:border-[#e94560] bg-[#12121a] hover:bg-[#1a1a2a] text-gray-200 transition-all group flex items-center justify-between"
+            disabled={status === 'completed'}
+          >
+            <span>{choice.text}</span>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="text-gray-600 group-hover:text-[#e94560] transition-colors"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </button>
+        ))}
+
+        {!isChoice && status !== 'completed' && (
+          <button
+            onClick={onContinue}
+            className="w-full px-4 py-3 bg-[#e94560] hover:bg-[#d63850] text-white rounded-lg transition-colors font-medium shadow-md hover:shadow-lg"
+          >
+            Continue
+          </button>
+        )}
+
+        {status === 'completed' && (
+          <div className="text-center text-gray-500 text-sm border border-[#1f1f2e] rounded-lg p-3 bg-[#0f0f1a]">
+            Dialogue finished
+          </div>
+        )}
+
+        {noAvailableChoices && status !== 'completed' && (
+          <div className="text-xs text-gray-500 bg-[#0f0f1a] border border-dashed border-[#2a2a3e] rounded-lg p-3">
+            No available choices for the current conditions.
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/GamePlayer/WorldPane.tsx
+++ b/src/components/GamePlayer/WorldPane.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { NarrativeProgress } from '../../hooks/useNarrativeTraversal';
+
+interface WorldPaneProps {
+  progress: NarrativeProgress;
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+  visitedNodes: number;
+  totalNodes: number;
+}
+
+export function WorldPane({
+  progress,
+  onNextPage,
+  onPreviousPage,
+  visitedNodes,
+  totalNodes,
+}: WorldPaneProps) {
+  const completion = Math.round(progress.progress * 100);
+
+  return (
+    <aside className="w-64 bg-[#0b0b14] border-r border-[#1a1a2e] flex-shrink-0 flex flex-col">
+      <div className="p-4 border-b border-[#1a1a2e]">
+        <p className="text-[10px] uppercase tracking-wide text-gray-500 mb-1">Narrative</p>
+        <h2 className="text-lg font-semibold text-white leading-tight">{progress.chapterTitle}</h2>
+        <p className="text-xs text-gray-500 mt-1">{progress.actTitle}</p>
+      </div>
+
+      <div className="p-4 space-y-4 flex-1 overflow-y-auto">
+        <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3">
+          <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
+            <span>Page {progress.pageIndex + 1}</span>
+            <span className="text-gray-500">of {progress.pageCount}</span>
+          </div>
+          <div className="h-2 bg-[#141422] rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-[#e94560] to-[#8b5cf6]"
+              style={{ width: `${completion}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-[10px] text-gray-500 mt-2">
+            <span>Progress</span>
+            <span className="text-gray-300">{completion}%</span>
+          </div>
+        </div>
+
+        <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3 space-y-2">
+          <div className="flex items-center justify-between text-xs text-gray-400">
+            <span>Visited Storylets</span>
+            <span className="text-gray-100">{visitedNodes}</span>
+          </div>
+          <div className="flex items-center justify-between text-xs text-gray-400">
+            <span>Total Nodes</span>
+            <span className="text-gray-100">{totalNodes}</span>
+          </div>
+        </div>
+
+        <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3 space-y-2">
+          <p className="text-[11px] text-gray-400">Navigate chapters</p>
+          <div className="flex gap-2">
+            <button
+              className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+              onClick={onPreviousPage}
+            >
+              Previous
+            </button>
+            <button
+              className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+              onClick={onNextPage}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/GamePlayer/index.tsx
+++ b/src/components/GamePlayer/index.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useMemo } from 'react';
+import { DialogueTree } from '../../types';
+import { FlagSchema } from '../../types/flags';
+import { DialogueResult, FlagState } from '../../types/game-state';
+import { ReadingPane } from './ReadingPane';
+import { StoryletSidebar } from './StoryletSidebar';
+import { WorldPane } from './WorldPane';
+import { useDialogueRunner } from '../../hooks/useDialogueRunner';
+import { useNarrativeTraversal } from '../../hooks/useNarrativeTraversal';
+
+export interface GamePlayerProps {
+  dialogue: DialogueTree;
+  startNodeId?: string;
+  flagSchema?: FlagSchema;
+  initialFlags?: FlagState;
+  onComplete?: (result: DialogueResult) => void;
+  onFlagsChange?: (flags: FlagState) => void;
+}
+
+export function GamePlayer({
+  dialogue,
+  startNodeId,
+  flagSchema,
+  initialFlags,
+  onComplete,
+  onFlagsChange,
+}: GamePlayerProps) {
+  const runner = useDialogueRunner({
+    dialogue,
+    startNodeId,
+    flagSchema,
+    initialFlags,
+    onComplete,
+    onFlagsChange,
+  });
+
+  const narrative = useNarrativeTraversal({
+    title: dialogue.title,
+    initialPageCount: Math.max(runner.history.length, 1),
+  });
+
+  const { progress, nextPage, previousPage, setPageCount, goToPage } = narrative;
+
+  useEffect(() => {
+    const totalPages = Math.max(runner.history.length, 1);
+    setPageCount(totalPages);
+    goToPage(totalPages - 1);
+  }, [runner.history.length, setPageCount, goToPage]);
+
+  const totalNodes = useMemo(() => Object.keys(dialogue.nodes).length, [dialogue.nodes]);
+
+  return (
+    <div className="flex border border-[#1a1a2e] rounded-xl overflow-hidden bg-[#0f0f1a] h-full min-h-[480px]">
+      <WorldPane
+        progress={progress}
+        onNextPage={nextPage}
+        onPreviousPage={previousPage}
+        visitedNodes={runner.visitedNodeIds.length}
+        totalNodes={totalNodes}
+      />
+
+      <ReadingPane
+        history={runner.history}
+        currentStep={runner.currentStep}
+        currentPage={progress.pageIndex}
+        status={runner.status}
+      />
+
+      <StoryletSidebar
+        currentStep={runner.currentStep}
+        onContinue={runner.continueDialogue}
+        onChoose={runner.chooseOption}
+        status={runner.status}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useDialogueRunner.ts
+++ b/src/hooks/useDialogueRunner.ts
@@ -1,0 +1,361 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Choice, ConditionalBlock, DialogueNode, DialogueTree } from '../types';
+import { DialogueResult, FlagState } from '../types/game-state';
+import { FlagSchema } from '../types/flags';
+import { FLAG_TYPE, NODE_TYPE, type NodeType } from '../types/constants';
+import { mergeFlagUpdates } from '../lib/flag-manager';
+import { evaluateConditions } from '../lib/yarn-runner/condition-evaluator';
+
+export interface DialogueHistoryEntry {
+  nodeId: string;
+  type: NodeType;
+  speaker?: string;
+  content: string;
+}
+
+export interface DialogueStep {
+  nodeId: string;
+  type: NodeType;
+  speaker?: string;
+  content: string;
+  nextNodeId?: string;
+  isChoice: boolean;
+  isTerminal: boolean;
+  choices: Choice[];
+}
+
+interface DialogueRunnerOptions {
+  dialogue: DialogueTree;
+  startNodeId?: string;
+  initialFlags?: FlagState;
+  flagSchema?: FlagSchema;
+  onComplete?: (result: DialogueResult) => void;
+  onFlagsChange?: (flags: FlagState) => void;
+}
+
+interface ResolvedConditionalBlock {
+  block: ConditionalBlock | null;
+  nextNodeId?: string;
+}
+
+function findMatchingBlock(
+  blocks: ConditionalBlock[],
+  flags: FlagState,
+  memoryFlags: Set<string>
+): ResolvedConditionalBlock {
+  let matched: ConditionalBlock | null = null;
+
+  for (const block of blocks) {
+    if (block.type === 'else') {
+      if (!matched) {
+        matched = block;
+      }
+      continue;
+    }
+
+    if (!block.condition || block.condition.length === 0) {
+      continue;
+    }
+
+    const allMatch = evaluateConditions(block.condition, flags, memoryFlags);
+    if (allMatch) {
+      matched = block;
+      break;
+    }
+  }
+
+  if (!matched) {
+    return { block: null };
+  }
+
+  return {
+    block: matched,
+    nextNodeId: matched.nextNodeId,
+  };
+}
+
+function evaluateNode(
+  node: DialogueNode,
+  flags: FlagState,
+  memoryFlags: Set<string>
+): DialogueStep {
+  if (node.type === NODE_TYPE.PLAYER) {
+    const availableChoices = node.choices?.filter(choice => {
+      if (!choice.conditions) return true;
+      return evaluateConditions(choice.conditions, flags, memoryFlags);
+    }) || [];
+
+    return {
+      nodeId: node.id,
+      type: node.type,
+      content: node.content,
+      speaker: node.speaker,
+      nextNodeId: undefined,
+      isChoice: true,
+      isTerminal: availableChoices.length === 0,
+      choices: availableChoices,
+    };
+  }
+
+  if (node.type === NODE_TYPE.CONDITIONAL && node.conditionalBlocks) {
+    const { block, nextNodeId } = findMatchingBlock(node.conditionalBlocks, flags, memoryFlags);
+
+    if (!block) {
+      return {
+        nodeId: node.id,
+        type: node.type,
+        content: '',
+        speaker: undefined,
+        nextNodeId: undefined,
+        isChoice: false,
+        isTerminal: true,
+        choices: [],
+      };
+    }
+
+    return {
+      nodeId: node.id,
+      type: node.type,
+      content: block.content,
+      speaker: block.speaker,
+      nextNodeId: nextNodeId ?? node.nextNodeId,
+      isChoice: false,
+      isTerminal: !nextNodeId && !node.nextNodeId,
+      choices: [],
+    };
+  }
+
+  let content = node.content;
+  let speaker = node.speaker;
+  let nextNodeId = node.nextNodeId;
+
+  if (node.conditionalBlocks && node.conditionalBlocks.length > 0) {
+    const { block, nextNodeId: conditionalNext } = findMatchingBlock(node.conditionalBlocks, flags, memoryFlags);
+    if (block) {
+      content = block.content;
+      speaker = block.speaker ?? speaker;
+      nextNodeId = conditionalNext ?? nextNodeId;
+    }
+  }
+
+  return {
+    nodeId: node.id,
+    type: node.type,
+    content,
+    speaker,
+    nextNodeId,
+    isChoice: false,
+    isTerminal: !nextNodeId,
+    choices: [],
+  };
+}
+
+function buildCompletionResult(
+  dialogue: DialogueTree,
+  flags: FlagState,
+  visited: Set<string>
+): DialogueResult {
+  return {
+    updatedFlags: flags,
+    dialogueTree: dialogue,
+    completedNodeIds: Array.from(visited),
+  };
+}
+
+function isDialogueFlag(flagId: string, flagSchema?: FlagSchema): boolean {
+  if (!flagSchema) return false;
+  const definition = flagSchema.flags.find(flag => flag.id === flagId);
+  return definition?.type === FLAG_TYPE.DIALOGUE;
+}
+
+export function useDialogueRunner({
+  dialogue,
+  startNodeId,
+  initialFlags,
+  flagSchema,
+  onComplete,
+  onFlagsChange,
+}: DialogueRunnerOptions) {
+  const initialNodeId = startNodeId || dialogue.startNodeId;
+  const [currentNodeId, setCurrentNodeId] = useState(initialNodeId);
+  const [flags, setFlags] = useState<FlagState>(initialFlags || {});
+  const [history, setHistory] = useState<DialogueHistoryEntry[]>([]);
+  const [currentStep, setCurrentStep] = useState<DialogueStep | null>(null);
+  const [status, setStatus] = useState<'running' | 'completed'>('running');
+
+  const visitedNodesRef = useRef<Set<string>>(new Set());
+  const memoryFlagsRef = useRef<Set<string>>(new Set());
+  const hasCompletedRef = useRef(false);
+  const flagsRef = useRef(flags);
+
+  useEffect(() => {
+    flagsRef.current = flags;
+  }, [flags]);
+
+  useEffect(() => {
+    if (onFlagsChange) {
+      onFlagsChange(flags);
+    }
+  }, [flags, onFlagsChange]);
+
+  useEffect(() => {
+    visitedNodesRef.current = new Set();
+    memoryFlagsRef.current = new Set(
+      Object.keys(initialFlags || {}).filter(flagId => isDialogueFlag(flagId, flagSchema))
+    );
+    hasCompletedRef.current = false;
+    setHistory([]);
+    setFlags(initialFlags || {});
+    setStatus('running');
+    setCurrentNodeId(initialNodeId);
+  }, [dialogue.id, initialNodeId, initialFlags, flagSchema]);
+
+  const completeDialogue = useCallback(
+    (latestFlags?: FlagState) => {
+      if (hasCompletedRef.current) return;
+      hasCompletedRef.current = true;
+      setStatus('completed');
+
+      const finalFlags = latestFlags || flagsRef.current;
+      const result = buildCompletionResult(dialogue, finalFlags, visitedNodesRef.current);
+      onComplete?.(result);
+    },
+    [dialogue, onComplete]
+  );
+
+  const applyFlagUpdates = useCallback(
+    (updates: string[]): FlagState => {
+      let nextFlags = flagsRef.current;
+
+      setFlags(prevFlags => {
+        const merged = mergeFlagUpdates(prevFlags, updates, flagSchema);
+        nextFlags = merged;
+        return merged;
+      });
+
+      updates.forEach(flagId => {
+        if (isDialogueFlag(flagId, flagSchema)) {
+          memoryFlagsRef.current.add(flagId);
+        }
+      });
+
+      return nextFlags;
+    },
+    [flagSchema]
+  );
+
+  useEffect(() => {
+    if (status === 'completed') return;
+
+    const node = dialogue.nodes[currentNodeId];
+    if (!node) {
+      completeDialogue();
+      return;
+    }
+
+    visitedNodesRef.current.add(node.id);
+
+    const nextStep = evaluateNode(node, flagsRef.current, memoryFlagsRef.current);
+    setCurrentStep(nextStep);
+
+    if (!nextStep.isChoice) {
+      setHistory(prev => [
+        ...prev,
+        {
+          nodeId: node.id,
+          type: node.type,
+          speaker: nextStep.speaker,
+          content: nextStep.content,
+        },
+      ]);
+
+      if (node.setFlags && node.setFlags.length > 0) {
+        const updated = applyFlagUpdates(node.setFlags);
+        if (nextStep.isTerminal && !nextStep.nextNodeId) {
+          completeDialogue(updated);
+          return;
+        }
+      }
+
+      if (nextStep.isTerminal && !nextStep.nextNodeId) {
+        completeDialogue();
+      }
+    } else if (nextStep.isTerminal) {
+      completeDialogue();
+    }
+  }, [dialogue, currentNodeId, completeDialogue, applyFlagUpdates, status]);
+
+  const continueDialogue = useCallback(() => {
+    if (status === 'completed') return;
+    if (!currentStep) return;
+
+    if (currentStep.nextNodeId) {
+      setCurrentNodeId(currentStep.nextNodeId);
+      return;
+    }
+
+    completeDialogue();
+  }, [completeDialogue, currentStep, status]);
+
+  const chooseOption = useCallback(
+    (choiceId: string) => {
+      if (status === 'completed') return;
+      if (!currentStep || !currentStep.isChoice) return;
+
+      const choice = currentStep.choices.find(option => option.id === choiceId);
+      if (!choice) return;
+
+      setHistory(prev => [
+        ...prev,
+        {
+          nodeId: choice.id,
+          type: NODE_TYPE.PLAYER,
+          content: choice.text,
+        },
+      ]);
+
+      let latestFlags: FlagState | undefined;
+      if (choice.setFlags && choice.setFlags.length > 0) {
+        latestFlags = applyFlagUpdates(choice.setFlags);
+      }
+
+      if (choice.nextNodeId) {
+        setCurrentNodeId(choice.nextNodeId);
+      } else {
+        completeDialogue(latestFlags);
+      }
+    },
+    [applyFlagUpdates, completeDialogue, currentStep, status]
+  );
+
+  const resetDialogue = useCallback(() => {
+    visitedNodesRef.current = new Set();
+    memoryFlagsRef.current = new Set(
+      Object.keys(initialFlags || {}).filter(flagId => isDialogueFlag(flagId, flagSchema))
+    );
+    hasCompletedRef.current = false;
+    setHistory([]);
+    setFlags(initialFlags || {});
+    setStatus('running');
+    setCurrentNodeId(initialNodeId);
+    setCurrentStep(null);
+  }, [flagSchema, initialFlags, initialNodeId]);
+
+  const availableChoices = useMemo(() => {
+    if (!currentStep || !currentStep.isChoice) return [];
+    return currentStep.choices;
+  }, [currentStep]);
+
+  return {
+    status,
+    flags,
+    history,
+    currentNodeId,
+    currentStep,
+    availableChoices,
+    continueDialogue,
+    chooseOption,
+    resetDialogue,
+    visitedNodeIds: Array.from(visitedNodesRef.current),
+  };
+}

--- a/src/hooks/useNarrativeTraversal.ts
+++ b/src/hooks/useNarrativeTraversal.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface NarrativeLocation {
+  actIndex: number;
+  chapterIndex: number;
+  pageIndex: number;
+}
+
+export interface NarrativeProgress {
+  actTitle: string;
+  chapterTitle: string;
+  pageIndex: number;
+  pageCount: number;
+  progress: number;
+}
+
+interface NarrativeTraversalOptions {
+  title?: string;
+  initialPageCount?: number;
+}
+
+export function useNarrativeTraversal({
+  title,
+  initialPageCount = 1,
+}: NarrativeTraversalOptions) {
+  const [location, setLocation] = useState<NarrativeLocation>({
+    actIndex: 0,
+    chapterIndex: 0,
+    pageIndex: 0,
+  });
+  const [pageCount, setPageCount] = useState(Math.max(initialPageCount, 1));
+
+  useEffect(() => {
+    setPageCount(Math.max(initialPageCount, 1));
+    setLocation({ actIndex: 0, chapterIndex: 0, pageIndex: 0 });
+  }, [initialPageCount]);
+
+  const goToPage = useCallback((pageIndex: number) => {
+    setLocation(prev => ({
+      ...prev,
+      pageIndex: Math.min(Math.max(pageIndex, 0), Math.max(pageCount - 1, 0)),
+    }));
+  }, [pageCount]);
+
+  const nextPage = useCallback(() => {
+    setLocation(prev => ({
+      ...prev,
+      pageIndex: Math.min(prev.pageIndex + 1, Math.max(pageCount - 1, 0)),
+    }));
+  }, [pageCount]);
+
+  const previousPage = useCallback(() => {
+    setLocation(prev => ({
+      ...prev,
+      pageIndex: Math.max(prev.pageIndex - 1, 0),
+    }));
+  }, []);
+
+  const syncPageCount = useCallback((count: number) => {
+    setPageCount(Math.max(count, 1));
+    setLocation(prev => ({
+      ...prev,
+      pageIndex: Math.min(prev.pageIndex, Math.max(count - 1, 0)),
+    }));
+  }, []);
+
+  const progress = useMemo<NarrativeProgress>(() => {
+    const safePageCount = Math.max(pageCount, 1);
+    const currentPage = Math.min(location.pageIndex, safePageCount - 1);
+
+    return {
+      actTitle: `Act ${location.actIndex + 1}`,
+      chapterTitle: title ? `${title} — Chapter ${location.chapterIndex + 1}` : `Chapter ${location.chapterIndex + 1}`,
+      pageIndex: currentPage,
+      pageCount: safePageCount,
+      progress: (currentPage + 1) / safePageCount,
+    };
+  }, [location.actIndex, location.chapterIndex, location.pageIndex, pageCount, title]);
+
+  return {
+    location,
+    progress,
+    goToPage,
+    nextPage,
+    previousPage,
+    setPageCount: syncPageCount,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,12 @@
 export { DialogueEditorV2 } from './components/DialogueEditorV2';
+// Legacy scene player (use GamePlayer for new experiences)
 export { ScenePlayer } from './components/ScenePlayer';
 export type { ScenePlayerProps } from './components/ScenePlayer';
 // Legacy export for backward compatibility
 export { ScenePlayer as DialogueSimulator } from './components/ScenePlayer';
+export { GamePlayer } from './components/GamePlayer';
+export { useDialogueRunner } from './hooks/useDialogueRunner';
+export { useNarrativeTraversal } from './hooks/useNarrativeTraversal';
 export { GuidePanel } from './components/GuidePanel';
 export { FlagSelector } from './components/FlagSelector';
 export { FlagManager } from './components/FlagManager';


### PR DESCRIPTION
## Summary
- add reusable hooks for condition-aware dialogue traversal and narrative paging
- introduce GamePlayer layout with world, reading, and storylet panes
- update PlayView and exports to use the new player while keeping ScenePlayer legacy

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d863f2cb8832d909afc6945459edf)