### PR TITLE
Require npm run build in agent guide

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -270,6 +270,10 @@ Tests use Vitest. Key test files:
 - `src/**/*.test.ts`: Unit tests
 - Test utilities in `src/utils/` if needed
 
+### Required build check
+
+Always run `npm run build` after making changes to ensure the library compiles.
+
 ## Deployment
 
 ### Publishing the Package
@@ -340,4 +344,3 @@ When in doubt:
 2. Look at existing component implementations
 3. Follow the patterns in `DialogueEditorV2.tsx`
 4. Ensure demo works independently
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,3 +39,5 @@ export { exportToYarn, importFromYarn } from './lib/yarn-converter';
 export { initializeFlags, mergeFlagUpdates, validateFlags, getFlagValue } from './lib/flag-manager';
 export * from './utils/node-helpers';
 export * from './utils/feature-flags';
+export * from './utils/narrative-helpers';
+export * from './utils/narrative-converter';

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -26,6 +26,29 @@ export const NODE_TYPE = {
 export type NodeType = typeof NODE_TYPE[keyof typeof NODE_TYPE];
 
 /**
+ * Narrative node types
+ */
+export const NARRATIVE_NODE_TYPE = {
+  ACT: 'narrative_act',
+  CHAPTER: 'narrative_chapter',
+  PAGE: 'narrative_page',
+  STORYLET: 'narrative_storylet',
+} as const;
+
+export type NarrativeNodeType = typeof NARRATIVE_NODE_TYPE[keyof typeof NARRATIVE_NODE_TYPE];
+
+/**
+ * Narrative edge types
+ */
+export const NARRATIVE_EDGE_TYPE = {
+  ACT_TO_CHAPTER: 'narrative_act_to_chapter',
+  CHAPTER_TO_PAGE: 'narrative_chapter_to_page',
+  STORYLET_LINK: 'narrative_storylet_link',
+} as const;
+
+export type NarrativeEdgeType = typeof NARRATIVE_EDGE_TYPE[keyof typeof NARRATIVE_EDGE_TYPE];
+
+/**
  * Flag types for game state management
  */
 export const FLAG_TYPE = {
@@ -77,4 +100,3 @@ export const QUEST_STATE = {
 } as const;
 
 export type QuestState = typeof QUEST_STATE[keyof typeof QUEST_STATE];
-

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 import { ConditionOperator, NodeType } from './constants';
 export type { ViewMode } from './constants';
+export * from './narrative';
 
 export interface Choice {
   id: string;
@@ -89,4 +90,3 @@ export interface DraggingEdge {
   endX: number;
   endY: number;
 }
-

--- a/src/types/narrative.ts
+++ b/src/types/narrative.ts
@@ -1,0 +1,51 @@
+import { NarrativeNodeType, NARRATIVE_NODE_TYPE } from './constants';
+
+export interface NarrativeAct {
+  id: string;
+  title: string;
+  chapterIds: string[];
+}
+
+export interface NarrativeChapter {
+  id: string;
+  title: string;
+  actId: string;
+  pageIds: string[];
+}
+
+export interface NarrativePage {
+  id: string;
+  title: string;
+  chapterId: string;
+  dialogueId?: string;
+  storyletIds: string[];
+}
+
+export interface NarrativeStorylet {
+  id: string;
+  title: string;
+  pageId?: string;
+  linkedStoryletIds: string[];
+}
+
+export interface NarrativeThread {
+  id: string;
+  title: string;
+  actIds: string[];
+  acts: Record<string, NarrativeAct>;
+  chapters: Record<string, NarrativeChapter>;
+  pages: Record<string, NarrativePage>;
+  storylets: Record<string, NarrativeStorylet>;
+}
+
+export interface NarrativeNodeDescriptor {
+  id: string;
+  type: NarrativeNodeType;
+}
+
+export const NARRATIVE_NODE_ORDER: NarrativeNodeType[] = [
+  NARRATIVE_NODE_TYPE.ACT,
+  NARRATIVE_NODE_TYPE.CHAPTER,
+  NARRATIVE_NODE_TYPE.PAGE,
+  NARRATIVE_NODE_TYPE.STORYLET,
+];

--- a/src/utils/narrative-converter.ts
+++ b/src/utils/narrative-converter.ts
@@ -1,0 +1,183 @@
+import { Edge, Node, Position } from 'reactflow';
+import {
+  NarrativeAct,
+  NarrativeChapter,
+  NarrativePage,
+  NarrativeStorylet,
+  NarrativeThread,
+} from '../types';
+import { NARRATIVE_EDGE_TYPE, NARRATIVE_NODE_TYPE, NarrativeNodeType } from '../types/constants';
+
+export interface NarrativeReactFlowNodeData {
+  nodeType: NarrativeNodeType;
+  recordId: string;
+  title: string;
+  record: NarrativeAct | NarrativeChapter | NarrativePage | NarrativeStorylet;
+}
+
+export type NarrativeReactFlowNode = Node<NarrativeReactFlowNodeData>;
+export type NarrativeReactFlowEdge = Edge;
+
+const DEFAULT_POSITIONS: Record<NarrativeNodeType, { x: number; nextY: number }> = {
+  [NARRATIVE_NODE_TYPE.ACT]: { x: 0, nextY: 0 },
+  [NARRATIVE_NODE_TYPE.CHAPTER]: { x: 280, nextY: 0 },
+  [NARRATIVE_NODE_TYPE.PAGE]: { x: 560, nextY: 0 },
+  [NARRATIVE_NODE_TYPE.STORYLET]: { x: 840, nextY: 0 },
+};
+
+const ROW_SPACING = 160;
+
+function buildNarrativeNodeId(nodeType: NarrativeNodeType, recordId: string): string {
+  return `${nodeType}-${recordId}`;
+}
+
+function createNode(
+  nodeType: NarrativeNodeType,
+  recordId: string,
+  title: string,
+  record: NarrativeAct | NarrativeChapter | NarrativePage | NarrativeStorylet,
+  positions: Record<NarrativeNodeType, { x: number; nextY: number }>
+): NarrativeReactFlowNode {
+  const nodeId = buildNarrativeNodeId(nodeType, recordId);
+  const position = {
+    x: positions[nodeType].x,
+    y: positions[nodeType].nextY,
+  };
+
+  positions[nodeType].nextY += ROW_SPACING;
+
+  return {
+    id: nodeId,
+    type: nodeType,
+    position,
+    data: {
+      nodeType,
+      recordId,
+      title,
+      record,
+    },
+    sourcePosition: Position.Right,
+    targetPosition: Position.Left,
+  };
+}
+
+export function convertNarrativeThreadToReactFlow(thread: NarrativeThread): {
+  nodes: NarrativeReactFlowNode[];
+  edges: NarrativeReactFlowEdge[];
+} {
+  const nodes: NarrativeReactFlowNode[] = [];
+  const edges: NarrativeReactFlowEdge[] = [];
+  const positions = {
+    [NARRATIVE_NODE_TYPE.ACT]: { ...DEFAULT_POSITIONS[NARRATIVE_NODE_TYPE.ACT] },
+    [NARRATIVE_NODE_TYPE.CHAPTER]: { ...DEFAULT_POSITIONS[NARRATIVE_NODE_TYPE.CHAPTER] },
+    [NARRATIVE_NODE_TYPE.PAGE]: { ...DEFAULT_POSITIONS[NARRATIVE_NODE_TYPE.PAGE] },
+    [NARRATIVE_NODE_TYPE.STORYLET]: { ...DEFAULT_POSITIONS[NARRATIVE_NODE_TYPE.STORYLET] },
+  };
+
+  const actOrder = thread.actIds.length ? thread.actIds : Object.keys(thread.acts);
+  const chapterIds = new Set<string>();
+  const pageIds = new Set<string>();
+  const storyletIds = new Set<string>();
+
+  actOrder.forEach(actId => {
+    const act = thread.acts[actId];
+    if (!act) return;
+
+    nodes.push(createNode(NARRATIVE_NODE_TYPE.ACT, act.id, act.title, act, positions));
+
+    act.chapterIds.forEach(chapterId => {
+      const chapter = thread.chapters[chapterId];
+      if (!chapter) return;
+
+      chapterIds.add(chapterId);
+      nodes.push(
+        createNode(NARRATIVE_NODE_TYPE.CHAPTER, chapter.id, chapter.title, chapter, positions)
+      );
+
+      edges.push({
+        id: `edge-${act.id}-${chapter.id}`,
+        source: buildNarrativeNodeId(NARRATIVE_NODE_TYPE.ACT, act.id),
+        target: buildNarrativeNodeId(NARRATIVE_NODE_TYPE.CHAPTER, chapter.id),
+        type: NARRATIVE_EDGE_TYPE.ACT_TO_CHAPTER,
+      });
+
+      chapter.pageIds.forEach(pageId => {
+        const page = thread.pages[pageId];
+        if (!page) return;
+
+        pageIds.add(pageId);
+        nodes.push(createNode(NARRATIVE_NODE_TYPE.PAGE, page.id, page.title, page, positions));
+
+        edges.push({
+          id: `edge-${chapter.id}-${page.id}`,
+          source: buildNarrativeNodeId(NARRATIVE_NODE_TYPE.CHAPTER, chapter.id),
+          target: buildNarrativeNodeId(NARRATIVE_NODE_TYPE.PAGE, page.id),
+          type: NARRATIVE_EDGE_TYPE.CHAPTER_TO_PAGE,
+        });
+
+        page.storyletIds.forEach(storyletId => {
+          const storylet = thread.storylets[storyletId];
+          if (!storylet || storyletIds.has(storyletId)) return;
+
+          storyletIds.add(storyletId);
+          nodes.push(
+            createNode(
+              NARRATIVE_NODE_TYPE.STORYLET,
+              storylet.id,
+              storylet.title,
+              storylet,
+              positions
+            )
+          );
+        });
+      });
+    });
+  });
+
+  Object.values(thread.storylets).forEach(storylet => {
+    if (storyletIds.has(storylet.id)) return;
+
+    storyletIds.add(storylet.id);
+    nodes.push(
+      createNode(
+        NARRATIVE_NODE_TYPE.STORYLET,
+        storylet.id,
+        storylet.title,
+        storylet,
+        positions
+      )
+    );
+  });
+
+  Object.values(thread.acts).forEach(act => {
+    if (actOrder.includes(act.id)) return;
+    nodes.push(createNode(NARRATIVE_NODE_TYPE.ACT, act.id, act.title, act, positions));
+  });
+
+  Object.values(thread.chapters).forEach(chapter => {
+    if (chapterIds.has(chapter.id)) return;
+    nodes.push(
+      createNode(NARRATIVE_NODE_TYPE.CHAPTER, chapter.id, chapter.title, chapter, positions)
+    );
+  });
+
+  Object.values(thread.pages).forEach(page => {
+    if (pageIds.has(page.id)) return;
+    nodes.push(createNode(NARRATIVE_NODE_TYPE.PAGE, page.id, page.title, page, positions));
+  });
+
+  Object.values(thread.storylets).forEach(storylet => {
+    storylet.linkedStoryletIds.forEach(targetId => {
+      if (!thread.storylets[targetId]) return;
+
+      edges.push({
+        id: `edge-storylet-${storylet.id}-${targetId}`,
+        source: buildNarrativeNodeId(NARRATIVE_NODE_TYPE.STORYLET, storylet.id),
+        target: buildNarrativeNodeId(NARRATIVE_NODE_TYPE.STORYLET, targetId),
+        type: NARRATIVE_EDGE_TYPE.STORYLET_LINK,
+      });
+    });
+  });
+
+  return { nodes, edges };
+}

--- a/src/utils/narrative-helpers.ts
+++ b/src/utils/narrative-helpers.ts
@@ -1,0 +1,414 @@
+import {
+  NarrativeAct,
+  NarrativeChapter,
+  NarrativePage,
+  NarrativeStorylet,
+  NarrativeThread,
+} from '../types';
+
+export interface LinearSequenceOptions {
+  threadId: string;
+  title: string;
+  actCount: number;
+  chaptersPerAct: number;
+  pagesPerChapter: number;
+  idPrefix?: string;
+}
+
+export function createEmptyNarrativeThread(id: string, title: string): NarrativeThread {
+  return {
+    id,
+    title,
+    actIds: [],
+    acts: {},
+    chapters: {},
+    pages: {},
+    storylets: {},
+  };
+}
+
+function normalizeAct(act: NarrativeAct): NarrativeAct {
+  return {
+    ...act,
+    chapterIds: act.chapterIds ?? [],
+  };
+}
+
+function normalizeChapter(chapter: NarrativeChapter, actId: string): NarrativeChapter {
+  return {
+    ...chapter,
+    actId,
+    pageIds: chapter.pageIds ?? [],
+  };
+}
+
+function normalizePage(page: NarrativePage, chapterId: string): NarrativePage {
+  return {
+    ...page,
+    chapterId,
+    storyletIds: page.storyletIds ?? [],
+  };
+}
+
+function normalizeStorylet(storylet: NarrativeStorylet, pageId?: string): NarrativeStorylet {
+  return {
+    ...storylet,
+    pageId,
+    linkedStoryletIds: storylet.linkedStoryletIds ?? [],
+  };
+}
+
+function insertId(ids: string[], id: string, index?: number): string[] {
+  const nextIds = [...ids];
+  const existingIndex = nextIds.indexOf(id);
+  if (existingIndex !== -1) {
+    return nextIds;
+  }
+  const safeIndex = index === undefined ? nextIds.length : Math.max(0, Math.min(index, nextIds.length));
+  nextIds.splice(safeIndex, 0, id);
+  return nextIds;
+}
+
+function removeIds(ids: string[], removed: Set<string>): string[] {
+  return ids.filter(id => !removed.has(id));
+}
+
+export function insertAct(
+  thread: NarrativeThread,
+  act: NarrativeAct,
+  index?: number
+): NarrativeThread {
+  const normalizedAct = normalizeAct(act);
+  const actIds = insertId(thread.actIds, normalizedAct.id, index);
+  return {
+    ...thread,
+    actIds,
+    acts: {
+      ...thread.acts,
+      [normalizedAct.id]: normalizedAct,
+    },
+  };
+}
+
+export function removeAct(thread: NarrativeThread, actId: string): NarrativeThread {
+  const act = thread.acts[actId];
+  if (!act) {
+    return thread;
+  }
+
+  const chapterIds = act.chapterIds;
+  const pageIds = chapterIds.flatMap(chapterId => thread.chapters[chapterId]?.pageIds ?? []);
+  const storyletIds = pageIds.flatMap(pageId => thread.pages[pageId]?.storyletIds ?? []);
+
+  const removedChapters = new Set(chapterIds);
+  const removedPages = new Set(pageIds);
+  const removedStorylets = new Set(storyletIds);
+
+  const nextActs = { ...thread.acts };
+  delete nextActs[actId];
+
+  const nextChapters = Object.fromEntries(
+    Object.entries(thread.chapters).filter(([id]) => !removedChapters.has(id))
+  );
+
+  const nextPages = Object.fromEntries(
+    Object.entries(thread.pages)
+      .filter(([id]) => !removedPages.has(id))
+      .map(([id, page]) => [
+        id,
+        {
+          ...page,
+          storyletIds: removeIds(page.storyletIds, removedStorylets),
+        },
+      ])
+  );
+
+  const nextStorylets = filterStorylets(thread.storylets, removedStorylets);
+
+  return {
+    ...thread,
+    actIds: thread.actIds.filter(id => id !== actId),
+    acts: nextActs,
+    chapters: nextChapters,
+    pages: nextPages,
+    storylets: nextStorylets,
+  };
+}
+
+export function insertChapter(
+  thread: NarrativeThread,
+  actId: string,
+  chapter: NarrativeChapter,
+  index?: number
+): NarrativeThread {
+  const act = thread.acts[actId];
+  if (!act) {
+    throw new Error(`Act ${actId} not found`);
+  }
+
+  const normalizedChapter = normalizeChapter(chapter, actId);
+  const chapterIds = insertId(act.chapterIds, normalizedChapter.id, index);
+
+  return {
+    ...thread,
+    acts: {
+      ...thread.acts,
+      [actId]: {
+        ...act,
+        chapterIds,
+      },
+    },
+    chapters: {
+      ...thread.chapters,
+      [normalizedChapter.id]: normalizedChapter,
+    },
+  };
+}
+
+export function removeChapter(thread: NarrativeThread, chapterId: string): NarrativeThread {
+  const chapter = thread.chapters[chapterId];
+  if (!chapter) {
+    return thread;
+  }
+
+  const pageIds = chapter.pageIds;
+  const storyletIds = pageIds.flatMap(pageId => thread.pages[pageId]?.storyletIds ?? []);
+
+  const removedPages = new Set(pageIds);
+  const removedStorylets = new Set(storyletIds);
+
+  const nextChapters = { ...thread.chapters };
+  delete nextChapters[chapterId];
+
+  const nextPages = Object.fromEntries(
+    Object.entries(thread.pages)
+      .filter(([id]) => !removedPages.has(id))
+      .map(([id, page]) => [
+        id,
+        {
+          ...page,
+          storyletIds: removeIds(page.storyletIds, removedStorylets),
+        },
+      ])
+  );
+
+  const nextStorylets = filterStorylets(thread.storylets, removedStorylets);
+
+  const nextActs = thread.acts[chapter.actId]
+    ? {
+        ...thread.acts,
+        [chapter.actId]: {
+          ...thread.acts[chapter.actId],
+          chapterIds: thread.acts[chapter.actId].chapterIds.filter(id => id !== chapterId),
+        },
+      }
+    : thread.acts;
+
+  return {
+    ...thread,
+    acts: nextActs,
+    chapters: nextChapters,
+    pages: nextPages,
+    storylets: nextStorylets,
+  };
+}
+
+export function insertPage(
+  thread: NarrativeThread,
+  chapterId: string,
+  page: NarrativePage,
+  index?: number
+): NarrativeThread {
+  const chapter = thread.chapters[chapterId];
+  if (!chapter) {
+    throw new Error(`Chapter ${chapterId} not found`);
+  }
+
+  const normalizedPage = normalizePage(page, chapterId);
+  const pageIds = insertId(chapter.pageIds, normalizedPage.id, index);
+
+  return {
+    ...thread,
+    chapters: {
+      ...thread.chapters,
+      [chapterId]: {
+        ...chapter,
+        pageIds,
+      },
+    },
+    pages: {
+      ...thread.pages,
+      [normalizedPage.id]: normalizedPage,
+    },
+  };
+}
+
+export function removePage(thread: NarrativeThread, pageId: string): NarrativeThread {
+  const page = thread.pages[pageId];
+  if (!page) {
+    return thread;
+  }
+
+  const removedStorylets = new Set(page.storyletIds);
+
+  const nextPages = { ...thread.pages };
+  delete nextPages[pageId];
+
+  const nextStorylets = filterStorylets(thread.storylets, removedStorylets);
+
+  const nextChapters = thread.chapters[page.chapterId]
+    ? {
+        ...thread.chapters,
+        [page.chapterId]: {
+          ...thread.chapters[page.chapterId],
+          pageIds: thread.chapters[page.chapterId].pageIds.filter(id => id !== pageId),
+        },
+      }
+    : thread.chapters;
+
+  return {
+    ...thread,
+    chapters: nextChapters,
+    pages: nextPages,
+    storylets: nextStorylets,
+  };
+}
+
+export function attachDialogueToPage(
+  thread: NarrativeThread,
+  pageId: string,
+  dialogueId?: string
+): NarrativeThread {
+  const page = thread.pages[pageId];
+  if (!page) {
+    throw new Error(`Page ${pageId} not found`);
+  }
+
+  return {
+    ...thread,
+    pages: {
+      ...thread.pages,
+      [pageId]: {
+        ...page,
+        dialogueId,
+      },
+    },
+  };
+}
+
+export function addStorylet(
+  thread: NarrativeThread,
+  pageId: string,
+  storylet: NarrativeStorylet,
+  index?: number
+): NarrativeThread {
+  const page = thread.pages[pageId];
+  if (!page) {
+    throw new Error(`Page ${pageId} not found`);
+  }
+
+  const normalizedStorylet = normalizeStorylet(storylet, pageId);
+  const storyletIds = insertId(page.storyletIds, normalizedStorylet.id, index);
+
+  return {
+    ...thread,
+    pages: {
+      ...thread.pages,
+      [pageId]: {
+        ...page,
+        storyletIds,
+      },
+    },
+    storylets: {
+      ...thread.storylets,
+      [normalizedStorylet.id]: normalizedStorylet,
+    },
+  };
+}
+
+export function removeStorylet(thread: NarrativeThread, storyletId: string): NarrativeThread {
+  const storylet = thread.storylets[storyletId];
+  if (!storylet) {
+    return thread;
+  }
+
+  const removedStorylets = new Set([storyletId]);
+
+  const nextStorylets = filterStorylets(thread.storylets, removedStorylets);
+  const nextPages = Object.fromEntries(
+    Object.entries(thread.pages).map(([id, page]) => [
+      id,
+      {
+        ...page,
+        storyletIds: removeIds(page.storyletIds, removedStorylets),
+      },
+    ])
+  );
+
+  return {
+    ...thread,
+    pages: nextPages,
+    storylets: nextStorylets,
+  };
+}
+
+function filterStorylets(
+  storylets: Record<string, NarrativeStorylet>,
+  removedStorylets: Set<string>
+): Record<string, NarrativeStorylet> {
+  return Object.fromEntries(
+    Object.entries(storylets)
+      .filter(([id]) => !removedStorylets.has(id))
+      .map(([id, storylet]) => [
+        id,
+        {
+          ...storylet,
+          linkedStoryletIds: removeIds(storylet.linkedStoryletIds, removedStorylets),
+        },
+      ])
+  );
+}
+
+export function buildLinearSequence(options: LinearSequenceOptions): NarrativeThread {
+  const {
+    threadId,
+    title,
+    actCount,
+    chaptersPerAct,
+    pagesPerChapter,
+    idPrefix = threadId,
+  } = options;
+
+  let thread = createEmptyNarrativeThread(threadId, title);
+
+  for (let actIndex = 0; actIndex < actCount; actIndex += 1) {
+    const actId = `${idPrefix}-act-${actIndex + 1}`;
+    thread = insertAct(thread, {
+      id: actId,
+      title: `Act ${actIndex + 1}`,
+      chapterIds: [],
+    });
+
+    for (let chapterIndex = 0; chapterIndex < chaptersPerAct; chapterIndex += 1) {
+      const chapterId = `${actId}-chapter-${chapterIndex + 1}`;
+      thread = insertChapter(thread, actId, {
+        id: chapterId,
+        title: `Chapter ${chapterIndex + 1}`,
+        actId,
+        pageIds: [],
+      });
+
+      for (let pageIndex = 0; pageIndex < pagesPerChapter; pageIndex += 1) {
+        const pageId = `${chapterId}-page-${pageIndex + 1}`;
+        thread = insertPage(thread, chapterId, {
+          id: pageId,
+          title: `Page ${pageIndex + 1}`,
+          chapterId,
+          storyletIds: [],
+        });
+      }
+    }
+  }
+
+  return thread;
+}


### PR DESCRIPTION
### Motivation

- Ensure contributors run a build step to catch compile errors early by documenting a required `npm run build` check in the agent guide.  
- Provide first-class narrative modeling to avoid string literals and improve type-safety for narrative threads.  
- Add pure, non-mutating helpers for predictable narrative CRUD operations and a converter to map narrative threads into React Flow nodes/edges.  

### Description

- Added narrative constants and types: `NARRATIVE_NODE_TYPE` / `NARRATIVE_EDGE_TYPE` in `src/types/constants.ts` and the `Narrative*` types in `src/types/narrative.ts`.  
- Implemented pure narrative helpers in `src/utils/narrative-helpers.ts` (create/remove/insert acts/chapters/pages/storylets, `buildLinearSequence`, `attachDialogueToPage`, etc.).  
- Implemented React Flow conversion in `src/utils/narrative-converter.ts` to emit stable node IDs and edges for act→chapter, chapter→page, and storylet links.  
- Exported the new types and utilities from the public entrypoints and documented the required build check by updating `agents.md` to state `npm run build` must be run after changes.  

### Testing

- Ran `npm run build`, which completed successfully (Next.js/Turbopack build and TypeScript compilation finished without errors).  
- No Vitest unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dcdfa5d98832dbc4e8d9ef3521e32)