### PR TITLE
Add Storylet & Randomizer V2 nodes and editor panels

### DIFF
--- a/src/components/RandomizerDialogueNodeV2.tsx
+++ b/src/components/RandomizerDialogueNodeV2.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Handle, Position, NodeProps, useUpdateNodeInternals } from 'reactflow';
+import { Shuffle, Hash, Flag, Play, GitBranch } from 'lucide-react';
+import { DialogueNode } from '../types';
+import { LayoutDirection } from '../utils/layout';
+import { RandomizerBranch } from '../types/narrative';
+
+interface RandomizerNodeData {
+  node: DialogueNode;
+  isDimmed?: boolean;
+  isInPath?: boolean;
+  layoutDirection?: LayoutDirection;
+  isStartNode?: boolean;
+  isEndNode?: boolean;
+}
+
+const RANDOMIZER_COLORS = ['#e94560', '#8b5cf6', '#06b6d4', '#22c55e', '#f59e0b'];
+
+export function RandomizerDialogueNodeV2({ data, selected }: NodeProps<RandomizerNodeData>) {
+  const { node, isDimmed, isInPath, layoutDirection = 'TB', isStartNode, isEndNode } = data;
+  const branches = node.randomizerBranches || [];
+  const updateNodeInternals = useUpdateNodeInternals();
+  const headerRef = useRef<HTMLDivElement>(null);
+  const branchRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [handlePositions, setHandlePositions] = useState<number[]>([]);
+
+  const isHorizontal = layoutDirection === 'LR';
+  const targetPosition = isHorizontal ? Position.Left : Position.Top;
+
+  useEffect(() => {
+    if (headerRef.current && branches.length > 0) {
+      const positions: number[] = [];
+      const headerHeight = headerRef.current.offsetHeight;
+      let cumulativeHeight = headerHeight;
+
+      branches.forEach((_branch: RandomizerBranch, idx: number) => {
+        const branchEl = branchRefs.current[idx];
+        if (branchEl) {
+          const branchHeight = branchEl.offsetHeight;
+          positions.push(cumulativeHeight + branchHeight / 2);
+          cumulativeHeight += branchHeight;
+        } else {
+          const estimatedHeight = 36;
+          positions.push(cumulativeHeight + estimatedHeight / 2);
+          cumulativeHeight += estimatedHeight;
+        }
+      });
+
+      setHandlePositions(positions);
+      setTimeout(() => {
+        updateNodeInternals(node.id);
+      }, 0);
+    }
+  }, [branches.length, node.id, updateNodeInternals]);
+
+  const borderClass = selected
+    ? 'border-df-player-selected shadow-lg shadow-df-glow'
+    : isStartNode
+      ? 'border-df-start shadow-md'
+      : isEndNode
+        ? 'border-df-end shadow-md'
+        : 'border-df-player-border';
+
+  const headerBgClass = isStartNode
+    ? 'bg-df-start-bg'
+    : isEndNode
+      ? 'bg-df-end-bg'
+      : 'bg-df-player-header';
+
+  return (
+    <div
+      className={`rounded-lg border-2 transition-all duration-300 ${borderClass} ${isInPath ? 'border-df-player-selected/70' : ''} bg-df-player-bg min-w-[320px] max-w-[450px] relative overflow-hidden`}
+      style={isDimmed ? { opacity: 0.35, filter: 'saturate(0.3)' } : undefined}
+    >
+      <Handle
+        type="target"
+        position={targetPosition}
+        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full"
+      />
+
+      <div
+        ref={headerRef}
+        className={`${headerBgClass} border-b-2 border-df-player-border px-3 py-2.5 flex items-center gap-3 relative`}
+      >
+        <div className="w-14 h-14 rounded-full bg-df-player-bg border-[3px] border-df-player-border flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
+          <Shuffle size={20} className="text-df-player-selected" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-bold text-df-text-primary truncate leading-tight">Randomizer</h3>
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-base/50 border border-df-control-border" title={`Node ID: ${node.id}`}>
+            <Hash size={12} className="text-df-text-secondary" />
+            <span className="text-[10px] font-mono text-df-text-secondary">{node.id}</span>
+          </div>
+
+          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-player-selected/20 border border-df-player-selected/50" title="Randomizer Node">
+            <Shuffle size={14} className="text-df-player-selected" />
+            <span className="text-[10px] font-semibold text-df-player-selected">RANDOMIZER</span>
+          </div>
+        </div>
+
+        {isStartNode && (
+          <div className="absolute top-1 right-1 bg-df-start text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+            <Play size={8} fill="currentColor" /> START
+          </div>
+        )}
+        {isEndNode && (
+          <div className="absolute top-1 right-1 bg-df-end text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+            <Flag size={8} /> END
+          </div>
+        )}
+      </div>
+
+      <div className="px-4 py-3">
+        {branches.length === 0 ? (
+          <div className="text-xs text-df-text-secondary bg-df-elevated border border-df-control-border rounded px-3 py-2 text-center">
+            No randomizer branches yet.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {branches.map((branch, idx) => {
+              const color = RANDOMIZER_COLORS[idx % RANDOMIZER_COLORS.length];
+              const label = branch.label || `Branch ${idx + 1}`;
+
+              return (
+                <div
+                  key={branch.id}
+                  ref={el => {
+                    branchRefs.current[idx] = el;
+                  }}
+                  className="relative bg-df-elevated border border-df-control-border rounded-lg px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-[9px] px-1.5 py-0.5 rounded bg-df-base text-df-text-primary font-semibold">
+                      {label}
+                    </span>
+                    {branch.weight !== undefined && (
+                      <span className="text-[9px] px-1.5 py-0.5 rounded bg-df-player-selected/20 text-df-player-selected border border-df-player-selected/40 font-semibold">
+                        wt {branch.weight}
+                      </span>
+                    )}
+                  </div>
+
+                  <div className="text-xs text-df-text-secondary space-y-1">
+                    {branch.nextNodeId ? (
+                      <div className="flex items-center gap-1">
+                        <GitBranch size={12} className="text-df-player-selected" />
+                        <span className="font-mono">{branch.nextNodeId}</span>
+                      </div>
+                    ) : (
+                      <div className="text-df-text-tertiary">No target node</div>
+                    )}
+                    {branch.storyletPoolId && (
+                      <div className="text-[10px] text-df-text-secondary font-mono">Pool: {branch.storyletPoolId}</div>
+                    )}
+                  </div>
+
+                  <Handle
+                    type="source"
+                    position={Position.Right}
+                    id={`branch-${idx}`}
+                    style={{
+                      top: `${handlePositions[idx] || 0}px`,
+                      right: -8,
+                      borderColor: color,
+                    }}
+                    className="!bg-df-control-bg !border-2 !w-3 !h-3 !rounded-full hover:!border-df-player-selected hover:!bg-df-player-selected/20"
+                  />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/StoryletDialogueNodeV2.tsx
+++ b/src/components/StoryletDialogueNodeV2.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { Handle, Position, NodeProps } from 'reactflow';
+import { Hash, BookOpen, Layers, Flag, Play } from 'lucide-react';
+import { DialogueNode } from '../types';
+import { FlagSchema } from '../types/flags';
+import { LayoutDirection } from '../utils/layout';
+import { NODE_TYPE } from '../types/constants';
+
+interface StoryletNodeData {
+  node: DialogueNode;
+  flagSchema?: FlagSchema;
+  isDimmed?: boolean;
+  isInPath?: boolean;
+  layoutDirection?: LayoutDirection;
+  isStartNode?: boolean;
+  isEndNode?: boolean;
+}
+
+const FLAG_COLORS: Record<string, string> = {
+  dialogue: 'bg-df-flag-dialogue-bg text-df-flag-dialogue border-df-flag-dialogue',
+  quest: 'bg-df-flag-quest-bg text-df-flag-quest border-df-flag-quest',
+  achievement: 'bg-df-flag-achievement-bg text-df-flag-achievement border-df-flag-achievement',
+  item: 'bg-df-flag-item-bg text-df-flag-item border-df-flag-item',
+  stat: 'bg-df-flag-stat-bg text-df-flag-stat border-df-flag-stat',
+  title: 'bg-df-flag-title-bg text-df-flag-title border-df-flag-title',
+  global: 'bg-df-flag-global-bg text-df-flag-global border-df-flag-global',
+};
+
+function getFlagColorClass(type: string): string {
+  return FLAG_COLORS[type] || FLAG_COLORS.dialogue;
+}
+
+export function StoryletDialogueNodeV2({ data, selected }: NodeProps<StoryletNodeData>) {
+  const {
+    node,
+    flagSchema,
+    isDimmed,
+    isInPath,
+    layoutDirection = 'TB',
+    isStartNode,
+    isEndNode,
+  } = data;
+
+  const isStoryletPool = node.type === NODE_TYPE.STORYLET_POOL;
+  const isHorizontal = layoutDirection === 'LR';
+  const targetPosition = isHorizontal ? Position.Left : Position.Top;
+  const sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
+
+  const borderClass = selected
+    ? 'border-df-npc-selected shadow-lg shadow-df-glow'
+    : isStartNode
+      ? 'border-df-start shadow-md'
+      : isEndNode
+        ? 'border-df-end shadow-md'
+        : 'border-df-npc-border';
+
+  const headerBgClass = isStartNode
+    ? 'bg-df-start-bg'
+    : isEndNode
+      ? 'bg-df-end-bg'
+      : 'bg-df-npc-header';
+
+  const contentPreview = node.content.length > 60
+    ? `${node.content.slice(0, 60)}...`
+    : node.content || 'No description yet.';
+
+  const storyletId = node.storyletId || node.storyletPool?.id;
+  const poolId = node.storyletPoolId || node.storyletPool?.id;
+  const primaryIdLabel = isStoryletPool ? 'Pool ID' : 'Storylet ID';
+
+  return (
+    <div
+      className={`rounded-lg border-2 transition-all duration-300 ${borderClass} ${isInPath ? 'border-df-node-selected/70' : ''} bg-df-npc-bg min-w-[320px] max-w-[450px] relative overflow-hidden`}
+      style={isDimmed ? { opacity: 0.35, filter: 'saturate(0.3)' } : undefined}
+    >
+      <Handle
+        type="target"
+        position={targetPosition}
+        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full"
+      />
+
+      <div className={`${headerBgClass} border-b-2 border-df-npc-border px-3 py-2.5 flex items-center gap-3 relative`}>
+        <div className="w-14 h-14 rounded-full bg-df-npc-bg border-[3px] border-df-npc-border flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
+          {isStoryletPool ? <Layers size={20} className="text-df-npc-selected" /> : <BookOpen size={20} className="text-df-npc-selected" />}
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-bold text-df-text-primary truncate leading-tight">
+            {isStoryletPool ? 'Storylet Pool' : 'Storylet'}
+          </h3>
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-base/50 border border-df-control-border" title={`Node ID: ${node.id}`}>
+            <Hash size={12} className="text-df-text-secondary" />
+            <span className="text-[10px] font-mono text-df-text-secondary">{node.id}</span>
+          </div>
+
+          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-npc-selected/20 border border-df-npc-selected/50" title="Storylet Node">
+            {isStoryletPool ? <Layers size={14} className="text-df-npc-selected" /> : <BookOpen size={14} className="text-df-npc-selected" />}
+            <span className="text-[10px] font-semibold text-df-npc-selected">
+              {isStoryletPool ? 'POOL' : 'STORYLET'}
+            </span>
+          </div>
+        </div>
+
+        {isStartNode && (
+          <div className="absolute top-1 right-1 bg-df-start text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+            <Play size={8} fill="currentColor" /> START
+          </div>
+        )}
+        {isEndNode && (
+          <div className="absolute top-1 right-1 bg-df-end text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+            <Flag size={8} /> END
+          </div>
+        )}
+      </div>
+
+      <div className="px-4 py-3 space-y-2">
+        <div className="bg-df-elevated border border-df-control-border rounded-lg px-4 py-3">
+          <p className="text-sm text-df-text-primary leading-relaxed">&quot;{contentPreview}&quot;</p>
+        </div>
+
+        <div className="space-y-1">
+          <div className="text-[10px] text-df-text-secondary uppercase">{primaryIdLabel}</div>
+          <div className="text-xs text-df-text-primary font-mono bg-df-base/40 border border-df-control-border rounded px-2 py-1">
+            {storyletId || 'Not set'}
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <div className="text-[10px] text-df-text-secondary uppercase">Pool Link</div>
+          <div className="text-xs text-df-text-primary font-mono bg-df-base/40 border border-df-control-border rounded px-2 py-1">
+            {poolId || 'Not linked'}
+          </div>
+        </div>
+
+        {node.setFlags && node.setFlags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {node.setFlags.map((flagId: string) => {
+              const flag = flagSchema?.flags.find((f: { id: string }) => f.id === flagId);
+              const flagType = flag?.type || 'dialogue';
+              return (
+                <span
+                  key={flagId}
+                  className={`text-[8px] px-1.5 py-0.5 rounded-full border ${getFlagColorClass(flagType)}`}
+                  title={flag?.name || flagId}
+                >
+                  {flagType === 'dialogue' ? 't' : flagType[0]}
+                </span>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <Handle
+        type="source"
+        position={sourcePosition}
+        id="next"
+        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full hover:!border-df-npc-selected hover:!bg-df-npc-selected/20"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Introduce Storylet and Randomizer node types to the V2 editor so narrative/storylet systems can be modelled in the graph UI.
- Reuse existing V2 visual conventions (colors, borders, typography) and avoid string literals by using `NODE_TYPE` constants.
- Allow editing/linking of storylets, storylet pools and randomizer branches from the node inspector to keep node configuration in the editor.

### Description

- Added two new React Flow node components: `src/components/StoryletDialogueNodeV2.tsx` and `src/components/RandomizerDialogueNodeV2.tsx` following the `NPCNodeV2`/`PlayerNodeV2` visual style and handles/metadata patterns.
- Registered the new node types in `src/components/DialogueEditorV2.tsx` using `NODE_TYPE` constants, introduced `isLinearNodeType` for shared linear-node logic, and extended connection/edge handling to support `branch-*` and `next` edges for storylet/randomizer nodes.
- Extended `src/utils/reactflow-converter.ts` to emit and consume edges for storylet `next` connections and randomizer `branch-*` outputs, and to preserve/sync `randomizerBranches` when converting between DialogueTree and React Flow.
- Extended `src/components/NodeEditor.tsx` to add inspector controls for `storyletId` / `storyletPoolId` and full randomizer branch editing (add/update/remove label, weight, target node, optional pool id) following the existing choice/conditional patterns.

### Testing

- Ran a full production build with `npm run build` (Next.js build + TypeScript) which completed successfully.
- Verified local dev boot with `npm run dev` and the editor compiled and served (TypeScript compile succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd6cd882c832da0e2b5cdaa80c303)