### PR TITLE
Use NarrativeThread for traversal, map pages to history by node IDs

### DIFF
--- a/src/components/DialogueEditorV2.tsx
+++ b/src/components/DialogueEditorV2.tsx
@@ -30,6 +30,7 @@ import { ENABLE_DEBUG_TOOLS } from '../utils/feature-flags';
 import 'reactflow/dist/style.css';
 
 import { DialogueEditorProps, DialogueTree, DialogueNode, Choice, ConditionalBlock, ViewMode } from '../types';
+import type { GameFlagState } from '../types/game-state';
 import { exportToYarn, importFromYarn } from '../lib/yarn-converter';
 import { convertDialogueTreeToReactFlow, updateDialogueTreeFromReactFlow, CHOICE_COLORS } from '../utils/reactflow-converter';
 import { createNode, deleteNodeFromTree, addChoiceToNode, removeChoiceFromNode, updateChoiceInNode } from '../utils/node-helpers';
@@ -75,6 +76,7 @@ const edgeTypes = {
 interface DialogueEditorV2InternalProps extends DialogueEditorProps {
   flagSchema?: FlagSchema;
   characters?: Record<string, Character>; // Characters from game state
+  gameStateFlags?: GameFlagState;
   initialViewMode?: ViewMode;
   viewMode?: ViewMode; // Controlled view mode (if provided, overrides initialViewMode)
   onViewModeChange?: (mode: ViewMode) => void; // Callback when view mode changes
@@ -96,6 +98,7 @@ function DialogueEditorV2Internal({
   showTitleEditor = true,
   flagSchema,
   characters = {},
+  gameStateFlags,
   initialViewMode = VIEW_MODE.GRAPH,
   viewMode: controlledViewMode,
   onViewModeChange,
@@ -1769,7 +1772,7 @@ function DialogueEditorV2Internal({
         <PlayView
           dialogue={dialogue}
           flagSchema={flagSchema}
-          initialGameStateFlags={initialFlags}
+          gameStateFlags={gameStateFlags}
         />
       )}
     </div>

--- a/src/components/DialogueEditorV2.tsx
+++ b/src/components/DialogueEditorV2.tsx
@@ -1769,6 +1769,7 @@ function DialogueEditorV2Internal({
         <PlayView
           dialogue={dialogue}
           flagSchema={flagSchema}
+          initialGameStateFlags={initialFlags}
         />
       )}
     </div>

--- a/src/components/GamePlayer/ReadingPane.tsx
+++ b/src/components/GamePlayer/ReadingPane.tsx
@@ -5,12 +5,11 @@ import { NODE_TYPE } from '../../types/constants';
 interface ReadingPaneProps {
   history: DialogueHistoryEntry[];
   currentStep: DialogueStep | null;
-  currentPage: number;
   status: 'running' | 'completed';
 }
 
-export function ReadingPane({ history, currentStep, currentPage, status }: ReadingPaneProps) {
-  const visibleHistory = history.slice(0, Math.max(currentPage + 1, 0));
+export function ReadingPane({ history, currentStep, status }: ReadingPaneProps) {
+  const visibleHistory = history;
 
   return (
     <section className="flex-1 flex flex-col bg-[#0d0d14]">

--- a/src/components/GamePlayer/index.tsx
+++ b/src/components/GamePlayer/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { DialogueTree } from '../../types';
+import { DialogueTree, type NarrativeThread } from '../../types';
 import { FlagSchema } from '../../types/flags';
 import { DialogueResult, FlagState } from '../../types/game-state';
 import { ReadingPane } from './ReadingPane';
@@ -7,6 +7,7 @@ import { StoryletSidebar } from './StoryletSidebar';
 import { WorldPane } from './WorldPane';
 import { useDialogueRunner } from '../../hooks/useDialogueRunner';
 import { useNarrativeTraversal } from '../../hooks/useNarrativeTraversal';
+import { NARRATIVE_ELEMENT } from '../../types/narrative';
 
 export interface GamePlayerProps {
   dialogue: DialogueTree;
@@ -15,6 +16,39 @@ export interface GamePlayerProps {
   initialFlags?: FlagState;
   onComplete?: (result: DialogueResult) => void;
   onFlagsChange?: (flags: FlagState) => void;
+  narrativeThread?: NarrativeThread;
+}
+
+function buildFallbackNarrativeThread(dialogue: DialogueTree): NarrativeThread {
+  const nodeIds = Object.keys(dialogue.nodes);
+
+  return {
+    id: `thread-${dialogue.id}`,
+    title: dialogue.title,
+    acts: [
+      {
+        id: `act-${dialogue.id}`,
+        title: dialogue.title ? `${dialogue.title} Act` : 'Untitled Act',
+        chapters: [
+          {
+            id: `chapter-${dialogue.id}`,
+            title: dialogue.title ?? 'Untitled Chapter',
+            pages: [
+              {
+                id: `page-${dialogue.id}`,
+                title: dialogue.title ?? 'Untitled Page',
+                nodeIds,
+                type: NARRATIVE_ELEMENT.PAGE,
+              },
+            ],
+            type: NARRATIVE_ELEMENT.CHAPTER,
+          },
+        ],
+        type: NARRATIVE_ELEMENT.ACT,
+      },
+    ],
+    type: NARRATIVE_ELEMENT.THREAD,
+  };
 }
 
 export function GamePlayer({
@@ -24,6 +58,7 @@ export function GamePlayer({
   initialFlags,
   onComplete,
   onFlagsChange,
+  narrativeThread,
 }: GamePlayerProps) {
   const runner = useDialogueRunner({
     dialogue,
@@ -34,20 +69,32 @@ export function GamePlayer({
     onFlagsChange,
   });
 
-  const narrative = useNarrativeTraversal({
-    title: dialogue.title,
-    initialPageCount: Math.max(runner.history.length, 1),
-  });
+  const resolvedThread = useMemo(
+    () => narrativeThread ?? buildFallbackNarrativeThread(dialogue),
+    [dialogue, narrativeThread]
+  );
 
-  const { progress, nextPage, previousPage, setPageCount, goToPage } = narrative;
+  const narrative = useNarrativeTraversal({ thread: resolvedThread });
+
+  const { progress, nextPage, previousPage, goToPage, sequence, currentStep } = narrative;
 
   useEffect(() => {
-    const totalPages = Math.max(runner.history.length, 1);
-    setPageCount(totalPages);
-    goToPage(totalPages - 1);
-  }, [runner.history.length, setPageCount, goToPage]);
+    const latestEntry = runner.history[runner.history.length - 1];
+    if (!latestEntry) return;
+    const pageIndex = sequence.findIndex(step => step.page.nodeIds.includes(latestEntry.nodeId));
+    if (pageIndex >= 0) {
+      goToPage(pageIndex);
+    }
+  }, [goToPage, runner.history, sequence]);
 
   const totalNodes = useMemo(() => Object.keys(dialogue.nodes).length, [dialogue.nodes]);
+  const currentPageHistory = useMemo(() => {
+    if (!currentStep) {
+      return [];
+    }
+    const nodeIds = new Set(currentStep.page.nodeIds);
+    return runner.history.filter(entry => nodeIds.has(entry.nodeId));
+  }, [currentStep, runner.history]);
 
   return (
     <div className="flex border border-[#1a1a2e] rounded-xl overflow-hidden bg-[#0f0f1a] h-full min-h-[480px]">
@@ -60,9 +107,8 @@ export function GamePlayer({
       />
 
       <ReadingPane
-        history={runner.history}
+        history={currentPageHistory}
         currentStep={runner.currentStep}
-        currentPage={progress.pageIndex}
         status={runner.status}
       />
 

--- a/src/components/GamePlayer/index.tsx
+++ b/src/components/GamePlayer/index.tsx
@@ -13,7 +13,7 @@ export interface GamePlayerProps {
   dialogue: DialogueTree;
   startNodeId?: string;
   flagSchema?: FlagSchema;
-  initialFlags?: FlagState;
+  gameStateFlags?: FlagState;
   onComplete?: (result: DialogueResult) => void;
   onFlagsChange?: (flags: FlagState) => void;
   narrativeThread?: NarrativeThread;
@@ -55,7 +55,7 @@ export function GamePlayer({
   dialogue,
   startNodeId,
   flagSchema,
-  initialFlags,
+  gameStateFlags,
   onComplete,
   onFlagsChange,
   narrativeThread,
@@ -64,7 +64,7 @@ export function GamePlayer({
     dialogue,
     startNodeId,
     flagSchema,
-    initialFlags,
+    gameStateFlags,
     onComplete,
     onFlagsChange,
   });

--- a/src/components/PlayView.tsx
+++ b/src/components/PlayView.tsx
@@ -10,7 +10,7 @@ interface PlayViewProps {
   dialogue: DialogueTree;
   startNodeId?: string;
   flagSchema?: FlagSchema;
-  initialGameStateFlags?: GameFlagState;
+  gameStateFlags?: GameFlagState;
   narrativeThread?: NarrativeThread;
 }
 
@@ -18,33 +18,33 @@ export function PlayView({
   dialogue,
   startNodeId,
   flagSchema,
-  initialGameStateFlags,
+  gameStateFlags,
   narrativeThread,
 }: PlayViewProps) {
-  // Initialize game flags with defaults from schema, then merge with initialGameStateFlags
-  const initialGameFlags = useMemo(() => {
+  // Initialize game flags with defaults from schema, then merge with gameStateFlags
+  const resolvedGameStateFlags = useMemo(() => {
     if (flagSchema) {
       const defaults = initializeFlags(flagSchema);
-      return { ...defaults, ...initialGameStateFlags };
+      return { ...defaults, ...gameStateFlags };
     }
-    return initialGameStateFlags || {};
-  }, [flagSchema, initialGameStateFlags]);
+    return gameStateFlags || {};
+  }, [flagSchema, gameStateFlags]);
   
-  const [currentFlags, setCurrentFlags] = useState<FlagState>(initialGameFlags);
+  const [currentFlags, setCurrentFlags] = useState<FlagState>(resolvedGameStateFlags);
   const [showDebugPanel, setShowDebugPanel] = useState(false);
   const [flagsSetDuringRun, setFlagsSetDuringRun] = useState<Set<string>>(new Set());
 
-  // Track initial flags to detect changes
-  const initialFlagsRef = useRef<GameFlagState>(initialGameFlags);
+  // Track baseline flags to detect changes
+  const baseFlagsRef = useRef<GameFlagState>(resolvedGameStateFlags);
 
   useEffect(() => {
-    initialFlagsRef.current = initialGameFlags;
-  }, [initialGameFlags]);
+    baseFlagsRef.current = resolvedGameStateFlags;
+  }, [resolvedGameStateFlags]);
 
   useEffect(() => {
-    setCurrentFlags(initialGameFlags);
+    setCurrentFlags(resolvedGameStateFlags);
     setFlagsSetDuringRun(new Set());
-  }, [initialGameFlags]);
+  }, [resolvedGameStateFlags]);
 
   const handleComplete = (result: DialogueResult) => {
     // Update flags from result
@@ -61,7 +61,7 @@ export function PlayView({
       setFlagsSetDuringRun(prev => {
         const next = new Set(prev);
         Object.keys(flags).forEach(flagId => {
-          const initialValue = initialFlagsRef.current[flagId];
+          const initialValue = baseFlagsRef.current[flagId];
           const currentValue = flags[flagId];
           if (initialValue !== currentValue) {
             next.add(flagId);
@@ -202,7 +202,7 @@ export function PlayView({
         dialogue={dialogue}
         startNodeId={startNodeId}
         flagSchema={flagSchema}
-        initialFlags={initialGameFlags}
+        gameStateFlags={resolvedGameStateFlags}
         onComplete={handleComplete}
         onFlagsChange={handleFlagUpdate}
         narrativeThread={narrativeThread}

--- a/src/components/PlayView.tsx
+++ b/src/components/PlayView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { DialogueTree } from '../types';
+import { DialogueTree, type NarrativeThread } from '../types';
 import { FLAG_TYPE } from '../types/constants';
 import { FlagSchema, FlagType } from '../types/flags';
 import { DialogueResult, FlagState, GameFlagState } from '../types/game-state';
@@ -11,9 +11,16 @@ interface PlayViewProps {
   startNodeId?: string;
   flagSchema?: FlagSchema;
   initialFlags?: GameFlagState;
+  narrativeThread?: NarrativeThread;
 }
 
-export function PlayView({ dialogue, startNodeId, flagSchema, initialFlags }: PlayViewProps) {
+export function PlayView({
+  dialogue,
+  startNodeId,
+  flagSchema,
+  initialFlags,
+  narrativeThread,
+}: PlayViewProps) {
   // Initialize game flags with defaults from schema, then merge with initialFlags
   const initialGameFlags = useMemo(() => {
     if (flagSchema) {
@@ -198,6 +205,7 @@ export function PlayView({ dialogue, startNodeId, flagSchema, initialFlags }: Pl
         initialFlags={initialGameFlags}
         onComplete={handleComplete}
         onFlagsChange={handleFlagUpdate}
+        narrativeThread={narrativeThread}
       />
     </main>
   );

--- a/src/components/PlayView.tsx
+++ b/src/components/PlayView.tsx
@@ -10,7 +10,7 @@ interface PlayViewProps {
   dialogue: DialogueTree;
   startNodeId?: string;
   flagSchema?: FlagSchema;
-  initialFlags?: GameFlagState;
+  initialGameStateFlags?: GameFlagState;
   narrativeThread?: NarrativeThread;
 }
 
@@ -18,17 +18,17 @@ export function PlayView({
   dialogue,
   startNodeId,
   flagSchema,
-  initialFlags,
+  initialGameStateFlags,
   narrativeThread,
 }: PlayViewProps) {
-  // Initialize game flags with defaults from schema, then merge with initialFlags
+  // Initialize game flags with defaults from schema, then merge with initialGameStateFlags
   const initialGameFlags = useMemo(() => {
     if (flagSchema) {
       const defaults = initializeFlags(flagSchema);
-      return { ...defaults, ...initialFlags };
+      return { ...defaults, ...initialGameStateFlags };
     }
-    return initialFlags || {};
-  }, [flagSchema, initialFlags]);
+    return initialGameStateFlags || {};
+  }, [flagSchema, initialGameStateFlags]);
   
   const [currentFlags, setCurrentFlags] = useState<FlagState>(initialGameFlags);
   const [showDebugPanel, setShowDebugPanel] = useState(false);

--- a/src/components/ScenePlayer.tsx
+++ b/src/components/ScenePlayer.tsx
@@ -42,7 +42,7 @@ export function ScenePlayer({
   onDialogueEnd,
 }: ScenePlayerProps) {
   // Validate and extract flags from gameState
-  const initialFlags = useMemo(() => {
+  const gameStateFlags = useMemo(() => {
     try {
       validateGameState(gameState);
       return extractFlagsFromGameState(gameState, flattenConfig);
@@ -53,7 +53,7 @@ export function ScenePlayer({
   }, [gameState, flattenConfig]);
   
   const [currentNodeId, setCurrentNodeId] = useState<string>(startNodeId || dialogue.startNodeId);
-  const [flags, setFlags] = useState<FlagState>(initialFlags);
+  const [flags, setFlags] = useState<FlagState>(gameStateFlags);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [isTyping, setIsTyping] = useState(false);
   const [visitedNodes, setVisitedNodes] = useState<Set<string>>(new Set());

--- a/src/hooks/useDialogueRunner.ts
+++ b/src/hooks/useDialogueRunner.ts
@@ -27,7 +27,7 @@ export interface DialogueStep {
 interface DialogueRunnerOptions {
   dialogue: DialogueTree;
   startNodeId?: string;
-  initialFlags?: FlagState;
+  gameStateFlags?: FlagState;
   flagSchema?: FlagSchema;
   onComplete?: (result: DialogueResult) => void;
   onFlagsChange?: (flags: FlagState) => void;
@@ -174,14 +174,14 @@ function isDialogueFlag(flagId: string, flagSchema?: FlagSchema): boolean {
 export function useDialogueRunner({
   dialogue,
   startNodeId,
-  initialFlags,
+  gameStateFlags,
   flagSchema,
   onComplete,
   onFlagsChange,
 }: DialogueRunnerOptions) {
   const initialNodeId = startNodeId || dialogue.startNodeId;
   const [currentNodeId, setCurrentNodeId] = useState(initialNodeId);
-  const [flags, setFlags] = useState<FlagState>(initialFlags || {});
+  const [flags, setFlags] = useState<FlagState>(gameStateFlags || {});
   const [history, setHistory] = useState<DialogueHistoryEntry[]>([]);
   const [currentStep, setCurrentStep] = useState<DialogueStep | null>(null);
   const [status, setStatus] = useState<'running' | 'completed'>('running');
@@ -204,14 +204,14 @@ export function useDialogueRunner({
   useEffect(() => {
     visitedNodesRef.current = new Set();
     memoryFlagsRef.current = new Set(
-      Object.keys(initialFlags || {}).filter(flagId => isDialogueFlag(flagId, flagSchema))
+      Object.keys(gameStateFlags || {}).filter(flagId => isDialogueFlag(flagId, flagSchema))
     );
     hasCompletedRef.current = false;
     setHistory([]);
-    setFlags(initialFlags || {});
+    setFlags(gameStateFlags || {});
     setStatus('running');
     setCurrentNodeId(initialNodeId);
-  }, [dialogue.id, initialNodeId, initialFlags, flagSchema]);
+  }, [dialogue.id, initialNodeId, gameStateFlags, flagSchema]);
 
   const completeDialogue = useCallback(
     (latestFlags?: FlagState) => {
@@ -334,15 +334,15 @@ export function useDialogueRunner({
   const resetDialogue = useCallback(() => {
     visitedNodesRef.current = new Set();
     memoryFlagsRef.current = new Set(
-      Object.keys(initialFlags || {}).filter(flagId => isDialogueFlag(flagId, flagSchema))
+      Object.keys(gameStateFlags || {}).filter(flagId => isDialogueFlag(flagId, flagSchema))
     );
     hasCompletedRef.current = false;
     setHistory([]);
-    setFlags(initialFlags || {});
+    setFlags(gameStateFlags || {});
     setStatus('running');
     setCurrentNodeId(initialNodeId);
     setCurrentStep(null);
-  }, [flagSchema, initialFlags, initialNodeId]);
+  }, [flagSchema, gameStateFlags, initialNodeId]);
 
   const availableChoices = useMemo(() => {
     if (!currentStep || !currentStep.isChoice) return [];

--- a/src/hooks/useNarrativeTraversal.ts
+++ b/src/hooks/useNarrativeTraversal.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { StoryThread } from '../types/narrative';
+import { buildLinearSequence, type NarrativeSequenceStep } from '../utils/narrative-helpers';
 
 export interface NarrativeLocation {
   actIndex: number;
@@ -15,74 +17,126 @@ export interface NarrativeProgress {
 }
 
 interface NarrativeTraversalOptions {
-  title?: string;
-  initialPageCount?: number;
+  thread: StoryThread;
+  initialLocation?: NarrativeLocation;
 }
 
-export function useNarrativeTraversal({
-  title,
-  initialPageCount = 1,
-}: NarrativeTraversalOptions) {
-  const [location, setLocation] = useState<NarrativeLocation>({
-    actIndex: 0,
-    chapterIndex: 0,
-    pageIndex: 0,
-  });
-  const [pageCount, setPageCount] = useState(Math.max(initialPageCount, 1));
+const DEFAULT_LOCATION: NarrativeLocation = {
+  actIndex: 0,
+  chapterIndex: 0,
+  pageIndex: 0,
+};
+
+function resolveLocationStep(
+  sequence: NarrativeSequenceStep[],
+  location: NarrativeLocation
+): NarrativeSequenceStep | undefined {
+  return sequence.find(
+    step =>
+      step.actIndex === location.actIndex &&
+      step.chapterIndex === location.chapterIndex &&
+      step.pageIndex === location.pageIndex
+  );
+}
+
+export function useNarrativeTraversal({ thread, initialLocation }: NarrativeTraversalOptions) {
+  const [location, setLocation] = useState<NarrativeLocation>(
+    initialLocation ?? DEFAULT_LOCATION
+  );
+
+  const sequence = useMemo(() => buildLinearSequence(thread), [thread]);
+
+  const currentSequenceIndex = useMemo(() => {
+    if (sequence.length === 0) {
+      return 0;
+    }
+    const matchIndex = sequence.findIndex(step =>
+      step.actIndex === location.actIndex &&
+      step.chapterIndex === location.chapterIndex &&
+      step.pageIndex === location.pageIndex
+    );
+    return matchIndex >= 0 ? matchIndex : 0;
+  }, [location.actIndex, location.chapterIndex, location.pageIndex, sequence]);
+
+  const currentStep = sequence[currentSequenceIndex];
 
   useEffect(() => {
-    setPageCount(Math.max(initialPageCount, 1));
-    setLocation({ actIndex: 0, chapterIndex: 0, pageIndex: 0 });
-  }, [initialPageCount]);
+    if (!initialLocation) return;
+    setLocation(initialLocation);
+  }, [initialLocation]);
 
-  const goToPage = useCallback((pageIndex: number) => {
-    setLocation(prev => ({
-      ...prev,
-      pageIndex: Math.min(Math.max(pageIndex, 0), Math.max(pageCount - 1, 0)),
-    }));
-  }, [pageCount]);
+  useEffect(() => {
+    if (sequence.length === 0) {
+      setLocation(DEFAULT_LOCATION);
+      return;
+    }
+    setLocation(prev => {
+      const match = resolveLocationStep(sequence, prev);
+      if (match) {
+        return prev;
+      }
+      return {
+        actIndex: sequence[0].actIndex,
+        chapterIndex: sequence[0].chapterIndex,
+        pageIndex: sequence[0].pageIndex,
+      };
+    });
+  }, [sequence]);
+
+  const setLocationFromSequenceIndex = useCallback(
+    (index: number) => {
+      if (sequence.length === 0) {
+        setLocation(DEFAULT_LOCATION);
+        return;
+      }
+      const clampedIndex = Math.min(Math.max(index, 0), sequence.length - 1);
+      const step = sequence[clampedIndex];
+      setLocation({
+        actIndex: step.actIndex,
+        chapterIndex: step.chapterIndex,
+        pageIndex: step.pageIndex,
+      });
+    },
+    [sequence]
+  );
+
+  const goToPage = useCallback(
+    (pageIndex: number) => {
+      setLocationFromSequenceIndex(pageIndex);
+    },
+    [setLocationFromSequenceIndex]
+  );
 
   const nextPage = useCallback(() => {
-    setLocation(prev => ({
-      ...prev,
-      pageIndex: Math.min(prev.pageIndex + 1, Math.max(pageCount - 1, 0)),
-    }));
-  }, [pageCount]);
+    setLocationFromSequenceIndex(currentSequenceIndex + 1);
+  }, [currentSequenceIndex, setLocationFromSequenceIndex]);
 
   const previousPage = useCallback(() => {
-    setLocation(prev => ({
-      ...prev,
-      pageIndex: Math.max(prev.pageIndex - 1, 0),
-    }));
-  }, []);
-
-  const syncPageCount = useCallback((count: number) => {
-    setPageCount(Math.max(count, 1));
-    setLocation(prev => ({
-      ...prev,
-      pageIndex: Math.min(prev.pageIndex, Math.max(count - 1, 0)),
-    }));
-  }, []);
+    setLocationFromSequenceIndex(currentSequenceIndex - 1);
+  }, [currentSequenceIndex, setLocationFromSequenceIndex]);
 
   const progress = useMemo<NarrativeProgress>(() => {
-    const safePageCount = Math.max(pageCount, 1);
-    const currentPage = Math.min(location.pageIndex, safePageCount - 1);
+    const safePageCount = Math.max(sequence.length, 1);
+    const safeIndex = Math.min(currentSequenceIndex, safePageCount - 1);
+    const actTitle = currentStep?.act.title ?? 'Untitled Act';
+    const chapterTitle = currentStep?.chapter.title ?? 'Untitled Chapter';
 
     return {
-      actTitle: `Act ${location.actIndex + 1}`,
-      chapterTitle: title ? `${title} — Chapter ${location.chapterIndex + 1}` : `Chapter ${location.chapterIndex + 1}`,
-      pageIndex: currentPage,
+      actTitle,
+      chapterTitle,
+      pageIndex: safeIndex,
       pageCount: safePageCount,
-      progress: (currentPage + 1) / safePageCount,
+      progress: (safeIndex + 1) / safePageCount,
     };
-  }, [location.actIndex, location.chapterIndex, location.pageIndex, pageCount, title]);
+  }, [currentSequenceIndex, currentStep?.act.title, currentStep?.chapter.title, sequence.length]);
 
   return {
     location,
     progress,
+    sequence,
+    currentStep: currentStep ?? null,
     goToPage,
     nextPage,
     previousPage,
-    setPageCount: syncPageCount,
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,7 @@ export type {
   NarrativeChapter,
   NarrativeElement,
   NarrativePage,
+  NarrativeThread,
   RandomizerBranch,
   StoryThread,
   Storylet,
@@ -88,4 +89,3 @@ export interface DraggingEdge {
   endX: number;
   endY: number;
 }
-

--- a/src/types/narrative.ts
+++ b/src/types/narrative.ts
@@ -52,6 +52,8 @@ export interface StoryThread {
   type?: typeof NARRATIVE_ELEMENT.THREAD;
 }
 
+export type NarrativeThread = StoryThread;
+
 export interface Storylet {
   id: string;
   title?: string;


### PR DESCRIPTION
### Motivation

- Provide a single source of truth for narrative structure (acts/chapters/pages) rather than using ad-hoc title/page-count placeholders.  
- Compute and display human-friendly act and chapter titles derived from real narrative data.  
- Make page navigation map directly to dialogue content (by node ids) so the UI shows only the page-scoped history.  
- Allow GamePlayer to be driven by an external `NarrativeThread` while keeping a sensible fallback when none is provided.

### Description

- Added a `NarrativeThread` alias and exported it from the narrative types so it can be used widely via `src/types/narrative.ts` and `src/types/index.ts`.  
- Reworked `useNarrativeTraversal` to accept a `thread: StoryThread` and build a linear `sequence` (via `buildLinearSequence`) so `progress.actTitle`, `progress.chapterTitle`, `pageCount`, and `progress` are derived from real data and sequence indices rather than placeholder text.  
- Updated `GamePlayer` and `PlayView` to accept an optional `narrativeThread` prop, build a fallback thread from a `DialogueTree` when not supplied, and pass the thread into `useNarrativeTraversal`.  
- Changed page selection to map `runner.history` entries to pages by matching `nodeId` against `page.nodeIds`, and show only the page-scoped slice of history in the reading pane (updated `ReadingPane` to render the provided history slice). 

### Testing

- Ran `npm run build` which completed successfully and TypeScript compiled without errors.  
- No additional automated unit tests were changed or added in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695df323e518832dacf576fef88f825c)