### PR TITLE
Update GamePlayer navigation labels and empty states

### DIFF
--- a/src/components/GamePlayer/ChoiceList.tsx
+++ b/src/components/GamePlayer/ChoiceList.tsx
@@ -11,6 +11,7 @@ interface ChoiceListProps {
 export function ChoiceList({ currentStep, onContinue, onChoose, status }: ChoiceListProps) {
   const isChoice = currentStep?.isChoice;
   const noAvailableChoices = isChoice && currentStep?.choices.length === 0;
+  const hasStep = Boolean(currentStep);
 
   return (
     <div className="space-y-3">
@@ -39,13 +40,19 @@ export function ChoiceList({ currentStep, onContinue, onChoose, status }: Choice
           </button>
         ))}
 
-        {!isChoice && status !== 'completed' && (
+        {!isChoice && hasStep && status !== 'completed' && (
           <button
             onClick={onContinue}
             className="w-full px-4 py-3 bg-[#e94560] hover:bg-[#d63850] text-white rounded-xl transition-colors font-medium shadow-md"
           >
             Continue
           </button>
+        )}
+
+        {!hasStep && status !== 'completed' && (
+          <div className="text-xs text-gray-500 bg-[#0f0f1a] border border-dashed border-[#2a2a3e] rounded-xl p-3">
+            No dialogue is available for this page yet. Move to another page to continue.
+          </div>
         )}
 
         {status === 'completed' && (

--- a/src/components/GamePlayer/DialogueBox.tsx
+++ b/src/components/GamePlayer/DialogueBox.tsx
@@ -13,7 +13,7 @@ export function DialogueBox({ history, currentStep, status }: DialogueBoxProps) 
     <section className="bg-[#0b0b14]/90 border border-[#1a1a2e] rounded-2xl backdrop-blur">
       <div className="px-5 py-4 flex flex-col gap-3 max-h-[200px] overflow-y-auto">
         {history.length === 0 && (
-          <p className="text-gray-500 text-sm">Use the choice cards to begin the scene.</p>
+          <p className="text-gray-500 text-sm">Use the choice cards to begin this page.</p>
         )}
 
         {history.map(entry => (

--- a/src/components/GamePlayer/ProgressOverlay.tsx
+++ b/src/components/GamePlayer/ProgressOverlay.tsx
@@ -5,8 +5,9 @@ interface ProgressOverlayProps {
   progress: NarrativeProgress;
   onNextPage: () => void;
   onPreviousPage: () => void;
-  visitedNodes: number;
-  totalNodes: number;
+  visitedPages: number;
+  totalPages: number;
+  hasPages: boolean;
   isOpen: boolean;
   onToggle: () => void;
 }
@@ -15,12 +16,16 @@ export function ProgressOverlay({
   progress,
   onNextPage,
   onPreviousPage,
-  visitedNodes,
-  totalNodes,
+  visitedPages,
+  totalPages,
+  hasPages,
   isOpen,
   onToggle,
 }: ProgressOverlayProps) {
   const completion = Math.round(progress.progress * 100);
+  const canGoPrevious = hasPages && progress.pageIndex > 0;
+  const canGoNext = hasPages && progress.pageIndex < progress.pageCount - 1;
+  const showNavigation = canGoPrevious || canGoNext;
 
   return (
     <div className="absolute right-6 top-6 z-20">
@@ -34,55 +39,73 @@ export function ProgressOverlay({
       {isOpen && (
         <div className="mt-3 w-64 rounded-2xl border border-[#1a1a2e] bg-[#0b0b14]/95 backdrop-blur p-4 space-y-3 shadow-lg">
           <div>
-            <p className="text-[10px] uppercase tracking-wide text-gray-500">Narrative</p>
+            <p className="text-[10px] uppercase tracking-wide text-gray-500">Chapter</p>
             <h2 className="text-sm font-semibold text-white leading-tight">{progress.chapterTitle}</h2>
-            <p className="text-xs text-gray-500 mt-1">{progress.actTitle}</p>
+            <p className="text-xs text-gray-500 mt-1">Act: {progress.actTitle}</p>
           </div>
 
           <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3">
-            <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
-              <span>Page {progress.pageIndex + 1}</span>
-              <span className="text-gray-500">of {progress.pageCount}</span>
-            </div>
-            <div className="h-2 bg-[#141422] rounded-full overflow-hidden">
-              <div
-                className="h-full bg-gradient-to-r from-[#e94560] to-[#8b5cf6]"
-                style={{ width: `${completion}%` }}
-              />
-            </div>
-            <div className="flex items-center justify-between text-[10px] text-gray-500 mt-2">
-              <span>Progress</span>
-              <span className="text-gray-300">{completion}%</span>
-            </div>
+            {hasPages ? (
+              <>
+                <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
+                  <span>Page {progress.pageIndex + 1}</span>
+                  <span className="text-gray-500">of {progress.pageCount}</span>
+                </div>
+                <div className="h-2 bg-[#141422] rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-gradient-to-r from-[#e94560] to-[#8b5cf6]"
+                    style={{ width: `${completion}%` }}
+                  />
+                </div>
+                <div className="flex items-center justify-between text-[10px] text-gray-500 mt-2">
+                  <span>Progress</span>
+                  <span className="text-gray-300">{completion}%</span>
+                </div>
+              </>
+            ) : (
+              <p className="text-xs text-gray-500">
+                No pages are available yet. Add a page to begin the journey.
+              </p>
+            )}
           </div>
 
           <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3 space-y-2">
             <div className="flex items-center justify-between text-xs text-gray-400">
-              <span>Visited Storylets</span>
-              <span className="text-gray-100">{visitedNodes}</span>
+              <span>Visited Pages</span>
+              <span className="text-gray-100">{visitedPages}</span>
             </div>
             <div className="flex items-center justify-between text-xs text-gray-400">
-              <span>Total Nodes</span>
-              <span className="text-gray-100">{totalNodes}</span>
+              <span>Total Pages</span>
+              <span className="text-gray-100">{totalPages}</span>
             </div>
           </div>
 
           <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3 space-y-2">
-            <p className="text-[11px] text-gray-400">Navigate chapters</p>
-            <div className="flex gap-2">
-              <button
-                className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
-                onClick={onPreviousPage}
-              >
-                Previous
-              </button>
-              <button
-                className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
-                onClick={onNextPage}
-              >
-                Next
-              </button>
-            </div>
+            <p className="text-[11px] text-gray-400">Navigate pages</p>
+            {showNavigation ? (
+              <div className="flex gap-2">
+                {canGoPrevious && (
+                  <button
+                    className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+                    onClick={onPreviousPage}
+                  >
+                    Previous
+                  </button>
+                )}
+                {canGoNext && (
+                  <button
+                    className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+                    onClick={onNextPage}
+                  >
+                    Next
+                  </button>
+                )}
+              </div>
+            ) : (
+              <p className="text-[11px] text-gray-500">
+                {hasPages ? 'This chapter has one page.' : 'No pages to navigate yet.'}
+              </p>
+            )}
           </div>
         </div>
       )}

--- a/src/components/GamePlayer/ReadingPane.tsx
+++ b/src/components/GamePlayer/ReadingPane.tsx
@@ -9,5 +9,15 @@ interface ReadingPaneProps {
 }
 
 export function ReadingPane({ history, currentStep, status }: ReadingPaneProps) {
+  if (!currentStep && history.length === 0) {
+    return (
+      <section className="bg-[#0b0b14]/90 border border-[#1a1a2e] rounded-2xl backdrop-blur">
+        <div className="px-5 py-4 text-sm text-gray-500">
+          No dialogue is available for this page yet. Choose another page to continue.
+        </div>
+      </section>
+    );
+  }
+
   return <DialogueBox history={history} currentStep={currentStep} status={status} />;
 }

--- a/src/components/GamePlayer/WorldPane.tsx
+++ b/src/components/GamePlayer/WorldPane.tsx
@@ -5,72 +5,95 @@ interface WorldPaneProps {
   progress: NarrativeProgress;
   onNextPage: () => void;
   onPreviousPage: () => void;
-  visitedNodes: number;
-  totalNodes: number;
+  visitedPages: number;
+  totalPages: number;
+  hasPages: boolean;
 }
 
 export function WorldPane({
   progress,
   onNextPage,
   onPreviousPage,
-  visitedNodes,
-  totalNodes,
+  visitedPages,
+  totalPages,
+  hasPages,
 }: WorldPaneProps) {
   const completion = Math.round(progress.progress * 100);
+  const canGoPrevious = hasPages && progress.pageIndex > 0;
+  const canGoNext = hasPages && progress.pageIndex < progress.pageCount - 1;
+  const showNavigation = canGoPrevious || canGoNext;
 
   return (
     <aside className="w-64 bg-[#0b0b14] border-r border-[#1a1a2e] flex-shrink-0 flex flex-col">
       <div className="p-4 border-b border-[#1a1a2e]">
-        <p className="text-[10px] uppercase tracking-wide text-gray-500 mb-1">Narrative</p>
+        <p className="text-[10px] uppercase tracking-wide text-gray-500 mb-1">Chapter</p>
         <h2 className="text-lg font-semibold text-white leading-tight">{progress.chapterTitle}</h2>
-        <p className="text-xs text-gray-500 mt-1">{progress.actTitle}</p>
+        <p className="text-xs text-gray-500 mt-1">Act: {progress.actTitle}</p>
       </div>
 
       <div className="p-4 space-y-4 flex-1 overflow-y-auto">
         <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3">
-          <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
-            <span>Page {progress.pageIndex + 1}</span>
-            <span className="text-gray-500">of {progress.pageCount}</span>
-          </div>
-          <div className="h-2 bg-[#141422] rounded-full overflow-hidden">
-            <div
-              className="h-full bg-gradient-to-r from-[#e94560] to-[#8b5cf6]"
-              style={{ width: `${completion}%` }}
-            />
-          </div>
-          <div className="flex items-center justify-between text-[10px] text-gray-500 mt-2">
-            <span>Progress</span>
-            <span className="text-gray-300">{completion}%</span>
-          </div>
+          {hasPages ? (
+            <>
+              <div className="flex items-center justify-between text-xs text-gray-400 mb-2">
+                <span>Page {progress.pageIndex + 1}</span>
+                <span className="text-gray-500">of {progress.pageCount}</span>
+              </div>
+              <div className="h-2 bg-[#141422] rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-gradient-to-r from-[#e94560] to-[#8b5cf6]"
+                  style={{ width: `${completion}%` }}
+                />
+              </div>
+              <div className="flex items-center justify-between text-[10px] text-gray-500 mt-2">
+                <span>Progress</span>
+                <span className="text-gray-300">{completion}%</span>
+              </div>
+            </>
+          ) : (
+            <p className="text-xs text-gray-500">
+              No pages are available yet. Add a page to begin the journey.
+            </p>
+          )}
         </div>
 
         <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3 space-y-2">
           <div className="flex items-center justify-between text-xs text-gray-400">
-            <span>Visited Storylets</span>
-            <span className="text-gray-100">{visitedNodes}</span>
+            <span>Visited Pages</span>
+            <span className="text-gray-100">{visitedPages}</span>
           </div>
           <div className="flex items-center justify-between text-xs text-gray-400">
-            <span>Total Nodes</span>
-            <span className="text-gray-100">{totalNodes}</span>
+            <span>Total Pages</span>
+            <span className="text-gray-100">{totalPages}</span>
           </div>
         </div>
 
         <div className="bg-[#0f0f1a] border border-[#1f1f2e] rounded-lg p-3 space-y-2">
-          <p className="text-[11px] text-gray-400">Navigate chapters</p>
-          <div className="flex gap-2">
-            <button
-              className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
-              onClick={onPreviousPage}
-            >
-              Previous
-            </button>
-            <button
-              className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
-              onClick={onNextPage}
-            >
-              Next
-            </button>
-          </div>
+          <p className="text-[11px] text-gray-400">Navigate pages</p>
+          {showNavigation ? (
+            <div className="flex gap-2">
+              {canGoPrevious && (
+                <button
+                  className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+                  onClick={onPreviousPage}
+                >
+                  Previous
+                </button>
+              )}
+              {canGoNext && (
+                <button
+                  className="flex-1 py-2 rounded-md border border-[#2a2a3e] text-gray-300 hover:text-white hover:border-[#e94560] transition-colors"
+                  onClick={onNextPage}
+                >
+                  Next
+                </button>
+              )}
+            </div>
+          ) : (
+            <p className="text-[11px] text-gray-500">
+              {hasPages ? 'This chapter has one page.' : 'No pages to navigate yet.'}
+            </p>
+          )}
         </div>
       </div>
     </aside>

--- a/src/components/GamePlayer/index.tsx
+++ b/src/components/GamePlayer/index.tsx
@@ -89,7 +89,18 @@ export function GamePlayer({
     }
   }, [goToPage, runner.history, sequence]);
 
-  const totalNodes = useMemo(() => Object.keys(dialogue.nodes).length, [dialogue.nodes]);
+  const totalPages = sequence.length;
+  const hasPages = totalPages > 0;
+  const visitedPages = useMemo(() => {
+    if (!hasPages) {
+      return 0;
+    }
+    const visitedNodeIds = new Set(runner.visitedNodeIds);
+    return sequence.reduce((count, step) => {
+      const pageVisited = step.page.nodeIds.some(nodeId => visitedNodeIds.has(nodeId));
+      return pageVisited ? count + 1 : count;
+    }, 0);
+  }, [hasPages, runner.visitedNodeIds, sequence]);
   const currentPageHistory = useMemo(() => {
     if (!currentStep) {
       return [];
@@ -106,8 +117,9 @@ export function GamePlayer({
         progress={progress}
         onNextPage={nextPage}
         onPreviousPage={previousPage}
-        visitedNodes={runner.visitedNodeIds.length}
-        totalNodes={totalNodes}
+        visitedPages={visitedPages}
+        totalPages={totalPages}
+        hasPages={hasPages}
         isOpen={isOverlayOpen}
         onToggle={() => setIsOverlayOpen(open => !open)}
       />


### PR DESCRIPTION
### Motivation
- Align the GamePlayer UI wording with the narrative hierarchy (Act → Chapter → Page) to avoid confusing terms like “Storylets.”
- Only present navigation controls that are actually actionable so users don't see dead controls for single-page chapters.
- Surface clear empty-state guidance when a page has no dialogue to keep behavior predictable and low-friction.

### Description
- Replace generic labels and headings (`Narrative`, `Visited Storylets`, `Total Nodes`, `Navigate chapters`) with hierarchy-accurate wording (`Chapter`, `Visited Pages`, `Total Pages`, `Navigate pages`) in `WorldPane.tsx` and `ProgressOverlay.tsx`.
- Add `hasPages`, `totalPages`, and `visitedPages` and compute page-level visitation in `GamePlayer/index.tsx`, and pass them into the overlay components.
- Render navigation buttons conditionally so only actionable `Previous`/`Next` controls appear, and show contextual messages for single-page or no-page states in `WorldPane.tsx` and `ProgressOverlay.tsx`.
- Add page-level empty-state guidance in `ReadingPane.tsx` and `ChoiceList.tsx`, and tweak the `DialogueBox` prompt to reference the current page.

### Testing
- Ran `npm run build`, which completed successfully and compiled the app.
- Performed an automated UI smoke check with a Playwright script that loaded the demo and captured a screenshot of the updated GamePlayer UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e0166bc54832d8090949d321d6f6c)