### PR TITLE
Add narrative utilities and storylet/randomizer nodes

### DIFF
--- a/src/components/NarrativeEditor.tsx
+++ b/src/components/NarrativeEditor.tsx
@@ -17,6 +17,7 @@ import {
   type NarrativeStructure,
   DEFAULT_NARRATIVE_ENTITY_LABELS,
 } from '../types/narrative';
+import { NARRATIVE_ENTITY_TYPE } from '../types/constants';
 
 interface NarrativeEditorProps {
   narrative?: NarrativeStructure;
@@ -68,7 +69,9 @@ export function NarrativeEditor({ narrative: narrativeProp, onChange, onSelectSt
     <div className={`grid grid-cols-1 lg:grid-cols-5 gap-4 ${className}`}>
       <div className="lg:col-span-2 space-y-3 bg-df-surface border border-df-border rounded-lg p-4">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-df-text">{DEFAULT_NARRATIVE_ENTITY_LABELS.act}</h3>
+          <h3 className="text-sm font-semibold text-df-text">
+            {DEFAULT_NARRATIVE_ENTITY_LABELS[NARRATIVE_ENTITY_TYPE.ACT]}
+          </h3>
           <button
             className="text-xs text-df-primary hover:text-white"
             onClick={() => onChange(addAct(narrative))}
@@ -87,7 +90,9 @@ export function NarrativeEditor({ narrative: narrativeProp, onChange, onSelectSt
         </select>
 
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-df-text">{DEFAULT_NARRATIVE_ENTITY_LABELS.chapter}</h3>
+          <h3 className="text-sm font-semibold text-df-text">
+            {DEFAULT_NARRATIVE_ENTITY_LABELS[NARRATIVE_ENTITY_TYPE.CHAPTER]}
+          </h3>
           {selectedAct && (
             <button
               className="text-xs text-df-primary hover:text-white"
@@ -108,7 +113,9 @@ export function NarrativeEditor({ narrative: narrativeProp, onChange, onSelectSt
         </select>
 
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-df-text">{DEFAULT_NARRATIVE_ENTITY_LABELS.page}</h3>
+          <h3 className="text-sm font-semibold text-df-text">
+            {DEFAULT_NARRATIVE_ENTITY_LABELS[NARRATIVE_ENTITY_TYPE.PAGE]}
+          </h3>
           {selectedAct && selectedChapter && (
             <button
               className="text-xs text-df-primary hover:text-white"

--- a/src/components/NarrativeEditor.tsx
+++ b/src/components/NarrativeEditor.tsx
@@ -1,0 +1,284 @@
+import React, { useMemo, useState, useEffect } from 'react';
+import {
+  addAct,
+  addChapter,
+  addPage,
+  addStorylet,
+  addStoryletExit,
+  updateStorylet,
+  updateStoryletExit,
+  createEmptyNarrative,
+} from '../utils/narrative-helpers';
+import {
+  type NarrativeAct,
+  type NarrativeChapter,
+  type NarrativePage,
+  type NarrativeStorylet,
+  type NarrativeStructure,
+  DEFAULT_NARRATIVE_ENTITY_LABELS,
+} from '../types/narrative';
+
+interface NarrativeEditorProps {
+  narrative?: NarrativeStructure;
+  onChange: (narrative: NarrativeStructure) => void;
+  onSelectStorylet?: (storylet: NarrativeStorylet, page: NarrativePage, chapter: NarrativeChapter, act: NarrativeAct) => void;
+  className?: string;
+}
+
+export function NarrativeEditor({ narrative: narrativeProp, onChange, onSelectStorylet, className = '' }: NarrativeEditorProps) {
+  const narrative = useMemo(() => narrativeProp ?? createEmptyNarrative(), [narrativeProp]);
+  const [selectedActId, setSelectedActId] = useState<string>(narrative.startActId || narrative.acts[0]?.id || '');
+  const [selectedChapterId, setSelectedChapterId] = useState<string>(narrative.startChapterId || narrative.acts[0]?.chapters[0]?.id || '');
+  const [selectedPageId, setSelectedPageId] = useState<string>(narrative.startPageId || narrative.acts[0]?.chapters[0]?.pages[0]?.id || '');
+
+  const selectedAct = narrative.acts.find(act => act.id === selectedActId) || narrative.acts[0];
+  const selectedChapter = selectedAct?.chapters.find(ch => ch.id === selectedChapterId) || selectedAct?.chapters[0];
+  const selectedPage = selectedChapter?.pages.find(p => p.id === selectedPageId) || selectedChapter?.pages[0];
+  const selectedStorylet = selectedPage?.storylets.find(s => s.id === selectedPage?.startStoryletId) || selectedPage?.storylets[0];
+
+  useEffect(() => {
+    if (!selectedAct && narrative.acts[0]) {
+      setSelectedActId(narrative.acts[0].id);
+    }
+  }, [narrative.acts, selectedAct]);
+
+  useEffect(() => {
+    if (selectedAct && !selectedChapter && selectedAct.chapters[0]) {
+      setSelectedChapterId(selectedAct.chapters[0].id);
+    }
+  }, [selectedAct, selectedChapter]);
+
+  useEffect(() => {
+    if (selectedChapter && !selectedPage && selectedChapter.pages[0]) {
+      setSelectedPageId(selectedChapter.pages[0].id);
+    }
+  }, [selectedChapter, selectedPage]);
+
+  const handleStoryletUpdate = (updates: Partial<NarrativeStorylet>) => {
+    if (!selectedAct || !selectedChapter || !selectedPage || !selectedStorylet) return;
+    onChange(updateStorylet(narrative, selectedAct.id, selectedChapter.id, selectedPage.id, selectedStorylet.id, updates));
+  };
+
+  const handleExitUpdate = (exitId: string, updates: Partial<NarrativeStorylet['exits'][number]>) => {
+    if (!selectedAct || !selectedChapter || !selectedPage || !selectedStorylet) return;
+    onChange(updateStoryletExit(narrative, selectedAct.id, selectedChapter.id, selectedPage.id, selectedStorylet.id, exitId, updates));
+  };
+
+  return (
+    <div className={`grid grid-cols-1 lg:grid-cols-5 gap-4 ${className}`}>
+      <div className="lg:col-span-2 space-y-3 bg-df-surface border border-df-border rounded-lg p-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-df-text">{DEFAULT_NARRATIVE_ENTITY_LABELS.act}</h3>
+          <button
+            className="text-xs text-df-primary hover:text-white"
+            onClick={() => onChange(addAct(narrative))}
+          >
+            + Add Act
+          </button>
+        </div>
+        <select
+          value={selectedAct?.id || ''}
+          onChange={(e) => setSelectedActId(e.target.value)}
+          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+        >
+          {narrative.acts.map(act => (
+            <option key={act.id} value={act.id}>{act.title}</option>
+          ))}
+        </select>
+
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-df-text">{DEFAULT_NARRATIVE_ENTITY_LABELS.chapter}</h3>
+          {selectedAct && (
+            <button
+              className="text-xs text-df-primary hover:text-white"
+              onClick={() => onChange(addChapter(narrative, selectedAct.id))}
+            >
+              + Add Chapter
+            </button>
+          )}
+        </div>
+        <select
+          value={selectedChapter?.id || ''}
+          onChange={(e) => setSelectedChapterId(e.target.value)}
+          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+        >
+          {selectedAct?.chapters.map(ch => (
+            <option key={ch.id} value={ch.id}>{ch.title}</option>
+          ))}
+        </select>
+
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-df-text">{DEFAULT_NARRATIVE_ENTITY_LABELS.page}</h3>
+          {selectedAct && selectedChapter && (
+            <button
+              className="text-xs text-df-primary hover:text-white"
+              onClick={() => onChange(addPage(narrative, selectedAct.id, selectedChapter.id))}
+            >
+              + Add Page
+            </button>
+          )}
+        </div>
+        <select
+          value={selectedPage?.id || ''}
+          onChange={(e) => setSelectedPageId(e.target.value)}
+          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+        >
+          {selectedChapter?.pages.map(page => (
+            <option key={page.id} value={page.id}>{page.title}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="lg:col-span-3 space-y-4">
+        <div className="bg-df-surface border border-df-border rounded-lg p-4">
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-sm font-semibold text-df-text">Storylets</h3>
+            {selectedAct && selectedChapter && selectedPage && (
+              <button
+                className="text-xs text-df-primary hover:text-white"
+                onClick={() => onChange(addStorylet(narrative, selectedAct.id, selectedChapter.id, selectedPage.id))}
+              >
+                + Add Storylet
+              </button>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {selectedPage?.storylets.map(storylet => (
+              <button
+                key={storylet.id}
+                onClick={() => onSelectStorylet?.(storylet, selectedPage, selectedChapter!, selectedAct!)}
+                className={`text-left border rounded-lg px-3 py-2 transition-colors ${
+                  selectedStorylet?.id === storylet.id ? 'border-df-start bg-df-start/10' : 'border-df-border bg-df-elevated'
+                }`}
+              >
+                <div className="font-semibold text-sm text-df-text">{storylet.title}</div>
+                <div className="text-xs text-df-muted-foreground">{storylet.summary || 'No summary'}</div>
+                <div className="text-[11px] text-df-muted-foreground mt-1">Tags: {(storylet.tags || []).join(', ') || 'none'}</div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {selectedStorylet && selectedAct && selectedChapter && selectedPage && (
+          <div className="bg-df-surface border border-df-border rounded-lg p-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-df-text">Storylet Details</h3>
+              <span className="text-[11px] text-df-muted-foreground">{selectedStorylet.id}</span>
+            </div>
+            <div>
+              <label className="text-[10px] text-gray-500 uppercase">Title</label>
+              <input
+                type="text"
+                value={selectedStorylet.title}
+                onChange={(e) => handleStoryletUpdate({ title: e.target.value })}
+                className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-gray-500 uppercase">Summary</label>
+              <textarea
+                value={selectedStorylet.summary || ''}
+                onChange={(e) => handleStoryletUpdate({ summary: e.target.value })}
+                className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary min-h-[80px]"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="text-[10px] text-gray-500 uppercase">Dialogue ID</label>
+                <input
+                  type="text"
+                  value={selectedStorylet.dialogueId || ''}
+                  onChange={(e) => handleStoryletUpdate({ dialogueId: e.target.value })}
+                  className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+                  placeholder="dialogue-tree-id"
+                />
+              </div>
+              <div>
+                <label className="text-[10px] text-gray-500 uppercase">Weight</label>
+                <input
+                  type="number"
+                  value={selectedStorylet.weight ?? ''}
+                  onChange={(e) => handleStoryletUpdate({ weight: e.target.value === '' ? undefined : Number(e.target.value) })}
+                  className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+                  min={0}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="text-[10px] text-gray-500 uppercase">Tags</label>
+              <input
+                type="text"
+                value={selectedStorylet.tags?.join(', ') || ''}
+                onChange={(e) => handleStoryletUpdate({ tags: e.target.value.split(',').map(tag => tag.trim()).filter(Boolean) })}
+                className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+                placeholder="tag1, tag2"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <label className="text-[10px] text-gray-500 uppercase">Exits</label>
+                <button
+                  className="text-xs text-df-primary hover:text-white"
+                  onClick={() => onChange(addStoryletExit(narrative, selectedAct.id, selectedChapter.id, selectedPage.id, selectedStorylet.id))}
+                >
+                  + Add Exit
+                </button>
+              </div>
+              {(selectedStorylet.exits || []).map(exit => (
+                <div key={exit.id} className="border border-df-border rounded p-2 space-y-2 bg-df-elevated">
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="text-[10px] text-gray-500 uppercase">Label</label>
+                      <input
+                        type="text"
+                        value={exit.label}
+                        onChange={(e) => handleExitUpdate(exit.id, { label: e.target.value })}
+                        className="w-full bg-df-surface border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[10px] text-gray-500 uppercase">Weight</label>
+                      <input
+                        type="number"
+                        value={exit.weight ?? ''}
+                        onChange={(e) => handleExitUpdate(exit.id, { weight: e.target.value === '' ? undefined : Number(e.target.value) })}
+                        className="w-full bg-df-surface border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+                        min={0}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <label className="text-[10px] text-gray-500 uppercase">Target Storylet</label>
+                      <input
+                        type="text"
+                        value={exit.targetStoryletId || ''}
+                        onChange={(e) => handleExitUpdate(exit.id, { targetStoryletId: e.target.value || undefined })}
+                        className="w-full bg-df-surface border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+                        placeholder="storylet-id"
+                      />
+                    </div>
+                    <div>
+                      <label className="text-[10px] text-gray-500 uppercase">Target Page</label>
+                      <input
+                        type="text"
+                        value={exit.targetPageId || ''}
+                        onChange={(e) => handleExitUpdate(exit.id, { targetPageId: e.target.value || undefined })}
+                        className="w-full bg-df-surface border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary"
+                        placeholder="page-id"
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+NarrativeEditor.displayName = 'NarrativeEditor';

--- a/src/components/NarrativeGraphView.tsx
+++ b/src/components/NarrativeGraphView.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from 'react';
+import ReactFlow, { Background, Controls, MiniMap, ReactFlowProvider } from 'reactflow';
+import { convertNarrativeToReactFlow } from '../utils/narrative-converter';
+import { type NarrativeStructure, type NarrativeEntityMeta } from '../types/narrative';
+import { type LayoutDirection } from '../utils/layout';
+
+interface NarrativeGraphViewProps {
+  narrative: NarrativeStructure;
+  layoutDirection?: LayoutDirection;
+  height?: number;
+  onSelectNode?: (meta: NarrativeEntityMeta) => void;
+  className?: string;
+}
+
+export function NarrativeGraphView({
+  narrative,
+  layoutDirection = 'TB',
+  height = 420,
+  onSelectNode,
+  className = '',
+}: NarrativeGraphViewProps) {
+  const { nodes, edges } = useMemo(() => convertNarrativeToReactFlow(narrative, layoutDirection), [narrative, layoutDirection]);
+
+  return (
+    <div className={`border border-df-border rounded-lg overflow-hidden bg-df-surface ${className}`} style={{ height }}>
+      <ReactFlowProvider>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          fitView
+          nodesDraggable={false}
+          nodesConnectable={false}
+          onNodeClick={(_, node) => onSelectNode?.(node.data.meta)}
+          className="bg-df-surface"
+        >
+          <MiniMap pannable zoomable className="!bg-df-muted" />
+          <Controls showInteractive={false} />
+          <Background gap={16} />
+        </ReactFlow>
+      </ReactFlowProvider>
+    </div>
+  );
+}
+
+NarrativeGraphView.displayName = 'NarrativeGraphView';

--- a/src/components/NodeEditor.tsx
+++ b/src/components/NodeEditor.tsx
@@ -4,7 +4,7 @@ import { FlagSchema } from '../types/flags';
 import { Character } from '../types/characters';
 import { FlagSelector } from './FlagSelector';
 import { CharacterSelector } from './CharacterSelector';
-import { CONDITION_OPERATOR } from '../types/constants';
+import { CONDITION_OPERATOR, NODE_TYPE } from '../types/constants';
 import { AlertCircle, CheckCircle, Info, GitBranch, X, User, Maximize2 } from 'lucide-react';
 import { CHOICE_COLORS } from '../utils/reactflow-converter';
 import { EdgeIcon } from './EdgeIcon';
@@ -292,17 +292,21 @@ export function NodeEditor({
   
   // Determine border color based on node type - use duller border colors
   const getBorderColor = () => {
-    if (node.type === 'npc') return 'border-df-npc-border';
-    if (node.type === 'player') return 'border-df-player-border';
-    if (node.type === 'conditional') return 'border-df-conditional-border';
+    if (node.type === NODE_TYPE.NPC) return 'border-df-npc-border';
+    if (node.type === NODE_TYPE.PLAYER) return 'border-df-player-border';
+    if (node.type === NODE_TYPE.CONDITIONAL) return 'border-df-conditional-border';
+    if (node.type === NODE_TYPE.STORYLET) return 'border-df-start';
+    if (node.type === NODE_TYPE.RANDOMIZER) return 'border-df-player-selected';
     return 'border-df-control-border';
   };
 
   // Get node type badge colors
   const getNodeTypeBadge = () => {
-    if (node.type === 'npc') return 'bg-df-npc-selected/20 text-df-npc-selected';
-    if (node.type === 'player') return 'bg-df-player-selected/20 text-df-player-selected';
-    if (node.type === 'conditional') return 'bg-df-conditional-border/20 text-df-conditional-border';
+    if (node.type === NODE_TYPE.NPC) return 'bg-df-npc-selected/20 text-df-npc-selected';
+    if (node.type === NODE_TYPE.PLAYER) return 'bg-df-player-selected/20 text-df-player-selected';
+    if (node.type === NODE_TYPE.CONDITIONAL) return 'bg-df-conditional-border/20 text-df-conditional-border';
+    if (node.type === NODE_TYPE.STORYLET) return 'bg-df-start/10 text-df-start';
+    if (node.type === NODE_TYPE.RANDOMIZER) return 'bg-df-player-selected/10 text-df-player-selected';
     return 'bg-df-control-bg text-df-text-secondary';
   };
 
@@ -328,7 +332,11 @@ export function NodeEditor({
       <div className="p-4 space-y-4">
         <div className="flex items-center justify-between">
           <span className={`text-xs px-2 py-0.5 rounded ${getNodeTypeBadge()}`}>
-            {node.type === 'npc' ? 'NPC' : node.type === 'player' ? 'PLAYER' : 'CONDITIONAL'}
+            {node.type === NODE_TYPE.NPC && 'NPC'}
+            {node.type === NODE_TYPE.PLAYER && 'PLAYER'}
+            {node.type === NODE_TYPE.CONDITIONAL && 'CONDITIONAL'}
+            {node.type === NODE_TYPE.STORYLET && 'STORYLET'}
+            {node.type === NODE_TYPE.RANDOMIZER && 'RANDOMIZER'}
           </span>
           <div className="flex gap-1">
             <button onClick={onDelete} className="p-1 text-gray-500 hover:text-red-400" title="Delete node">
@@ -355,7 +363,7 @@ export function NodeEditor({
           />
         </div>
 
-        {node.type === 'npc' && (
+        {node.type === NODE_TYPE.NPC && (
           <>
             <div>
               <label className="text-[10px] text-df-text-secondary uppercase">Character</label>
@@ -432,7 +440,7 @@ export function NodeEditor({
           </>
         )}
 
-        {node.type === 'conditional' && (
+        {node.type === NODE_TYPE.CONDITIONAL && (
           <>
             <div>
               <div className="flex items-center justify-between mb-2">
@@ -1012,7 +1020,7 @@ export function NodeEditor({
           </>
         )}
 
-        {node.type === 'player' && (
+        {node.type === NODE_TYPE.PLAYER && (
           <div>
             <div>
               <label className="text-[10px] text-df-text-secondary uppercase">Character</label>
@@ -1316,6 +1324,162 @@ export function NodeEditor({
                       flagSchema={flagSchema}
                       placeholder="Set flags..."
                     />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {node.type === NODE_TYPE.STORYLET && (
+          <div className="space-y-3">
+            <div>
+              <label className="text-[10px] text-gray-500 uppercase">Storylet ID</label>
+              <input
+                type="text"
+                value={node.storyletId || ''}
+                onChange={(e) => onUpdate({ storyletId: e.target.value })}
+                className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-start outline-none"
+                placeholder="Link to storylet registry"
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-gray-500 uppercase">Content</label>
+              <textarea
+                value={node.content}
+                onChange={(e) => onUpdate({ content: e.target.value })}
+                className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-start outline-none min-h-[80px]"
+                placeholder="Entry text for this storylet"
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-gray-500 uppercase">Tags</label>
+              <input
+                type="text"
+                value={node.tags?.join(', ') || ''}
+                onChange={(e) => onUpdate({ tags: e.target.value.split(',').map(tag => tag.trim()).filter(Boolean) })}
+                className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-start outline-none"
+                placeholder="combat, intro, quest"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div>
+                <label className="text-[10px] text-gray-500 uppercase">Weight</label>
+                <input
+                  type="number"
+                  value={node.weight ?? ''}
+                  onChange={(e) => onUpdate({ weight: e.target.value === '' ? undefined : Number(e.target.value) })}
+                  className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-start outline-none"
+                  placeholder="1"
+                  min={0}
+                />
+              </div>
+              <div>
+                <label className="text-[10px] text-gray-500 uppercase">Next Node</label>
+                <select
+                  value={node.nextNodeId || ''}
+                  onChange={(e) => onUpdate({ nextNodeId: e.target.value || undefined })}
+                  className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-start outline-none"
+                >
+                  <option value="">— End —</option>
+                  {Object.keys(dialogue.nodes).filter(id => id !== node.id).map(id => (
+                    <option key={id} value={id}>{id}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {node.type === NODE_TYPE.RANDOMIZER && (
+          <div className="space-y-3">
+            <div>
+              <label className="text-[10px] text-gray-500 uppercase">Description</label>
+              <textarea
+                value={node.content}
+                onChange={(e) => onUpdate({ content: e.target.value })}
+                className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-player-selected outline-none min-h-[60px]"
+                placeholder="Explain how this random choice behaves"
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <label className="text-[10px] text-gray-500 uppercase">Outcomes</label>
+              <button
+                type="button"
+                className="text-[10px] text-df-player-selected hover:text-white"
+                onClick={() => {
+                  const newOptions = [...(node.randomizerOptions ?? [])];
+                  newOptions.push({ id: `r_${Date.now()}`, label: `Outcome ${newOptions.length + 1}`, weight: 1, nextNodeId: '' });
+                  onUpdate({ randomizerOptions: newOptions });
+                }}
+              >
+                + Add
+              </button>
+            </div>
+            <div className="space-y-2">
+              {(node.randomizerOptions ?? []).map((option, idx) => {
+                const color = CHOICE_COLORS[idx % CHOICE_COLORS.length];
+                return (
+                  <div key={option.id} className="rounded border border-df-control-border bg-df-elevated p-2 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: color }} />
+                      <input
+                        type="text"
+                        value={option.label}
+                        onChange={(e) => {
+                          const newOptions = [...(node.randomizerOptions ?? [])];
+                          newOptions[idx] = { ...option, label: e.target.value };
+                          onUpdate({ randomizerOptions: newOptions });
+                        }}
+                        className="flex-1 bg-df-surface border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-player-selected outline-none"
+                        placeholder="Outcome label"
+                      />
+                      <button
+                        type="button"
+                        className="text-gray-500 hover:text-red-500"
+                        onClick={() => {
+                          const newOptions = [...(node.randomizerOptions ?? [])].filter((_, i) => i !== idx);
+                          onUpdate({ randomizerOptions: newOptions });
+                        }}
+                        title="Remove outcome"
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div>
+                        <label className="text-[10px] text-gray-500 uppercase">Weight</label>
+                        <input
+                          type="number"
+                          value={option.weight ?? ''}
+                          onChange={(e) => {
+                            const newOptions = [...(node.randomizerOptions ?? [])];
+                            newOptions[idx] = { ...option, weight: e.target.value === '' ? undefined : Number(e.target.value) };
+                            onUpdate({ randomizerOptions: newOptions });
+                          }}
+                          className="w-full bg-df-surface border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-player-selected outline-none"
+                          min={0}
+                          placeholder="1"
+                        />
+                      </div>
+                      <div>
+                        <label className="text-[10px] text-gray-500 uppercase">Next Node</label>
+                        <select
+                          value={option.nextNodeId || ''}
+                          onChange={(e) => {
+                            const newOptions = [...(node.randomizerOptions ?? [])];
+                            newOptions[idx] = { ...option, nextNodeId: e.target.value || undefined };
+                            onUpdate({ randomizerOptions: newOptions });
+                          }}
+                          className="w-full bg-df-surface border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-player-selected outline-none"
+                        >
+                          <option value="">— Select target —</option>
+                          {Object.keys(dialogue.nodes).filter(id => id !== node.id).map(id => (
+                            <option key={id} value={id}>{id}</option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
                   </div>
                 );
               })}

--- a/src/components/RandomizerDialogueNodeV2.tsx
+++ b/src/components/RandomizerDialogueNodeV2.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+import { Dice5, Shuffle } from 'lucide-react';
+import { DialogueNode } from '../types';
+import { LayoutDirection } from '../utils/layout';
+import { CHOICE_COLORS } from '../utils/reactflow-converter';
+import { NODE_TYPE } from '../types/constants';
+
+interface RandomizerNodeData {
+  node: DialogueNode;
+  layoutDirection?: LayoutDirection;
+  isInPath?: boolean;
+  isDimmed?: boolean;
+}
+
+export function RandomizerDialogueNodeV2({ data, selected }: NodeProps<RandomizerNodeData>) {
+  const { node, layoutDirection = 'TB', isInPath, isDimmed } = data;
+  const isHorizontal = layoutDirection === 'LR';
+  const targetPosition = isHorizontal ? Position.Left : Position.Top;
+  const sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
+
+  const options = node.randomizerOptions ?? [];
+
+  return (
+    <div
+      className={`rounded-lg border-2 bg-df-surface text-df-text shadow-sm transition-all ${
+        selected ? 'border-df-node-selected shadow-lg shadow-df-glow' : 'border-df-border'
+      } ${isDimmed ? 'opacity-40 saturate-50' : ''} min-w-[280px] max-w-[400px]`}
+    >
+      <Handle
+        type="target"
+        position={targetPosition}
+        id="target"
+        className="!bg-df-control-bg !border-df-control-border !w-3.5 !h-3.5 !rounded-full"
+      />
+
+      <div className="flex items-center gap-2 border-b border-df-border bg-df-muted px-3 py-2">
+        <Dice5 size={18} className="text-df-primary" />
+        <div className="flex flex-col">
+          <span className="font-semibold text-sm">Randomizer</span>
+          <span className="text-xs text-df-muted-foreground">{node.content || 'Randomly choose an outcome'}</span>
+        </div>
+      </div>
+
+      <div className="px-3 py-2 space-y-2">
+        {options.length === 0 && (
+          <div className="text-xs text-df-muted-foreground">Add outcomes to route to new beats.</div>
+        )}
+        {options.map((option, idx) => {
+          const color = CHOICE_COLORS[idx % CHOICE_COLORS.length];
+          return (
+            <div key={option.id} className="flex items-center gap-2 rounded border border-df-border/60 bg-df-muted px-2 py-1 text-xs">
+              <div
+                className="h-3 w-3 rounded-full"
+                style={{ backgroundColor: color }}
+                title={option.label}
+              />
+              <div className="flex-1 truncate">
+                <span className="font-semibold">{option.label}</span>
+                {option.weight !== undefined && <span className="ml-2 text-[11px] text-df-muted-foreground">w: {option.weight}</span>}
+              </div>
+              <span className="text-[11px] text-df-muted-foreground">{option.nextNodeId || 'Unlinked'}</span>
+              <Handle
+                type="source"
+                position={sourcePosition}
+                id={`outcome-${idx}`}
+                className="!bg-df-control-bg !border-df-control-border !w-3 !h-3 !rounded-full"
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      {isInPath && <div className="bg-df-node-selected/10 px-3 py-2 text-[11px] text-df-muted-foreground">Path active</div>}
+    </div>
+  );
+}
+
+RandomizerDialogueNodeV2.displayName = 'RandomizerDialogueNodeV2';
+
+export const RANDOMIZER_NODE_TYPE = NODE_TYPE.RANDOMIZER;

--- a/src/components/StoryletDialogueNodeV2.tsx
+++ b/src/components/StoryletDialogueNodeV2.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+import { BookmarkPlus, Tags, Share2 } from 'lucide-react';
+import { DialogueNode } from '../types';
+import { LayoutDirection } from '../utils/layout';
+import { NODE_TYPE } from '../types/constants';
+
+interface StoryletNodeData {
+  node: DialogueNode;
+  layoutDirection?: LayoutDirection;
+  isStartNode?: boolean;
+  isInPath?: boolean;
+  isDimmed?: boolean;
+}
+
+export function StoryletDialogueNodeV2({ data, selected }: NodeProps<StoryletNodeData>) {
+  const {
+    node,
+    layoutDirection = 'TB',
+    isStartNode,
+    isInPath,
+    isDimmed,
+  } = data;
+
+  const isHorizontal = layoutDirection === 'LR';
+  const targetPosition = isHorizontal ? Position.Left : Position.Top;
+  const sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
+
+  const tags = node.tags?.length ? node.tags.join(', ') : 'No tags';
+
+  return (
+    <div
+      className={`rounded-lg border-2 bg-df-surface text-df-text shadow-sm transition-all ${
+        selected ? 'border-df-node-selected shadow-lg shadow-df-glow' : 'border-df-border'
+      } ${isDimmed ? 'opacity-40 saturate-50' : ''} min-w-[260px] max-w-[380px]`}
+    >
+      <Handle
+        type="target"
+        position={targetPosition}
+        id="target"
+        className="!bg-df-control-bg !border-df-control-border !w-3.5 !h-3.5 !rounded-full"
+      />
+
+      <div className="flex items-center gap-2 border-b border-df-border bg-df-muted px-3 py-2">
+        <BookmarkPlus size={18} className="text-df-primary" />
+        <div className="flex flex-col">
+          <span className="font-semibold text-sm">Storylet Node</span>
+          <span className="text-xs text-df-muted-foreground">{node.storyletId || 'Unlinked storylet'}</span>
+        </div>
+        {isStartNode && (
+          <span className="ml-auto rounded-full bg-df-start-bg px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-df-text">
+            Start
+          </span>
+        )}
+      </div>
+
+      <div className="px-3 py-2 space-y-2">
+        <div className="text-xs text-df-muted-foreground">{node.content || 'Storylet entry point'}</div>
+        <div className="flex items-center gap-2 text-xs text-df-muted-foreground">
+          <Tags size={14} />
+          <span className="truncate">{tags}</span>
+        </div>
+        {node.weight !== undefined && (
+          <div className="flex items-center gap-2 text-xs text-df-muted-foreground">
+            <Share2 size={14} />
+            <span>Weight: {node.weight}</span>
+          </div>
+        )}
+      </div>
+
+      <Handle
+        type="source"
+        position={sourcePosition}
+        id="next"
+        className="!bg-df-control-bg !border-df-control-border !w-3.5 !h-3.5 !rounded-full"
+      />
+    </div>
+  );
+}
+
+StoryletDialogueNodeV2.displayName = 'StoryletDialogueNodeV2';
+
+export const STORYLET_NODE_TYPE = NODE_TYPE.STORYLET;

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -21,9 +21,20 @@ export const NODE_TYPE = {
   NPC: 'npc',
   PLAYER: 'player',
   CONDITIONAL: 'conditional',
+  STORYLET: 'storylet',
+  RANDOMIZER: 'randomizer',
 } as const;
 
 export type NodeType = typeof NODE_TYPE[keyof typeof NODE_TYPE];
+
+export const NARRATIVE_ENTITY_TYPE = {
+  ACT: 'act',
+  CHAPTER: 'chapter',
+  PAGE: 'page',
+  STORYLET: 'storylet',
+} as const;
+
+export type NarrativeEntityType = typeof NARRATIVE_ENTITY_TYPE[keyof typeof NARRATIVE_ENTITY_TYPE];
 
 /**
  * Flag types for game state management

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,13 @@ export interface Choice {
   setFlags?: string[];
 }
 
+export interface RandomizerOption {
+  id: string;
+  label: string;
+  nextNodeId?: string;
+  weight?: number;
+}
+
 export interface Condition {
   flag: string;
   operator: ConditionOperator;
@@ -38,6 +45,10 @@ export interface DialogueNode {
   nextNodeId?: string;
   setFlags?: string[];
   conditionalBlocks?: ConditionalBlock[]; // For conditional nodes (if/elseif/else/endif)
+  storyletId?: string;
+  tags?: string[];
+  weight?: number;
+  randomizerOptions?: RandomizerOption[];
   x: number;
   y: number;
 }

--- a/src/types/narrative.ts
+++ b/src/types/narrative.ts
@@ -1,0 +1,73 @@
+import { NARRATIVE_ENTITY_TYPE, type NarrativeEntityType } from './constants';
+import type { Condition } from './index';
+
+export interface NarrativeStoryletExit {
+  id: string;
+  label: string;
+  targetStoryletId?: string;
+  targetPageId?: string;
+  weight?: number;
+  conditions?: Condition[];
+}
+
+export interface NarrativeStorylet {
+  id: string;
+  title: string;
+  summary?: string;
+  dialogueId?: string;
+  tags?: string[];
+  weight?: number;
+  entryNodeId?: string;
+  exits?: NarrativeStoryletExit[];
+  notes?: string;
+}
+
+export interface NarrativePage {
+  id: string;
+  title: string;
+  summary?: string;
+  storylets: NarrativeStorylet[];
+  startStoryletId?: string;
+  metadata?: Record<string, string | number | boolean>;
+}
+
+export interface NarrativeChapter {
+  id: string;
+  title: string;
+  summary?: string;
+  pages: NarrativePage[];
+  startPageId?: string;
+}
+
+export interface NarrativeAct {
+  id: string;
+  title: string;
+  summary?: string;
+  chapters: NarrativeChapter[];
+  startChapterId?: string;
+}
+
+export interface NarrativeStructure {
+  id: string;
+  title: string;
+  acts: NarrativeAct[];
+  startActId?: string;
+  startChapterId?: string;
+  startPageId?: string;
+}
+
+export interface NarrativeEntityMeta {
+  id: string;
+  type: NarrativeEntityType;
+  actId?: string;
+  chapterId?: string;
+  pageId?: string;
+  storyletId?: string;
+}
+
+export const DEFAULT_NARRATIVE_ENTITY_LABELS: Record<NarrativeEntityType, string> = {
+  [NARRATIVE_ENTITY_TYPE.ACT]: 'Act',
+  [NARRATIVE_ENTITY_TYPE.CHAPTER]: 'Chapter',
+  [NARRATIVE_ENTITY_TYPE.PAGE]: 'Page',
+  [NARRATIVE_ENTITY_TYPE.STORYLET]: 'Storylet',
+};

--- a/src/utils/narrative-converter.ts
+++ b/src/utils/narrative-converter.ts
@@ -1,6 +1,6 @@
 import { Node, Edge, Position } from 'reactflow';
 import { LayoutDirection } from './layout';
-import { NARRATIVE_ENTITY_TYPE } from '../types/constants';
+import { NARRATIVE_ENTITY_TYPE, type NarrativeEntityType } from '../types/constants';
 import {
   type NarrativeStructure,
   type NarrativeAct,
@@ -11,7 +11,7 @@ import {
 
 export interface NarrativeFlowNodeData {
   label: string;
-  type: string;
+  type: NarrativeEntityType;
   meta: {
     actId?: string;
     chapterId?: string;

--- a/src/utils/narrative-converter.ts
+++ b/src/utils/narrative-converter.ts
@@ -1,0 +1,201 @@
+import { Node, Edge, Position } from 'reactflow';
+import { LayoutDirection } from './layout';
+import { NARRATIVE_ENTITY_TYPE } from '../types/constants';
+import {
+  type NarrativeStructure,
+  type NarrativeAct,
+  type NarrativeChapter,
+  type NarrativePage,
+  type NarrativeStorylet,
+} from '../types/narrative';
+
+export interface NarrativeFlowNodeData {
+  label: string;
+  type: string;
+  meta: {
+    actId?: string;
+    chapterId?: string;
+    pageId?: string;
+    storyletId?: string;
+  };
+  description?: string;
+}
+
+export type NarrativeFlowNode = Node<NarrativeFlowNodeData>;
+export type NarrativeFlowEdge = Edge;
+
+function basePosition(index: number, depth: number, direction: LayoutDirection): { x: number; y: number } {
+  const spacingX = 320;
+  const spacingY = 220;
+  if (direction === 'LR') {
+    return { x: depth * spacingX, y: index * spacingY };
+  }
+  return { x: index * spacingX, y: depth * spacingY };
+}
+
+function addActNodes(
+  nodes: NarrativeFlowNode[],
+  edges: NarrativeFlowEdge[],
+  narrative: NarrativeStructure,
+  direction: LayoutDirection
+): void {
+  narrative.acts.forEach((act, actIdx) => {
+    nodes.push({
+      id: act.id,
+      type: 'default',
+      position: basePosition(actIdx, 0, direction),
+      data: {
+        label: act.title,
+        type: NARRATIVE_ENTITY_TYPE.ACT,
+        description: act.summary,
+        meta: { actId: act.id },
+      },
+      sourcePosition: direction === 'LR' ? Position.Right : Position.Bottom,
+      targetPosition: direction === 'LR' ? Position.Left : Position.Top,
+    });
+    addChapterNodes(nodes, edges, act, actIdx, direction);
+  });
+}
+
+function addChapterNodes(
+  nodes: NarrativeFlowNode[],
+  edges: NarrativeFlowEdge[],
+  act: NarrativeAct,
+  actIdx: number,
+  direction: LayoutDirection
+): void {
+  act.chapters.forEach((chapter, chapterIdx) => {
+    const position = basePosition(chapterIdx, 1, direction);
+    nodes.push({
+      id: chapter.id,
+      type: 'default',
+      position,
+      data: {
+        label: chapter.title,
+        type: NARRATIVE_ENTITY_TYPE.CHAPTER,
+        description: chapter.summary,
+        meta: { actId: act.id, chapterId: chapter.id },
+      },
+      sourcePosition: direction === 'LR' ? Position.Right : Position.Bottom,
+      targetPosition: direction === 'LR' ? Position.Left : Position.Top,
+    });
+
+    edges.push({
+      id: `${act.id}-${chapter.id}`,
+      source: act.id,
+      target: chapter.id,
+      animated: act.startChapterId === chapter.id,
+    });
+
+    addPageNodes(nodes, edges, act, chapter, chapterIdx, direction);
+  });
+}
+
+function addPageNodes(
+  nodes: NarrativeFlowNode[],
+  edges: NarrativeFlowEdge[],
+  act: NarrativeAct,
+  chapter: NarrativeChapter,
+  chapterIdx: number,
+  direction: LayoutDirection
+): void {
+  chapter.pages.forEach((page, pageIdx) => {
+    const position = basePosition(pageIdx, 2, direction);
+    nodes.push({
+      id: page.id,
+      type: 'default',
+      position,
+      data: {
+        label: page.title,
+        type: NARRATIVE_ENTITY_TYPE.PAGE,
+        description: page.summary,
+        meta: { actId: act.id, chapterId: chapter.id, pageId: page.id },
+      },
+      sourcePosition: direction === 'LR' ? Position.Right : Position.Bottom,
+      targetPosition: direction === 'LR' ? Position.Left : Position.Top,
+    });
+
+    edges.push({
+      id: `${chapter.id}-${page.id}`,
+      source: chapter.id,
+      target: page.id,
+      animated: chapter.startPageId === page.id,
+    });
+
+    addStoryletNodes(nodes, edges, act, chapter, page, pageIdx, direction);
+  });
+}
+
+function addStoryletNodes(
+  nodes: NarrativeFlowNode[],
+  edges: NarrativeFlowEdge[],
+  act: NarrativeAct,
+  chapter: NarrativeChapter,
+  page: NarrativePage,
+  pageIdx: number,
+  direction: LayoutDirection
+): void {
+  page.storylets.forEach((storylet, storyletIdx) => {
+    const position = basePosition(storyletIdx, 3, direction);
+    nodes.push({
+      id: storylet.id,
+      type: 'default',
+      position,
+      data: {
+        label: storylet.title,
+        type: NARRATIVE_ENTITY_TYPE.STORYLET,
+        description: storylet.summary,
+        meta: {
+          actId: act.id,
+          chapterId: chapter.id,
+          pageId: page.id,
+          storyletId: storylet.id,
+        },
+      },
+      sourcePosition: direction === 'LR' ? Position.Right : Position.Bottom,
+      targetPosition: direction === 'LR' ? Position.Left : Position.Top,
+    });
+
+    edges.push({
+      id: `${page.id}-${storylet.id}`,
+      source: page.id,
+      target: storylet.id,
+      animated: page.startStoryletId === storylet.id,
+    });
+
+    addExitEdges(edges, page, storylet);
+  });
+}
+
+function addExitEdges(edges: NarrativeFlowEdge[], page: NarrativePage, storylet: NarrativeStorylet): void {
+  storylet.exits?.forEach(exit => {
+    if (exit.targetStoryletId) {
+      edges.push({
+        id: `${storylet.id}-${exit.id}`,
+        source: storylet.id,
+        target: exit.targetStoryletId,
+        label: exit.label,
+        animated: Boolean(exit.weight && exit.weight > 1),
+      });
+    } else if (exit.targetPageId) {
+      edges.push({
+        id: `${storylet.id}-${exit.id}`,
+        source: storylet.id,
+        target: exit.targetPageId,
+        label: exit.label,
+      });
+    }
+  });
+}
+
+export function convertNarrativeToReactFlow(
+  narrative: NarrativeStructure,
+  direction: LayoutDirection = 'TB'
+): { nodes: NarrativeFlowNode[]; edges: NarrativeFlowEdge[] } {
+  const nodes: NarrativeFlowNode[] = [];
+  const edges: NarrativeFlowEdge[] = [];
+
+  addActNodes(nodes, edges, narrative, direction);
+
+  return { nodes, edges };
+}

--- a/src/utils/narrative-helpers.ts
+++ b/src/utils/narrative-helpers.ts
@@ -7,6 +7,7 @@ import {
   type NarrativeStorylet,
   type NarrativeStoryletExit,
   type NarrativeStructure,
+  DEFAULT_NARRATIVE_ENTITY_LABELS,
 } from '../types/narrative';
 
 function createId(prefix: string): string {
@@ -17,10 +18,10 @@ function createId(prefix: string): string {
 }
 
 export function createEmptyNarrative(title = 'Untitled Narrative'): NarrativeStructure {
-  const actId = createId('act');
-  const chapterId = createId('chapter');
-  const pageId = createId('page');
-  const storyletId = createId('storylet');
+  const actId = createId(NARRATIVE_ENTITY_TYPE.ACT);
+  const chapterId = createId(NARRATIVE_ENTITY_TYPE.CHAPTER);
+  const pageId = createId(NARRATIVE_ENTITY_TYPE.PAGE);
+  const storyletId = createId(NARRATIVE_ENTITY_TYPE.STORYLET);
 
   const starterStorylet: NarrativeStorylet = {
     id: storyletId,
@@ -61,10 +62,10 @@ export function createEmptyNarrative(title = 'Untitled Narrative'): NarrativeStr
 }
 
 export function addAct(narrative: NarrativeStructure, title = 'New Act'): NarrativeStructure {
-  const actId = createId('act');
-  const chapterId = createId('chapter');
-  const pageId = createId('page');
-  const storyletId = createId('storylet');
+  const actId = createId(NARRATIVE_ENTITY_TYPE.ACT);
+  const chapterId = createId(NARRATIVE_ENTITY_TYPE.CHAPTER);
+  const pageId = createId(NARRATIVE_ENTITY_TYPE.PAGE);
+  const storyletId = createId(NARRATIVE_ENTITY_TYPE.STORYLET);
 
   const starterStorylet: NarrativeStorylet = {
     id: storyletId,
@@ -105,9 +106,9 @@ export function addChapter(
   actId: string,
   title = 'New Chapter'
 ): NarrativeStructure {
-  const chapterId = createId('chapter');
-  const pageId = createId('page');
-  const storyletId = createId('storylet');
+  const chapterId = createId(NARRATIVE_ENTITY_TYPE.CHAPTER);
+  const pageId = createId(NARRATIVE_ENTITY_TYPE.PAGE);
+  const storyletId = createId(NARRATIVE_ENTITY_TYPE.STORYLET);
 
   const starterStorylet: NarrativeStorylet = {
     id: storyletId,
@@ -149,8 +150,8 @@ export function addPage(
   chapterId: string,
   title = 'New Page'
 ): NarrativeStructure {
-  const pageId = createId('page');
-  const storyletId = createId('storylet');
+  const pageId = createId(NARRATIVE_ENTITY_TYPE.PAGE);
+  const storyletId = createId(NARRATIVE_ENTITY_TYPE.STORYLET);
 
   const starterStorylet: NarrativeStorylet = {
     id: storyletId,
@@ -191,7 +192,7 @@ export function addStorylet(
   pageId: string,
   title = 'New Storylet'
 ): NarrativeStructure {
-  const storyletId = createId('storylet');
+  const storyletId = createId(NARRATIVE_ENTITY_TYPE.STORYLET);
   const storylet: NarrativeStorylet = {
     id: storyletId,
     title,
@@ -368,18 +369,7 @@ export function getStorylet(
 }
 
 export function getEntityLabel(meta: NarrativeEntityMeta): string {
-  switch (meta.type) {
-    case NARRATIVE_ENTITY_TYPE.ACT:
-      return 'Act';
-    case NARRATIVE_ENTITY_TYPE.CHAPTER:
-      return 'Chapter';
-    case NARRATIVE_ENTITY_TYPE.PAGE:
-      return 'Page';
-    case NARRATIVE_ENTITY_TYPE.STORYLET:
-      return 'Storylet';
-    default:
-      return 'Entity';
-  }
+  return DEFAULT_NARRATIVE_ENTITY_LABELS[meta.type] ?? 'Entity';
 }
 
 export function flattenNarrative(narrative: NarrativeStructure): NarrativeEntityMeta[] {

--- a/src/utils/narrative-helpers.ts
+++ b/src/utils/narrative-helpers.ts
@@ -1,0 +1,413 @@
+import { NARRATIVE_ENTITY_TYPE } from '../types/constants';
+import {
+  type NarrativeAct,
+  type NarrativeChapter,
+  type NarrativeEntityMeta,
+  type NarrativePage,
+  type NarrativeStorylet,
+  type NarrativeStoryletExit,
+  type NarrativeStructure,
+} from '../types/narrative';
+
+function createId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1000)}`;
+}
+
+export function createEmptyNarrative(title = 'Untitled Narrative'): NarrativeStructure {
+  const actId = createId('act');
+  const chapterId = createId('chapter');
+  const pageId = createId('page');
+  const storyletId = createId('storylet');
+
+  const starterStorylet: NarrativeStorylet = {
+    id: storyletId,
+    title: 'First Storylet',
+    summary: 'Use storylets to reference dialogue graphs or beats.',
+    exits: [],
+  };
+
+  const starterPage: NarrativePage = {
+    id: pageId,
+    title: 'Page 1',
+    storylets: [starterStorylet],
+    startStoryletId: storyletId,
+  };
+
+  const starterChapter: NarrativeChapter = {
+    id: chapterId,
+    title: 'Chapter 1',
+    pages: [starterPage],
+    startPageId: pageId,
+  };
+
+  const starterAct: NarrativeAct = {
+    id: actId,
+    title: 'Act 1',
+    chapters: [starterChapter],
+    startChapterId: chapterId,
+  };
+
+  return {
+    id: createId('narrative'),
+    title,
+    acts: [starterAct],
+    startActId: actId,
+    startChapterId: chapterId,
+    startPageId: pageId,
+  };
+}
+
+export function addAct(narrative: NarrativeStructure, title = 'New Act'): NarrativeStructure {
+  const actId = createId('act');
+  const chapterId = createId('chapter');
+  const pageId = createId('page');
+  const storyletId = createId('storylet');
+
+  const starterStorylet: NarrativeStorylet = {
+    id: storyletId,
+    title: 'Storylet',
+    exits: [],
+  };
+
+  const starterPage: NarrativePage = {
+    id: pageId,
+    title: 'Page',
+    storylets: [starterStorylet],
+    startStoryletId: storyletId,
+  };
+
+  const starterChapter: NarrativeChapter = {
+    id: chapterId,
+    title: 'Chapter',
+    pages: [starterPage],
+    startPageId: pageId,
+  };
+
+  const newAct: NarrativeAct = {
+    id: actId,
+    title,
+    chapters: [starterChapter],
+    startChapterId: chapterId,
+  };
+
+  return {
+    ...narrative,
+    acts: [...narrative.acts, newAct],
+    startActId: narrative.startActId ?? actId,
+  };
+}
+
+export function addChapter(
+  narrative: NarrativeStructure,
+  actId: string,
+  title = 'New Chapter'
+): NarrativeStructure {
+  const chapterId = createId('chapter');
+  const pageId = createId('page');
+  const storyletId = createId('storylet');
+
+  const starterStorylet: NarrativeStorylet = {
+    id: storyletId,
+    title: 'Storylet',
+    exits: [],
+  };
+
+  const starterPage: NarrativePage = {
+    id: pageId,
+    title: 'Page',
+    storylets: [starterStorylet],
+    startStoryletId: storyletId,
+  };
+
+  const updatedActs = narrative.acts.map(act => {
+    if (act.id !== actId) return act;
+    const newChapter: NarrativeChapter = {
+      id: chapterId,
+      title,
+      pages: [starterPage],
+      startPageId: pageId,
+    };
+    return {
+      ...act,
+      chapters: [...act.chapters, newChapter],
+      startChapterId: act.startChapterId ?? chapterId,
+    };
+  });
+
+  return {
+    ...narrative,
+    acts: updatedActs,
+  };
+}
+
+export function addPage(
+  narrative: NarrativeStructure,
+  actId: string,
+  chapterId: string,
+  title = 'New Page'
+): NarrativeStructure {
+  const pageId = createId('page');
+  const storyletId = createId('storylet');
+
+  const starterStorylet: NarrativeStorylet = {
+    id: storyletId,
+    title: 'Storylet',
+    exits: [],
+  };
+
+  const starterPage: NarrativePage = {
+    id: pageId,
+    title,
+    storylets: [starterStorylet],
+    startStoryletId: storyletId,
+  };
+
+  const updatedActs = narrative.acts.map(act => {
+    if (act.id !== actId) return act;
+    const chapters = act.chapters.map(chapter => {
+      if (chapter.id !== chapterId) return chapter;
+      return {
+        ...chapter,
+        pages: [...chapter.pages, starterPage],
+        startPageId: chapter.startPageId ?? pageId,
+      };
+    });
+    return { ...act, chapters };
+  });
+
+  return {
+    ...narrative,
+    acts: updatedActs,
+  };
+}
+
+export function addStorylet(
+  narrative: NarrativeStructure,
+  actId: string,
+  chapterId: string,
+  pageId: string,
+  title = 'New Storylet'
+): NarrativeStructure {
+  const storyletId = createId('storylet');
+  const storylet: NarrativeStorylet = {
+    id: storyletId,
+    title,
+    exits: [],
+  };
+
+  const acts = narrative.acts.map(act => {
+    if (act.id !== actId) return act;
+    const chapters = act.chapters.map(chapter => {
+      if (chapter.id !== chapterId) return chapter;
+      const pages = chapter.pages.map(page => {
+        if (page.id !== pageId) return page;
+        return {
+          ...page,
+          storylets: [...page.storylets, storylet],
+          startStoryletId: page.startStoryletId ?? storyletId,
+        };
+      });
+      return { ...chapter, pages };
+    });
+    return { ...act, chapters };
+  });
+
+  return {
+    ...narrative,
+    acts,
+  };
+}
+
+export function updateStorylet(
+  narrative: NarrativeStructure,
+  actId: string,
+  chapterId: string,
+  pageId: string,
+  storyletId: string,
+  updates: Partial<NarrativeStorylet>
+): NarrativeStructure {
+  const acts = narrative.acts.map(act => {
+    if (act.id !== actId) return act;
+    const chapters = act.chapters.map(chapter => {
+      if (chapter.id !== chapterId) return chapter;
+      const pages = chapter.pages.map(page => {
+        if (page.id !== pageId) return page;
+        const storylets = page.storylets.map(storylet =>
+          storylet.id === storyletId ? { ...storylet, ...updates } : storylet
+        );
+        return { ...page, storylets };
+      });
+      return { ...chapter, pages };
+    });
+    return { ...act, chapters };
+  });
+
+  return { ...narrative, acts };
+}
+
+export function updateStoryletExit(
+  narrative: NarrativeStructure,
+  actId: string,
+  chapterId: string,
+  pageId: string,
+  storyletId: string,
+  exitId: string,
+  updates: Partial<NarrativeStoryletExit>
+): NarrativeStructure {
+  const storylet = getStorylet(narrative, { actId, chapterId, pageId, storyletId });
+  if (!storylet) return narrative;
+
+  const exits = storylet.exits?.map(exit =>
+    exit.id === exitId ? { ...exit, ...updates } : exit
+  ) ?? [];
+
+  return updateStorylet(narrative, actId, chapterId, pageId, storyletId, {
+    exits,
+  });
+}
+
+export function removeStorylet(
+  narrative: NarrativeStructure,
+  actId: string,
+  chapterId: string,
+  pageId: string,
+  storyletId: string
+): NarrativeStructure {
+  const acts = narrative.acts.map(act => {
+    if (act.id !== actId) return act;
+    const chapters = act.chapters.map(chapter => {
+      if (chapter.id !== chapterId) return chapter;
+      const pages = chapter.pages.map(page => {
+        if (page.id !== pageId) return page;
+        const storylets = page.storylets.filter(s => s.id !== storyletId);
+        const startStoryletId = page.startStoryletId === storyletId ? storylets[0]?.id : page.startStoryletId;
+        return { ...page, storylets, startStoryletId };
+      });
+      return { ...chapter, pages };
+    });
+    return { ...act, chapters };
+  });
+
+  return { ...narrative, acts };
+}
+
+export function removePage(
+  narrative: NarrativeStructure,
+  actId: string,
+  chapterId: string,
+  pageId: string
+): NarrativeStructure {
+  const acts = narrative.acts.map(act => {
+    if (act.id !== actId) return act;
+    const chapters = act.chapters.map(chapter => {
+      if (chapter.id !== chapterId) return chapter;
+      const pages = chapter.pages.filter(p => p.id !== pageId);
+      const startPageId = chapter.startPageId === pageId ? pages[0]?.id : chapter.startPageId;
+      return { ...chapter, pages, startPageId };
+    });
+    return { ...act, chapters };
+  });
+
+  return { ...narrative, acts };
+}
+
+export function removeChapter(
+  narrative: NarrativeStructure,
+  actId: string,
+  chapterId: string
+): NarrativeStructure {
+  const acts = narrative.acts.map(act => {
+    if (act.id !== actId) return act;
+    const chapters = act.chapters.filter(ch => ch.id !== chapterId);
+    const startChapterId = act.startChapterId === chapterId ? chapters[0]?.id : act.startChapterId;
+    return { ...act, chapters, startChapterId };
+  });
+
+  return { ...narrative, acts };
+}
+
+export function removeAct(narrative: NarrativeStructure, actId: string): NarrativeStructure {
+  const acts = narrative.acts.filter(act => act.id !== actId);
+  const startActId = narrative.startActId === actId ? acts[0]?.id : narrative.startActId;
+  return { ...narrative, acts, startActId };
+}
+
+export function addStoryletExit(
+  narrative: NarrativeStructure,
+  actId: string,
+  chapterId: string,
+  pageId: string,
+  storyletId: string,
+  label = 'Outcome'
+): NarrativeStructure {
+  const storylet = getStorylet(narrative, { actId, chapterId, pageId, storyletId });
+  if (!storylet) return narrative;
+
+  const exit: NarrativeStoryletExit = {
+    id: createId('exit'),
+    label,
+    weight: 1,
+  };
+
+  const exits = [...(storylet.exits ?? []), exit];
+
+  return updateStorylet(narrative, actId, chapterId, pageId, storyletId, { exits });
+}
+
+export function getStorylet(
+  narrative: NarrativeStructure,
+  meta: Pick<NarrativeEntityMeta, 'actId' | 'chapterId' | 'pageId' | 'storyletId'>
+): NarrativeStorylet | undefined {
+  const act = narrative.acts.find(a => a.id === meta.actId);
+  const chapter = act?.chapters.find(c => c.id === meta.chapterId);
+  const page = chapter?.pages.find(p => p.id === meta.pageId);
+  return page?.storylets.find(s => s.id === meta.storyletId);
+}
+
+export function getEntityLabel(meta: NarrativeEntityMeta): string {
+  switch (meta.type) {
+    case NARRATIVE_ENTITY_TYPE.ACT:
+      return 'Act';
+    case NARRATIVE_ENTITY_TYPE.CHAPTER:
+      return 'Chapter';
+    case NARRATIVE_ENTITY_TYPE.PAGE:
+      return 'Page';
+    case NARRATIVE_ENTITY_TYPE.STORYLET:
+      return 'Storylet';
+    default:
+      return 'Entity';
+  }
+}
+
+export function flattenNarrative(narrative: NarrativeStructure): NarrativeEntityMeta[] {
+  const entities: NarrativeEntityMeta[] = [];
+  narrative.acts.forEach(act => {
+    entities.push({ id: act.id, type: NARRATIVE_ENTITY_TYPE.ACT, actId: act.id });
+    act.chapters.forEach(chapter => {
+      entities.push({ id: chapter.id, type: NARRATIVE_ENTITY_TYPE.CHAPTER, actId: act.id, chapterId: chapter.id });
+      chapter.pages.forEach(page => {
+        entities.push({
+          id: page.id,
+          type: NARRATIVE_ENTITY_TYPE.PAGE,
+          actId: act.id,
+          chapterId: chapter.id,
+          pageId: page.id,
+        });
+        page.storylets.forEach(storylet => {
+          entities.push({
+            id: storylet.id,
+            type: NARRATIVE_ENTITY_TYPE.STORYLET,
+            actId: act.id,
+            chapterId: chapter.id,
+            pageId: page.id,
+            storyletId: storylet.id,
+          });
+        });
+      });
+    });
+  });
+  return entities;
+}

--- a/src/utils/node-helpers.ts
+++ b/src/utils/node-helpers.ts
@@ -1,4 +1,4 @@
-import { DialogueNode, DialogueTree, Choice } from '../types';
+import { DialogueNode, DialogueTree, Choice, RandomizerOption } from '../types';
 import { NODE_TYPE, NodeType } from '../types/constants';
 
 export function createNode(
@@ -39,6 +39,31 @@ export function createNode(
       }],
       x,
       y
+    };
+  } else if (type === NODE_TYPE.STORYLET) {
+    return {
+      id,
+      type,
+      content: 'Storylet bridge...',
+      storyletId: '',
+      tags: [],
+      nextNodeId: '',
+      x,
+      y,
+    };
+  } else if (type === NODE_TYPE.RANDOMIZER) {
+    const options: RandomizerOption[] = [
+      { id: `r_${Date.now()}`, label: 'Outcome A', weight: 1, nextNodeId: '' },
+      { id: `r_${Date.now() + 1}`, label: 'Outcome B', weight: 1, nextNodeId: '' },
+    ];
+
+    return {
+      id,
+      type,
+      content: 'Randomly select the next beat.',
+      randomizerOptions: options,
+      x,
+      y,
     };
   }
   


### PR DESCRIPTION
## Summary
- add narrative data structures, helper utilities, and graph conversion to support acts, chapters, pages, and storylets
- introduce narrative editor and graph view components for managing and visualizing storylet flows
- add storylet and randomizer dialogue node types with editor support and updated React Flow conversion

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d86409f94832d954381a1e8c70566)