### PR TITLE
Redesign GamePlayer to VN-style layout with focused VN components

### DIFF
--- a/src/components/GamePlayer/ChoiceList.tsx
+++ b/src/components/GamePlayer/ChoiceList.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { DialogueStep } from '../../hooks/useDialogueRunner';
+
+interface ChoiceListProps {
+  currentStep: DialogueStep | null;
+  onContinue: () => void;
+  onChoose: (choiceId: string) => void;
+  status: 'running' | 'completed';
+}
+
+export function ChoiceList({ currentStep, onContinue, onChoose, status }: ChoiceListProps) {
+  const isChoice = currentStep?.isChoice;
+  const noAvailableChoices = isChoice && currentStep?.choices.length === 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-[10px] uppercase tracking-wide text-gray-500">Choices</p>
+          <h3 className="text-sm font-semibold text-white">What happens next?</h3>
+        </div>
+        <span className="text-[10px] px-2 py-1 rounded-full bg-[#12121f] border border-[#1f1f2e] text-gray-400">
+          {isChoice ? 'Choice' : 'Narrative'}
+        </span>
+      </div>
+
+      <div className="grid gap-2">
+        {isChoice && currentStep?.choices.map(choice => (
+          <button
+            key={choice.id}
+            onClick={() => onChoose(choice.id)}
+            className="w-full text-left px-4 py-3 rounded-xl border border-[#2a2a3e] bg-[#12121a] text-gray-200 hover:border-[#e94560] hover:bg-[#1a1a2a] transition-all shadow-sm"
+            disabled={status === 'completed'}
+          >
+            <div className="flex items-center justify-between">
+              <span>{choice.text}</span>
+              <span className="text-xs text-gray-500">Select</span>
+            </div>
+          </button>
+        ))}
+
+        {!isChoice && status !== 'completed' && (
+          <button
+            onClick={onContinue}
+            className="w-full px-4 py-3 bg-[#e94560] hover:bg-[#d63850] text-white rounded-xl transition-colors font-medium shadow-md"
+          >
+            Continue
+          </button>
+        )}
+
+        {status === 'completed' && (
+          <div className="text-center text-gray-500 text-sm border border-[#1f1f2e] rounded-xl p-3 bg-[#0f0f1a]">
+            Dialogue finished
+          </div>
+        )}
+
+        {noAvailableChoices && status !== 'completed' && (
+          <div className="text-xs text-gray-500 bg-[#0f0f1a] border border-dashed border-[#2a2a3e] rounded-xl p-3">
+            No available choices for the current conditions.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/GamePlayer/DialogueBox.tsx
+++ b/src/components/GamePlayer/DialogueBox.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { DialogueHistoryEntry, DialogueStep } from '../../hooks/useDialogueRunner';
+import { NODE_TYPE } from '../../types/constants';
+
+interface DialogueBoxProps {
+  history: DialogueHistoryEntry[];
+  currentStep: DialogueStep | null;
+  status: 'running' | 'completed';
+}
+
+export function DialogueBox({ history, currentStep, status }: DialogueBoxProps) {
+  return (
+    <section className="bg-[#0b0b14]/90 border border-[#1a1a2e] rounded-2xl backdrop-blur">
+      <div className="px-5 py-4 flex flex-col gap-3 max-h-[200px] overflow-y-auto">
+        {history.length === 0 && (
+          <p className="text-gray-500 text-sm">Use the choice cards to begin the scene.</p>
+        )}
+
+        {history.map(entry => (
+          <div
+            key={`${entry.nodeId}-${entry.content}`}
+            className={`flex ${entry.type === NODE_TYPE.PLAYER ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`max-w-[80%] rounded-2xl px-4 py-3 text-sm shadow-md border ${
+                entry.type === NODE_TYPE.PLAYER
+                  ? 'bg-[#e94560] text-white border-[#e94560]/70 rounded-br-md'
+                  : 'bg-[#121226] text-gray-100 border-[#24243b] rounded-bl-md'
+              }`}
+            >
+              {entry.type !== NODE_TYPE.PLAYER && entry.speaker && (
+                <div className="text-[11px] text-[#e94560] font-medium mb-1">{entry.speaker}</div>
+              )}
+              <div className="whitespace-pre-wrap leading-relaxed">{entry.content}</div>
+            </div>
+          </div>
+        ))}
+
+        {currentStep && currentStep.isChoice && currentStep.content && (
+          <div className="text-xs text-gray-400 border border-dashed border-[#2a2a3e] rounded-lg px-3 py-2">
+            <p className="uppercase tracking-wide text-[10px] text-gray-500 mb-1">Prompt</p>
+            <p>{currentStep.content}</p>
+          </div>
+        )}
+
+        {status === 'completed' && (
+          <div className="text-center text-gray-500 text-xs pt-1">Dialogue complete.</div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/GamePlayer/ProgressOverlay.tsx
+++ b/src/components/GamePlayer/ProgressOverlay.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { NarrativeProgress } from '../../hooks/useNarrativeTraversal';
+
+interface ProgressOverlayProps {
+  progress: NarrativeProgress;
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+  visitedNodes: number;
+  totalNodes: number;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export function ProgressOverlay({
+  progress,
+  onNextPage,
+  onPreviousPage,
+  visitedNodes,
+  totalNodes,
+  isOpen,
+  onToggle,
+}: ProgressOverlayProps) {
+  const completion = Math.round(progress.progress * 100);
+
+  return (
+    <div className="absolute right-6 top-6 z-20">
+      <button
+        onClick={onToggle}
+        className="text-[10px] uppercase tracking-wide px-3 py-2 rounded-full bg-[#12121f]/90 border border-[#1f1f2e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+      >
+        {isOpen ? 'Hide Info' : 'Show Info'}
+      </button>
+
+      {isOpen && (
+        <div className="mt-3 w-64 rounded-2xl border border-[#1a1a2e] bg-[#0b0b14]/95 backdrop-blur p-4 space-y-3 shadow-lg">
+          <div>
+            <p className="text-[10px] uppercase tracking-wide text-gray-500">Narrative</p>
+            <h2 className="text-sm font-semibold text-white leading-tight">{progress.chapterTitle}</h2>
+            <p className="text-xs text-gray-500 mt-1">{progress.actTitle}</p>
+          </div>
+
+          <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3">
+            <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
+              <span>Page {progress.pageIndex + 1}</span>
+              <span className="text-gray-500">of {progress.pageCount}</span>
+            </div>
+            <div className="h-2 bg-[#141422] rounded-full overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-[#e94560] to-[#8b5cf6]"
+                style={{ width: `${completion}%` }}
+              />
+            </div>
+            <div className="flex items-center justify-between text-[10px] text-gray-500 mt-2">
+              <span>Progress</span>
+              <span className="text-gray-300">{completion}%</span>
+            </div>
+          </div>
+
+          <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3 space-y-2">
+            <div className="flex items-center justify-between text-xs text-gray-400">
+              <span>Visited Storylets</span>
+              <span className="text-gray-100">{visitedNodes}</span>
+            </div>
+            <div className="flex items-center justify-between text-xs text-gray-400">
+              <span>Total Nodes</span>
+              <span className="text-gray-100">{totalNodes}</span>
+            </div>
+          </div>
+
+          <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3 space-y-2">
+            <p className="text-[11px] text-gray-400">Navigate chapters</p>
+            <div className="flex gap-2">
+              <button
+                className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+                onClick={onPreviousPage}
+              >
+                Previous
+              </button>
+              <button
+                className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+                onClick={onNextPage}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/GamePlayer/ReadingPane.tsx
+++ b/src/components/GamePlayer/ReadingPane.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { DialogueHistoryEntry, DialogueStep } from '../../hooks/useDialogueRunner';
-import { NODE_TYPE } from '../../types/constants';
+import { DialogueBox } from './DialogueBox';
 
 interface ReadingPaneProps {
   history: DialogueHistoryEntry[];
@@ -9,46 +9,5 @@ interface ReadingPaneProps {
 }
 
 export function ReadingPane({ history, currentStep, status }: ReadingPaneProps) {
-  const visibleHistory = history;
-
-  return (
-    <section className="flex-1 flex flex-col bg-[#0d0d14]">
-      <div className="flex-1 overflow-y-auto p-6 space-y-4">
-        {visibleHistory.length === 0 && (
-          <div className="text-gray-500 text-sm">Use the storylets on the right to begin the scene.</div>
-        )}
-
-        {visibleHistory.map(entry => (
-          <div
-            key={`${entry.nodeId}-${entry.content}`}
-            className={`flex ${entry.type === NODE_TYPE.PLAYER ? 'justify-end' : 'justify-start'}`}
-          >
-            <div
-              className={`max-w-[80%] rounded-2xl px-4 py-3 shadow-lg ${
-                entry.type === NODE_TYPE.PLAYER
-                  ? 'bg-[#e94560] text-white rounded-br-md'
-                  : 'bg-[#1a1a2e] text-gray-100 rounded-bl-md'
-              }`}
-            >
-              {entry.type !== NODE_TYPE.PLAYER && entry.speaker && (
-                <div className="text-xs text-[#e94560] font-medium mb-1">{entry.speaker}</div>
-              )}
-              <div className="whitespace-pre-wrap leading-relaxed">{entry.content}</div>
-            </div>
-          </div>
-        ))}
-
-        {currentStep && currentStep.isChoice && currentStep.content && (
-          <div className="text-gray-400 text-sm border border-dashed border-[#2a2a3e] rounded-lg p-3">
-            <p className="text-xs uppercase tracking-wide text-gray-500 mb-1">Prompt</p>
-            <p>{currentStep.content}</p>
-          </div>
-        )}
-
-        {status === 'completed' && (
-          <div className="text-center text-gray-500 text-sm pt-4">Dialogue complete.</div>
-        )}
-      </div>
-    </section>
-  );
+  return <DialogueBox history={history} currentStep={currentStep} status={status} />;
 }

--- a/src/components/GamePlayer/StoryletSidebar.tsx
+++ b/src/components/GamePlayer/StoryletSidebar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DialogueStep } from '../../hooks/useDialogueRunner';
+import { ChoiceList } from './ChoiceList';
 
 interface StoryletSidebarProps {
   currentStep: DialogueStep | null;
@@ -9,65 +10,14 @@ interface StoryletSidebarProps {
 }
 
 export function StoryletSidebar({ currentStep, onContinue, onChoose, status }: StoryletSidebarProps) {
-  const isChoice = currentStep?.isChoice;
-  const noAvailableChoices = isChoice && currentStep?.choices.length === 0;
-
   return (
-    <aside className="w-80 bg-[#0b0b14] border-l border-[#1a1a2e] flex-shrink-0 p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-[10px] uppercase tracking-wide text-gray-500">Storylets</p>
-          <h3 className="text-white font-semibold">What happens next?</h3>
-        </div>
-        <span className="text-[10px] px-2 py-1 rounded-full bg-[#12121f] border border-[#1f1f2e] text-gray-400">
-          {isChoice ? 'Choice' : 'Narrative'}
-        </span>
-      </div>
-
-      <div className="space-y-2">
-        {isChoice && currentStep?.choices.map(choice => (
-          <button
-            key={choice.id}
-            onClick={() => onChoose(choice.id)}
-            className="w-full text-left px-4 py-3 rounded-lg border border-[#2a2a3e] hover:border-[#e94560] bg-[#12121a] hover:bg-[#1a1a2a] text-gray-200 transition-all group flex items-center justify-between"
-            disabled={status === 'completed'}
-          >
-            <span>{choice.text}</span>
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              className="text-gray-600 group-hover:text-[#e94560] transition-colors"
-            >
-              <polyline points="9 18 15 12 9 6" />
-            </svg>
-          </button>
-        ))}
-
-        {!isChoice && status !== 'completed' && (
-          <button
-            onClick={onContinue}
-            className="w-full px-4 py-3 bg-[#e94560] hover:bg-[#d63850] text-white rounded-lg transition-colors font-medium shadow-md hover:shadow-lg"
-          >
-            Continue
-          </button>
-        )}
-
-        {status === 'completed' && (
-          <div className="text-center text-gray-500 text-sm border border-[#1f1f2e] rounded-lg p-3 bg-[#0f0f1a]">
-            Dialogue finished
-          </div>
-        )}
-
-        {noAvailableChoices && status !== 'completed' && (
-          <div className="text-xs text-gray-500 bg-[#0f0f1a] border border-dashed border-[#2a2a3e] rounded-lg p-3">
-            No available choices for the current conditions.
-          </div>
-        )}
-      </div>
-    </aside>
+    <div className="bg-[#0b0b14]/90 border border-[#1a1a2e] rounded-2xl backdrop-blur p-4">
+      <ChoiceList
+        currentStep={currentStep}
+        onContinue={onContinue}
+        onChoose={onChoose}
+        status={status}
+      />
+    </div>
   );
 }

--- a/src/components/GamePlayer/VNStage.tsx
+++ b/src/components/GamePlayer/VNStage.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface VNStageProps {
+  backgroundLabel?: string;
+}
+
+export function VNStage({ backgroundLabel = 'Scene' }: VNStageProps) {
+  return (
+    <div className="relative flex-1 bg-gradient-to-b from-[#10102a] via-[#0b0b16] to-[#08080f]">
+      <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_top,_#3b3b6d,_transparent_55%)]" />
+      <div className="relative h-full w-full flex items-end justify-between px-6 pb-28">
+        <div className="flex flex-col items-center text-xs text-gray-500">
+          <div className="h-40 w-24 rounded-2xl border border-dashed border-[#2a2a3e]" />
+          <span className="mt-2">Left</span>
+        </div>
+        <div className="flex flex-col items-center text-xs text-gray-500">
+          <div className="h-52 w-32 rounded-3xl border border-dashed border-[#2a2a3e]" />
+          <span className="mt-2">Center</span>
+        </div>
+        <div className="flex flex-col items-center text-xs text-gray-500">
+          <div className="h-40 w-24 rounded-2xl border border-dashed border-[#2a2a3e]" />
+          <span className="mt-2">Right</span>
+        </div>
+      </div>
+      <div className="absolute left-6 top-6 text-xs uppercase tracking-[0.3em] text-gray-500">
+        {backgroundLabel}
+      </div>
+    </div>
+  );
+}

--- a/src/components/GamePlayer/index.tsx
+++ b/src/components/GamePlayer/index.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { DialogueTree, type NarrativeThread } from '../../types';
 import { FlagSchema } from '../../types/flags';
 import { DialogueResult, FlagState } from '../../types/game-state';
 import { ReadingPane } from './ReadingPane';
 import { StoryletSidebar } from './StoryletSidebar';
-import { WorldPane } from './WorldPane';
+import { VNStage } from './VNStage';
+import { ProgressOverlay } from './ProgressOverlay';
 import { useDialogueRunner } from '../../hooks/useDialogueRunner';
 import { useNarrativeTraversal } from '../../hooks/useNarrativeTraversal';
 import { NARRATIVE_ELEMENT } from '../../types/narrative';
@@ -77,6 +78,7 @@ export function GamePlayer({
   const narrative = useNarrativeTraversal({ thread: resolvedThread });
 
   const { progress, nextPage, previousPage, goToPage, sequence, currentStep } = narrative;
+  const [isOverlayOpen, setIsOverlayOpen] = useState(false);
 
   useEffect(() => {
     const latestEntry = runner.history[runner.history.length - 1];
@@ -97,27 +99,34 @@ export function GamePlayer({
   }, [currentStep, runner.history]);
 
   return (
-    <div className="flex border border-[#1a1a2e] rounded-xl overflow-hidden bg-[#0f0f1a] h-full min-h-[480px]">
-      <WorldPane
+    <div className="relative border border-[#1a1a2e] rounded-3xl overflow-hidden bg-[#0f0f1a] h-full min-h-[480px]">
+      <VNStage backgroundLabel={progress.chapterTitle} />
+
+      <ProgressOverlay
         progress={progress}
         onNextPage={nextPage}
         onPreviousPage={previousPage}
         visitedNodes={runner.visitedNodeIds.length}
         totalNodes={totalNodes}
+        isOpen={isOverlayOpen}
+        onToggle={() => setIsOverlayOpen(open => !open)}
       />
 
-      <ReadingPane
-        history={currentPageHistory}
-        currentStep={runner.currentStep}
-        status={runner.status}
-      />
-
-      <StoryletSidebar
-        currentStep={runner.currentStep}
-        onContinue={runner.continueDialogue}
-        onChoose={runner.chooseOption}
-        status={runner.status}
-      />
+      <div className="absolute inset-x-0 bottom-0 px-6 pb-6">
+        <div className="grid gap-4 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+          <ReadingPane
+            history={currentPageHistory}
+            currentStep={runner.currentStep}
+            status={runner.status}
+          />
+          <StoryletSidebar
+            currentStep={runner.currentStep}
+            onContinue={runner.continueDialogue}
+            onChoose={runner.chooseOption}
+            status={runner.status}
+          />
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Replace the existing three-pane game player with a visual-novel style stage and overlaid dialogue/choice area for clearer, more game-like playback.
- Break the monolithic UI into small focused components to improve maintainability and make it easier to iterate on visual-novel UX patterns.
- Move progress/navigation/metadata into a subtle, optional overlay instead of fixed sidebars so the stage remains the primary focus.
- Render reading and storylet UI as VN-style dialogue bubbles and RPG-style choice cards with predictable placement.

### Description

- Replaced the old three-pane layout in `src/components/GamePlayer/index.tsx` with a VN stage and overlay layout and removed the fixed `WorldPane` sidebar.
- Added focused components: `VNStage`, `DialogueBox`, `ChoiceList`, and `ProgressOverlay` under `src/components/GamePlayer/` and wired them into `GamePlayer`.
- Refactored `ReadingPane.tsx` and `StoryletSidebar.tsx` to delegate rendering to `DialogueBox` and `ChoiceList` respectively for consistent VN styling.
- Kept styling minimal and consistent (rounded boxes, subtle borders/backdrop blur) and added a toggleable progress overlay via `ProgressOverlay`.

### Testing

- Ran `npm run build` (Next.js production build) and the project compiled successfully.
- Started the dev server (`npm run dev`) and a headless rendering script captured a screenshot to verify layout rendering automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dfb0fd164832da987218e00ca446d)