### PR TITLE
Add NarrativeWorkspace for page-scoped dialogue editing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,25 +1,12 @@
 'use client';
 
-import { useState, useCallback } from 'react';
-import { DialogueEditorV2 } from '@magicborn/dialogue-forge/src/components/DialogueEditorV2';
-import { FlagManager } from '@magicborn/dialogue-forge/src/components/FlagManager';
-import { GuidePanel } from '@magicborn/dialogue-forge/src/components/GuidePanel';
+import { NarrativeWorkspace } from '@magicborn/dialogue-forge/src/components/NarrativeWorkspace';
 import { FlagSchema, exampleFlagSchema } from '@magicborn/dialogue-forge/src/types/flags';
-import { DialogueTree } from '@magicborn/dialogue-forge/src/types';
-import { exportToYarn } from '@magicborn/dialogue-forge/src/lib/yarn-converter';
-import type { ViewMode } from '@magicborn/dialogue-forge/src/types';
-import { NODE_TYPE, VIEW_MODE } from '@magicborn/dialogue-forge/src/types/constants';
-import { 
-  listExamples, 
-  getExampleDialogue, 
-  listDemoFlagSchemas,
-  getDemoFlagSchema,
-  getExampleCharacters
-} from '@magicborn/dialogue-forge/src/examples';
-import { Play, Layout, FileText } from 'lucide-react';
+import type { DialogueTree, StoryThread } from '@magicborn/dialogue-forge/src/types';
+import { NARRATIVE_ELEMENT } from '@magicborn/dialogue-forge/src/types/narrative';
+import { CONDITION_OPERATOR, FLAG_TYPE, NODE_TYPE } from '@magicborn/dialogue-forge/src/types/constants';
+import { getExampleCharacters } from '@magicborn/dialogue-forge/src/examples';
 import { ThemeSwitcher } from '@/components/ThemeSwitcher';
-
-
 
 // Tell Next.js this page is static (no dynamic params/searchParams)
 export const dynamic = 'force-static';
@@ -38,7 +25,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Stranger', // Fallback
         x: 300,
         y: 100,
-        content: "You find yourself at a crossroads. A cloaked figure emerges from the shadows.",
+        content: 'You find yourself at a crossroads. A cloaked figure emerges from the shadows.',
         nextNodeId: 'greeting',
       },
       'greeting': {
@@ -48,7 +35,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Stranger', // Fallback
         x: 300,
         y: 200,
-        content: "\"Traveler... I've been waiting for you. What brings you to these lands?\"",
+        content: '"Traveler... I\'ve been waiting for you. What brings you to these lands?"',
         nextNodeId: 'first_choice',
       },
       'first_choice': {
@@ -60,10 +47,10 @@ const demoDialogues: Record<string, DialogueTree> = {
         choices: [
           {
             id: 'choice_treasure',
-            text: "I seek the legendary treasure.",
+            text: 'I seek the legendary treasure.',
             nextNodeId: 'treasure_response',
             conditions: [
-              { flag: 'reputation', operator: 'greater_equal', value: 0 },
+              { flag: 'reputation', operator: CONDITION_OPERATOR.GREATER_EQUAL, value: 0 },
             ],
           },
           {
@@ -71,15 +58,15 @@ const demoDialogues: Record<string, DialogueTree> = {
             text: "I'm searching for ancient knowledge.",
             nextNodeId: 'knowledge_response',
             conditions: [
-              { flag: 'reputation', operator: 'greater_equal', value: 0 },
+              { flag: 'reputation', operator: CONDITION_OPERATOR.GREATER_EQUAL, value: 0 },
             ],
           },
           {
             id: 'choice_high_rep',
-            text: "I am a hero of this land!",
+            text: 'I am a hero of this land!',
             nextNodeId: 'high_rep_response',
             conditions: [
-              { flag: 'reputation', operator: 'greater_than', value: 50 },
+              { flag: 'reputation', operator: CONDITION_OPERATOR.GREATER_THAN, value: 50 },
             ],
           },
         ],
@@ -91,7 +78,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Stranger', // Fallback
         x: 200,
         y: 450,
-        content: "\"Many have sought the same. Take this map—it shows the entrance to the catacombs.\"",
+        content: '"Many have sought the same. Take this map—it shows the entrance to the catacombs."',
         nextNodeId: undefined,
       },
       'knowledge_response': {
@@ -101,7 +88,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Stranger', // Fallback
         x: 400,
         y: 450,
-        content: "\"A seeker of truth... Take this tome. It contains the riddles you must solve.\"",
+        content: '"A seeker of truth... Take this tome. It contains the riddles you must solve."',
         nextNodeId: undefined,
       },
       'high_rep_response': {
@@ -111,7 +98,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Stranger', // Fallback
         x: 500,
         y: 450,
-        content: "\"Ah, a hero! Your reputation precedes you. I have something special for you...\"",
+        content: '"Ah, a hero! Your reputation precedes you. I have something special for you..."',
         nextNodeId: undefined,
         setFlags: ['reputation'],
       },
@@ -128,7 +115,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Narrator',
         x: 300,
         y: 50,
-        content: "You push open the heavy wooden door and enter the Rusty Dragon tavern.",
+        content: 'You push open the heavy wooden door and enter the Rusty Dragon tavern.',
         nextNodeId: 'bartender_greet',
       },
       'bartender_greet': {
@@ -138,7 +125,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Bartender', // Fallback
         x: 300,
         y: 150,
-        content: "\"Welcome, stranger! What can I get ya? We've got ale, mead, or if you're looking for work, I might have something.\"",
+        content: '"Welcome, stranger! What can I get ya? We\'ve got ale, mead, or if you\'re looking for work, I might have something."',
         nextNodeId: 'tavern_choice',
       },
       'tavern_choice': {
@@ -149,14 +136,14 @@ const demoDialogues: Record<string, DialogueTree> = {
         y: 280,
         choices: [
           { id: 'order_ale', text: "I'll have an ale.", nextNodeId: 'drink_ale' },
-          { id: 'ask_work', text: "What kind of work?", nextNodeId: 'work_info' },
+          { id: 'ask_work', text: 'What kind of work?', nextNodeId: 'work_info' },
           { id: 'look_around', text: "I'll just look around.", nextNodeId: 'observe_tavern' },
-          { 
-            id: 'vip_entrance', 
+          {
+            id: 'vip_entrance',
             text: "I'm a VIP member.",
             nextNodeId: 'vip_response',
             conditions: [
-              { flag: 'reputation', operator: 'greater_than', value: 75 },
+              { flag: 'reputation', operator: CONDITION_OPERATOR.GREATER_THAN, value: 75 },
             ],
           },
         ],
@@ -168,7 +155,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Bartender', // Fallback
         x: 100,
         y: 420,
-        content: "\"Coming right up!\" He slides a frothy mug across the bar.",
+        content: '"Coming right up!" He slides a frothy mug across the bar.',
         nextNodeId: undefined,
       },
       'work_info': {
@@ -178,7 +165,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Bartender', // Fallback
         x: 300,
         y: 420,
-        content: "\"Rats in the cellar. Big ones. I'll pay 10 gold if you clear 'em out.\"",
+        content: '"Rats in the cellar. Big ones. I\'ll pay 10 gold if you clear \'em out."',
         nextNodeId: 'accept_quest',
       },
       'accept_quest': {
@@ -189,7 +176,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         y: 550,
         choices: [
           { id: 'accept', text: "I'll do it.", nextNodeId: 'quest_accepted' },
-          { id: 'decline', text: "Not interested." },
+          { id: 'decline', text: 'Not interested.' },
         ],
       },
       'quest_accepted': {
@@ -199,7 +186,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Bartender', // Fallback
         x: 300,
         y: 680,
-        content: "\"Great! The cellar door is in the back. Good luck!\"",
+        content: '"Great! The cellar door is in the back. Good luck!"',
         nextNodeId: undefined,
       },
       'observe_tavern': {
@@ -209,7 +196,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Narrator', // Fallback
         x: 500,
         y: 420,
-        content: "You notice a hooded figure in the corner, watching you intently...",
+        content: 'You notice a hooded figure in the corner, watching you intently...',
         nextNodeId: undefined,
       },
       'vip_response': {
@@ -219,7 +206,7 @@ const demoDialogues: Record<string, DialogueTree> = {
         speaker: 'Bartender', // Fallback
         x: 600,
         y: 420,
-        content: "\"Of course! Right this way to the VIP lounge. Your reputation grants you access.\"",
+        content: '"Of course! Right this way to the VIP lounge. Your reputation grants you access."',
         nextNodeId: undefined,
       },
     },
@@ -234,223 +221,80 @@ const demoFlagSchema: FlagSchema = {
     {
       id: 'reputation',
       name: 'Reputation',
-      type: 'stat',
+      type: FLAG_TYPE.STAT,
       description: 'Player reputation score',
       defaultValue: 0,
     },
   ],
 };
 
+const demoNarrativeThread: StoryThread = {
+  id: 'demo-thread',
+  title: 'Demo Narrative Thread',
+  summary: 'A short encounter split into narrative pages.',
+  type: NARRATIVE_ELEMENT.THREAD,
+  acts: [
+    {
+      id: 'act-one',
+      title: 'Act I',
+      summary: 'The traveler meets a mysterious figure.',
+      type: NARRATIVE_ELEMENT.ACT,
+      chapters: [
+        {
+          id: 'chapter-one',
+          title: 'Chapter 1',
+          summary: 'Crossroads encounter.',
+          type: NARRATIVE_ELEMENT.CHAPTER,
+          pages: [
+            {
+              id: 'page-arrival',
+              title: 'Arrival',
+              summary: 'The stranger appears and asks a question.',
+              nodeIds: ['start', 'greeting', 'first_choice'],
+              type: NARRATIVE_ELEMENT.PAGE,
+            },
+            {
+              id: 'page-responses',
+              title: 'Responses',
+              summary: 'The traveler chooses a response.',
+              nodeIds: ['treasure_response', 'knowledge_response', 'high_rep_response'],
+              type: NARRATIVE_ELEMENT.PAGE,
+            },
+          ],
+          storyletPools: [],
+        },
+      ],
+    },
+  ],
+};
+
 export default function DialogueForgeDemo() {
-  const [dialogueTree, setDialogueTree] = useState<DialogueTree>(demoDialogues['mysterious-stranger']);
-  const [flagSchema, setFlagSchema] = useState<FlagSchema>(demoFlagSchema);
-  const [viewMode, setViewMode] = useState<ViewMode>(VIEW_MODE.GRAPH);
-  const characters = getExampleCharacters(); // Get example characters
-  
-  // Panel states
-  const [showFlagManager, setShowFlagManager] = useState(false);
-  const [showGuide, setShowGuide] = useState(false);
-  const [showExamplePicker, setShowExamplePicker] = useState(false);
-
-  const handleExportYarn = useCallback(() => {
-    const yarn = exportToYarn(dialogueTree);
-    const blob = new Blob([yarn], { type: 'text/plain' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${dialogueTree.title.replace(/\s+/g, '_')}.yarn`;
-    a.click();
-    URL.revokeObjectURL(url);
-  }, [dialogueTree]);
-
-  const handleLoadExample = useCallback((exampleId: string) => {
-    // Try demo examples first
-    if (demoDialogues[exampleId]) {
-      setDialogueTree(demoDialogues[exampleId]);
-      setShowExamplePicker(false);
-      return;
-    }
-    // Try package examples
-    const example = getExampleDialogue(exampleId);
-    if (example) {
-      setDialogueTree(example);
-    }
-    setShowExamplePicker(false);
-  }, []);
-
-  const handleLoadFlagSchema = useCallback((schemaId: string) => {
-    const schema = getDemoFlagSchema(schemaId);
-    if (schema) {
-      setFlagSchema(schema);
-    }
-  }, []);
-
-  // Get all available examples
-  const allExamples = [
-    ...Object.keys(demoDialogues),
-    ...listExamples()
-  ].filter((v, i, a) => a.indexOf(v) === i); // unique
-
-  const allFlagSchemas = listDemoFlagSchemas();
+  const characters = getExampleCharacters();
+  const initialDialogue = demoDialogues['mysterious-stranger'];
 
   return (
     <div className="w-full h-screen flex flex-col">
-      {/* Header */}
       <div className="max-w-7xl mx-auto px-4 py-4 flex-shrink-0 w-full">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-white mb-1">Dialogue Forge Editor</h1>
+            <h1 className="text-2xl font-bold text-white mb-1">Dialogue Forge Workspace</h1>
             <p className="text-zinc-400 text-sm">
-              Create interactive dialogues with a visual node-based editor. Export to Yarn Spinner format.
+              Plan narrative arcs, edit dialogue pages, and preview gameplay in one workspace.
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            <ThemeSwitcher />
-            <div className="w-px h-6 bg-zinc-700" />
-            <button
-              onClick={() => setShowExamplePicker(true)}
-              className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white text-sm rounded-lg transition-colors"
-            >
-              Load Example
-            </button>
-            <div className="w-px h-6 bg-zinc-700" />
-            {/* View Mode Toggle */}
-            <div className="flex items-center gap-1 bg-[#12121a] border border-[#2a2a3e] rounded-lg p-1">
-              <button
-                onClick={() => setViewMode(VIEW_MODE.GRAPH)}
-                className={`px-3 py-1.5 text-sm rounded transition-colors flex items-center gap-1.5 ${
-                  viewMode === VIEW_MODE.GRAPH
-                    ? 'bg-indigo-600 text-white'
-                    : 'text-gray-400 hover:text-white'
-                }`}
-                title="Graph Editor"
-              >
-                <Layout size={14} />
-                <span className="hidden sm:inline">Editor</span>
-              </button>
-              <button
-                onClick={() => setViewMode(VIEW_MODE.PLAY)}
-                className={`px-3 py-1.5 text-sm rounded transition-colors flex items-center gap-1.5 ${
-                  viewMode === VIEW_MODE.PLAY
-                    ? 'bg-green-600 text-white'
-                    : 'text-gray-400 hover:text-white'
-                }`}
-                title="Play Dialogue"
-              >
-                <Play size={14} />
-                <span className="hidden sm:inline">Play</span>
-              </button>
-            </div>
-            <button
-              onClick={() => setShowExamplePicker(true)}
-              className="px-3 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white text-sm rounded-lg transition-colors"
-            >
-              Load Example
-            </button>
-          </div>
+          <ThemeSwitcher />
         </div>
       </div>
 
-      {/* Editor/Player */}
       <div className="flex-1 w-full min-h-0">
-        <DialogueEditorV2
-          dialogue={dialogueTree}
-          onChange={setDialogueTree}
-          onExportYarn={handleExportYarn}
-          flagSchema={flagSchema}
+        <NarrativeWorkspace
+          initialDialogue={initialDialogue}
+          initialThread={demoNarrativeThread}
+          flagSchema={demoFlagSchema}
           characters={characters}
-          viewMode={viewMode}
-          onViewModeChange={setViewMode}
-          className="w-full h-full"
-          onOpenFlagManager={() => setShowFlagManager(true)}
-          onOpenGuide={() => setShowGuide(true)}
+          className="h-full"
         />
       </div>
-
-      {/* Flag Manager Modal */}
-      {showFlagManager && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-[#0d0d14] border border-[#2a2a3e] rounded-lg shadow-xl max-w-4xl w-full max-h-[80vh] overflow-hidden">
-            <FlagManager
-              flagSchema={flagSchema}
-              dialogue={dialogueTree}
-              onUpdate={setFlagSchema}
-              onClose={() => setShowFlagManager(false)}
-            />
-          </div>
-        </div>
-      )}
-
-      {/* Guide Panel */}
-      <GuidePanel
-        isOpen={showGuide}
-        onClose={() => setShowGuide(false)}
-      />
-
-      {/* Example Picker Modal */}
-      {showExamplePicker && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-[#0d0d14] border border-[#2a2a3e] rounded-lg shadow-xl max-w-lg w-full p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-white">Load Example Dialogue</h2>
-              <button
-                onClick={() => setShowExamplePicker(false)}
-                className="text-gray-400 hover:text-white"
-              >
-                ✕
-              </button>
-            </div>
-            
-            <div className="space-y-2 max-h-64 overflow-y-auto">
-              <h3 className="text-sm font-medium text-gray-400 mb-2">Demo Examples</h3>
-              {Object.entries(demoDialogues).map(([id, dialogue]) => (
-                <button
-                  key={id}
-                  onClick={() => handleLoadExample(id)}
-                  className="w-full text-left px-4 py-3 bg-[#12121a] hover:bg-[#1a1a2e] border border-[#2a2a3e] rounded-lg transition-colors"
-                >
-                  <div className="font-medium text-white">{dialogue.title}</div>
-                  <div className="text-xs text-gray-400">
-                    {Object.keys(dialogue.nodes).length} nodes
-                  </div>
-                </button>
-              ))}
-              
-              {listExamples().length > 0 && (
-                <>
-                  <h3 className="text-sm font-medium text-gray-400 mt-4 mb-2">Package Examples</h3>
-                  {listExamples().map((id) => (
-                    <button
-                      key={id}
-                      onClick={() => handleLoadExample(id)}
-                      className="w-full text-left px-4 py-3 bg-[#12121a] hover:bg-[#1a1a2e] border border-[#2a2a3e] rounded-lg transition-colors"
-                    >
-                      <div className="font-medium text-white">{id}</div>
-                    </button>
-                  ))}
-                </>
-              )}
-            </div>
-
-            {allFlagSchemas.length > 0 && (
-              <div className="mt-4 pt-4 border-t border-[#2a2a3e]">
-                <h3 className="text-sm font-medium text-gray-400 mb-2">Flag Schemas</h3>
-                <div className="flex flex-wrap gap-2">
-                  {allFlagSchemas.map((id) => (
-                    <button
-                      key={id}
-                      onClick={() => handleLoadFlagSchema(id)}
-                      className="px-3 py-1 text-xs bg-purple-500/20 text-purple-400 border border-purple-500/30 rounded hover:bg-purple-500/30 transition-colors"
-                    >
-                      {id}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import { NarrativeWorkspace } from '@magicborn/dialogue-forge/src/components/NarrativeWorkspace';
 import { FlagSchema, exampleFlagSchema } from '@magicborn/dialogue-forge/src/types/flags';
 import type { DialogueTree, StoryThread } from '@magicborn/dialogue-forge/src/types';
-import { NARRATIVE_ELEMENT } from '@magicborn/dialogue-forge/src/types/narrative';
+import { NARRATIVE_ELEMENT, STORYLET_SELECTION_MODE } from '@magicborn/dialogue-forge/src/types/narrative';
 import { CONDITION_OPERATOR, FLAG_TYPE, NODE_TYPE } from '@magicborn/dialogue-forge/src/types/constants';
 import { getExampleCharacters } from '@magicborn/dialogue-forge/src/examples';
 import { ThemeSwitcher } from '@/components/ThemeSwitcher';
@@ -261,7 +261,30 @@ const demoNarrativeThread: StoryThread = {
               type: NARRATIVE_ELEMENT.PAGE,
             },
           ],
-          storyletPools: [],
+          storyletPools: [
+            {
+              id: 'storylet-pool-crossroads',
+              title: 'Crossroads Encounters',
+              summary: 'Optional beats triggered at the crossroads.',
+              selectionMode: STORYLET_SELECTION_MODE.WEIGHTED,
+              storylets: [
+                {
+                  id: 'storylet-whisper',
+                  title: 'Whispered Warning',
+                  summary: 'A spectral whisper hints at a hidden path.',
+                  weight: 3,
+                  type: NARRATIVE_ELEMENT.STORYLET,
+                },
+                {
+                  id: 'storylet-shadow',
+                  title: 'Shadowy Observer',
+                  summary: 'A lurking shadow tests the traveler’s resolve.',
+                  weight: 1,
+                  type: NARRATIVE_ELEMENT.STORYLET,
+                },
+              ],
+            },
+          ],
         },
       ],
     },
@@ -274,18 +297,6 @@ export default function DialogueForgeDemo() {
 
   return (
     <div className="w-full h-screen flex flex-col">
-      <div className="max-w-7xl mx-auto px-4 py-4 flex-shrink-0 w-full">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-bold text-white mb-1">Dialogue Forge Workspace</h1>
-            <p className="text-zinc-400 text-sm">
-              Plan narrative arcs, edit dialogue pages, and preview gameplay in one workspace.
-            </p>
-          </div>
-          <ThemeSwitcher />
-        </div>
-      </div>
-
       <div className="flex-1 w-full min-h-0">
         <NarrativeWorkspace
           initialDialogue={initialDialogue}
@@ -293,6 +304,7 @@ export default function DialogueForgeDemo() {
           flagSchema={demoFlagSchema}
           characters={characters}
           className="h-full"
+          toolbarActions={<ThemeSwitcher />}
         />
       </div>
     </div>

--- a/src/components/DialogueEditorV2.tsx
+++ b/src/components/DialogueEditorV2.tsx
@@ -86,6 +86,7 @@ interface DialogueEditorV2InternalProps extends DialogueEditorProps {
   onOpenGuide?: () => void;
   onLoadExampleDialogue?: (dialogue: DialogueTree) => void;
   onLoadExampleFlags?: (flags: FlagSchema) => void;
+  showMiniMap?: boolean;
   // Event hooks from DialogueEditorProps are already included
 }
 
@@ -108,6 +109,7 @@ function DialogueEditorV2Internal({
   onOpenGuide,
   onLoadExampleDialogue,
   onLoadExampleFlags,
+  showMiniMap = true,
   // Event hooks
   onNodeAdd,
   onNodeDelete,
@@ -1213,35 +1215,37 @@ function DialogueEditorV2Internal({
               <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#1a1a2e" />
               
               {/* Enhanced MiniMap with title */}
-              <Panel position="bottom-right" className="!p-0 !m-2">
-                <div className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg overflow-hidden shadow-xl">
-                  <div className="px-3 py-1.5 border-b border-df-sidebar-border flex items-center justify-between bg-df-elevated">
-                    <span className="text-[10px] font-medium text-df-text-secondary uppercase tracking-wider">Overview</span>
-                    <div className="flex items-center gap-1">
-                      <span className="w-2 h-2 rounded-full bg-df-npc-selected" title="NPC / Storylet" />
-                      <span className="w-2 h-2 rounded-full bg-df-player-selected" title="Player / Randomizer" />
-                      <span className="w-2 h-2 rounded-full bg-df-conditional-border" title="Conditional" />
+              {showMiniMap && (
+                <Panel position="bottom-right" className="!p-0 !m-2">
+                  <div className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg overflow-hidden shadow-xl">
+                    <div className="px-3 py-1.5 border-b border-df-sidebar-border flex items-center justify-between bg-df-elevated">
+                      <span className="text-[10px] font-medium text-df-text-secondary uppercase tracking-wider">Overview</span>
+                      <div className="flex items-center gap-1">
+                        <span className="w-2 h-2 rounded-full bg-df-npc-selected" title="NPC / Storylet" />
+                        <span className="w-2 h-2 rounded-full bg-df-player-selected" title="Player / Randomizer" />
+                        <span className="w-2 h-2 rounded-full bg-df-conditional-border" title="Conditional" />
+                      </div>
                     </div>
+                    <MiniMap 
+                      style={{ 
+                        width: 180, 
+                        height: 120,
+                        backgroundColor: '#08080c',
+                      }}
+                      maskColor="rgba(0, 0, 0, 0.7)"
+                      nodeColor={(node) => {
+                        if (node.type === NODE_TYPE.NPC || node.type === NODE_TYPE.STORYLET || node.type === NODE_TYPE.STORYLET_POOL) return '#e94560';
+                        if (node.type === NODE_TYPE.PLAYER || node.type === NODE_TYPE.RANDOMIZER) return '#8b5cf6';
+                        if (node.type === NODE_TYPE.CONDITIONAL) return '#3b82f6';
+                        return '#4a4a6a';
+                      }}
+                      nodeStrokeWidth={2}
+                      pannable
+                      zoomable
+                    />
                   </div>
-                  <MiniMap 
-                    style={{ 
-                      width: 180, 
-                      height: 120,
-                      backgroundColor: '#08080c',
-                    }}
-                    maskColor="rgba(0, 0, 0, 0.7)"
-                    nodeColor={(node) => {
-                      if (node.type === NODE_TYPE.NPC || node.type === NODE_TYPE.STORYLET || node.type === NODE_TYPE.STORYLET_POOL) return '#e94560';
-                      if (node.type === NODE_TYPE.PLAYER || node.type === NODE_TYPE.RANDOMIZER) return '#8b5cf6';
-                      if (node.type === NODE_TYPE.CONDITIONAL) return '#3b82f6';
-                      return '#4a4a6a';
-                    }}
-                    nodeStrokeWidth={2}
-                    pannable
-                    zoomable
-                  />
-                </div>
-              </Panel>
+                </Panel>
+              )}
               
               {/* Left Toolbar - Layout, Flags, Guide */}
               <Panel position="top-left" className="!bg-transparent !border-0 !p-0 !m-2">
@@ -1789,6 +1793,7 @@ export function DialogueEditorV2(props: DialogueEditorProps & {
   onLayoutStrategyChange?: (strategy: string) => void;
   onOpenFlagManager?: () => void;
   onOpenGuide?: () => void;
+  showMiniMap?: boolean;
 }) {
   return (
     <ReactFlowProvider>

--- a/src/components/DialogueEditorV2.tsx
+++ b/src/components/DialogueEditorV2.tsx
@@ -24,7 +24,7 @@ import ReactFlow, {
   ConnectionLineType,
   BackgroundVariant,
 } from 'reactflow';
-import { Edit3, Plus, Trash2, Play, Layout, ArrowDown, ArrowRight, Magnet, Sparkles, Undo2, Flag, Home, Target, BookOpen, Settings, Grid3x3 } from 'lucide-react';
+import { Edit3, Plus, Trash2, Play, Layout, ArrowDown, ArrowRight, Magnet, Sparkles, Undo2, Flag, Home, Target, BookOpen, Settings, Grid3x3, Map as MapIcon } from 'lucide-react';
 import { ExampleLoaderButton } from './ExampleLoaderButton';
 import { ENABLE_DEBUG_TOOLS } from '../utils/feature-flags';
 import 'reactflow/dist/style.css';
@@ -87,6 +87,7 @@ interface DialogueEditorV2InternalProps extends DialogueEditorProps {
   onLoadExampleDialogue?: (dialogue: DialogueTree) => void;
   onLoadExampleFlags?: (flags: FlagSchema) => void;
   showMiniMap?: boolean;
+  onToggleMiniMap?: () => void;
   // Event hooks from DialogueEditorProps are already included
 }
 
@@ -110,6 +111,7 @@ function DialogueEditorV2Internal({
   onLoadExampleDialogue,
   onLoadExampleFlags,
   showMiniMap = true,
+  onToggleMiniMap,
   // Event hooks
   onNodeAdd,
   onNodeDelete,
@@ -1290,6 +1292,19 @@ function DialogueEditorV2Internal({
                       </div>
                     )}
                   </div>
+                  {onToggleMiniMap && (
+                    <button
+                      onClick={onToggleMiniMap}
+                      className={`p-1.5 rounded transition-colors ${
+                        showMiniMap
+                          ? 'bg-df-npc-selected/20 text-df-npc-selected border border-df-npc-selected'
+                          : 'bg-df-elevated border border-df-control-border text-df-text-secondary hover:text-df-text-primary hover:border-df-control-hover'
+                      }`}
+                      title={showMiniMap ? 'Hide minimap' : 'Show minimap'}
+                    >
+                      <MapIcon size={14} />
+                    </button>
+                  )}
                   
                   {/* Flag Manager */}
                   {onOpenFlagManager && (
@@ -1794,6 +1809,7 @@ export function DialogueEditorV2(props: DialogueEditorProps & {
   onOpenFlagManager?: () => void;
   onOpenGuide?: () => void;
   showMiniMap?: boolean;
+  onToggleMiniMap?: () => void;
 }) {
   return (
     <ReactFlowProvider>

--- a/src/components/NarrativeGraphView.tsx
+++ b/src/components/NarrativeGraphView.tsx
@@ -5,10 +5,11 @@ import ReactFlow, {
   Controls,
   Handle,
   MiniMap,
+  Panel,
   Position,
   type NodeProps,
 } from 'reactflow';
-import { BookOpen, Files, Layers, ScrollText } from 'lucide-react';
+import { BookOpen, Files, Layers, ScrollText, Map } from 'lucide-react';
 import 'reactflow/dist/style.css';
 
 import { NARRATIVE_ELEMENT, type NarrativeElement, type StoryThread } from '../types/narrative';
@@ -23,6 +24,9 @@ interface NarrativeGraphViewProps {
   className?: string;
   showMiniMap?: boolean;
   onSelectElement?: (element: NarrativeElement, id: string) => void;
+  onToggleMiniMap?: () => void;
+  onPaneContextMenu?: (event: React.MouseEvent) => void;
+  onPaneClick?: () => void;
 }
 
 const elementMeta: Record<
@@ -117,6 +121,9 @@ export function NarrativeGraphView({
   className = '',
   showMiniMap = true,
   onSelectElement,
+  onToggleMiniMap,
+  onPaneContextMenu,
+  onPaneClick,
 }: NarrativeGraphViewProps) {
   const { nodes, edges } = useMemo(() => convertNarrativeToReactFlow(thread), [thread]);
 
@@ -137,8 +144,22 @@ export function NarrativeGraphView({
             onSelectElement?.(elementType, node.id);
           }
         }}
+        onPaneContextMenu={event => onPaneContextMenu?.(event)}
+        onPaneClick={() => onPaneClick?.()}
       >
         <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+        {onToggleMiniMap && (
+          <Panel position="top-left" className="!p-0 !m-2">
+            <button
+              type="button"
+              onClick={onToggleMiniMap}
+              className="rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
+              title={showMiniMap ? 'Hide minimap' : 'Show minimap'}
+            >
+              <Map size={14} />
+            </button>
+          </Panel>
+        )}
         {showMiniMap && (
           <MiniMap
             nodeColor={node => {

--- a/src/components/NarrativeGraphView.tsx
+++ b/src/components/NarrativeGraphView.tsx
@@ -21,6 +21,8 @@ import { NPCEdgeV2 } from './NPCEdgeV2';
 interface NarrativeGraphViewProps {
   thread: StoryThread;
   className?: string;
+  showMiniMap?: boolean;
+  onSelectElement?: (element: NarrativeElement, id: string) => void;
 }
 
 const elementMeta: Record<
@@ -110,7 +112,12 @@ const edgeTypes = {
   default: NPCEdgeV2,
 };
 
-export function NarrativeGraphView({ thread, className = '' }: NarrativeGraphViewProps) {
+export function NarrativeGraphView({
+  thread,
+  className = '',
+  showMiniMap = true,
+  onSelectElement,
+}: NarrativeGraphViewProps) {
   const { nodes, edges } = useMemo(() => convertNarrativeToReactFlow(thread), [thread]);
 
   return (
@@ -124,18 +131,26 @@ export function NarrativeGraphView({ thread, className = '' }: NarrativeGraphVie
         className="bg-df-canvas-bg"
         minZoom={0.1}
         maxZoom={1.5}
+        onNodeClick={(_, node) => {
+          const elementType = node.type as NarrativeElement | undefined;
+          if (elementType) {
+            onSelectElement?.(elementType, node.id);
+          }
+        }}
       >
         <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
-        <MiniMap
-          nodeColor={node => {
-            if (node.type === NARRATIVE_ELEMENT.ACT) return 'var(--color-df-player-border)';
-            if (node.type === NARRATIVE_ELEMENT.CHAPTER) return 'var(--color-df-conditional-border)';
-            if (node.type === NARRATIVE_ELEMENT.PAGE) return 'var(--color-df-node-border)';
-            return 'var(--color-df-npc-border)';
-          }}
-          maskColor="rgba(11, 11, 20, 0.8)"
-          className="border border-df-node-border"
-        />
+        {showMiniMap && (
+          <MiniMap
+            nodeColor={node => {
+              if (node.type === NARRATIVE_ELEMENT.ACT) return 'var(--color-df-player-border)';
+              if (node.type === NARRATIVE_ELEMENT.CHAPTER) return 'var(--color-df-conditional-border)';
+              if (node.type === NARRATIVE_ELEMENT.PAGE) return 'var(--color-df-node-border)';
+              return 'var(--color-df-npc-border)';
+            }}
+            maskColor="rgba(11, 11, 20, 0.8)"
+            className="border border-df-node-border"
+          />
+        )}
         <Controls className="bg-[#0f0f1a] border border-[#1f1f2e]" />
       </ReactFlow>
     </div>

--- a/src/components/NarrativeWorkspace.tsx
+++ b/src/components/NarrativeWorkspace.tsx
@@ -9,6 +9,7 @@ import {
   Info,
   LayoutPanelTop,
   ListTree,
+  Map,
   Play,
   Plus,
   Search,
@@ -99,6 +100,8 @@ export function NarrativeWorkspace({
   const [showGuide, setShowGuide] = useState(false);
   const [narrativeViewMode, setNarrativeViewMode] = useState<ViewMode>(VIEW_MODE.GRAPH);
   const [dialogueViewMode, setDialogueViewMode] = useState<ViewMode>(VIEW_MODE.GRAPH);
+  const [showNarrativeMiniMap, setShowNarrativeMiniMap] = useState(true);
+  const [showDialogueMiniMap, setShowDialogueMiniMap] = useState(true);
   const [storyletTab, setStoryletTab] = useState<'storylets' | 'pools'>('storylets');
   const [storyletSearch, setStoryletSearch] = useState('');
   const [poolSearch, setPoolSearch] = useState('');
@@ -519,7 +522,7 @@ export function NarrativeWorkspace({
 
   return (
     <div className={`flex h-full w-full flex-col ${className}`}>
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-df-sidebar-border bg-df-base/80 px-4 py-2">
+      <div className="flex items-center justify-between border-b border-df-sidebar-border bg-df-base/80 px-3 py-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
@@ -537,7 +540,7 @@ export function NarrativeWorkspace({
                 setShowFlagManager(true);
               }
             }}
-            title="Manage flags"
+            title="Game state"
           >
             <Flag size={16} />
           </button>
@@ -550,113 +553,12 @@ export function NarrativeWorkspace({
             <HelpCircle size={16} />
           </button>
         </div>
-
-        <div className="flex flex-wrap items-center gap-2 text-xs text-df-text-tertiary">
-          <div className="flex items-center gap-2">
-            <span className="inline-flex items-center gap-1">
-              <CircleDot size={12} />
-              Act
-            </span>
-            <select
-              className="rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-xs text-df-text-primary"
-              value={selectedAct?.id ?? ''}
-              onChange={event => {
-                const actId = event.target.value;
-                const act = thread.acts.find(item => item.id === actId);
-                setSelection(prev => ({
-                  ...prev,
-                  actId,
-                  chapterId: act?.chapters[0]?.id,
-                  pageId: act?.chapters[0]?.pages[0]?.id,
-                }));
-              }}
-              title="Select act"
-            >
-              {thread.acts.map(act => (
-                <option key={act.id} value={act.id}>
-                  {act.title ?? act.id}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              className="flex items-center justify-center rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
-              onClick={handleAddAct}
-              title="Add act"
-            >
-              <Plus size={12} />
-            </button>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <span className="inline-flex items-center gap-1">
-              <BookOpen size={12} />
-              Chapter
-            </span>
-            <select
-              className="rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-xs text-df-text-primary"
-              value={selectedChapter?.id ?? ''}
-              onChange={event => {
-                const chapterId = event.target.value;
-                const chapter = selectedAct?.chapters.find(item => item.id === chapterId);
-                setSelection(prev => ({
-                  ...prev,
-                  chapterId,
-                  pageId: chapter?.pages[0]?.id,
-                }));
-              }}
-              title="Select chapter"
-            >
-              {(selectedAct?.chapters ?? []).map(chapter => (
-                <option key={chapter.id} value={chapter.id}>
-                  {chapter.title ?? chapter.id}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              className="flex items-center justify-center rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
-              onClick={handleAddChapter}
-              title="Add chapter"
-            >
-              <Plus size={12} />
-            </button>
-          </div>
-
-          <div className="flex items-center gap-2">
-            <span className="inline-flex items-center gap-1">
-              <LayoutPanelTop size={12} />
-              Page
-            </span>
-            <select
-              className="rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-xs text-df-text-primary"
-              value={selectedPage?.id ?? ''}
-              onChange={event => setSelection(prev => ({ ...prev, pageId: event.target.value }))}
-              title="Select page"
-            >
-              {(selectedChapter?.pages ?? []).map(page => (
-                <option key={page.id} value={page.id}>
-                  {page.title ?? page.id}
-                </option>
-              ))}
-            </select>
-            <button
-              type="button"
-              className="flex items-center justify-center rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
-              onClick={handleAddPage}
-              title="Add page"
-            >
-              <Plus size={12} />
-            </button>
-          </div>
-        </div>
-
         <div className="flex items-center gap-2">{toolbarActions}</div>
       </div>
 
-      <div className="flex min-h-0 flex-1 gap-4 p-4">
-        <div className="flex min-w-0 flex-1 flex-col gap-3">
-          <div className="flex items-center justify-between rounded-lg border border-df-node-border bg-df-editor-bg px-3 py-2">
+      <div className="flex min-h-0 flex-1 gap-2 p-2">
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-df-node-border bg-df-editor-bg px-2 py-1.5">
             <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-df-text-tertiary">
               <CircleDot size={12} />
               Narrative Graph
@@ -664,7 +566,105 @@ export function NarrativeWorkspace({
                 <Info size={12} />
               </span>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex items-center gap-1 text-[11px] text-df-text-tertiary">
+                <span className="inline-flex items-center gap-1">
+                  <CircleDot size={12} />
+                  Act
+                </span>
+                <select
+                  className="rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-primary"
+                  value={selectedAct?.id ?? ''}
+                  onChange={event => {
+                    const actId = event.target.value;
+                    const act = thread.acts.find(item => item.id === actId);
+                    setSelection(prev => ({
+                      ...prev,
+                      actId,
+                      chapterId: act?.chapters[0]?.id,
+                      pageId: act?.chapters[0]?.pages[0]?.id,
+                    }));
+                  }}
+                  title="Select act"
+                >
+                  {thread.acts.map(act => (
+                    <option key={act.id} value={act.id}>
+                      {act.title ?? act.id}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="flex items-center justify-center rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
+                  onClick={handleAddAct}
+                  title="Add act"
+                >
+                  <Plus size={12} />
+                </button>
+              </div>
+
+              <div className="flex items-center gap-1 text-[11px] text-df-text-tertiary">
+                <span className="inline-flex items-center gap-1">
+                  <BookOpen size={12} />
+                  Chapter
+                </span>
+                <select
+                  className="rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-primary"
+                  value={selectedChapter?.id ?? ''}
+                  onChange={event => {
+                    const chapterId = event.target.value;
+                    const chapter = selectedAct?.chapters.find(item => item.id === chapterId);
+                    setSelection(prev => ({
+                      ...prev,
+                      chapterId,
+                      pageId: chapter?.pages[0]?.id,
+                    }));
+                  }}
+                  title="Select chapter"
+                >
+                  {(selectedAct?.chapters ?? []).map(chapter => (
+                    <option key={chapter.id} value={chapter.id}>
+                      {chapter.title ?? chapter.id}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="flex items-center justify-center rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
+                  onClick={handleAddChapter}
+                  title="Add chapter"
+                >
+                  <Plus size={12} />
+                </button>
+              </div>
+
+              <div className="flex items-center gap-1 text-[11px] text-df-text-tertiary">
+                <span className="inline-flex items-center gap-1">
+                  <LayoutPanelTop size={12} />
+                  Page
+                </span>
+                <select
+                  className="rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-primary"
+                  value={selectedPage?.id ?? ''}
+                  onChange={event => setSelection(prev => ({ ...prev, pageId: event.target.value }))}
+                  title="Select page"
+                >
+                  {(selectedChapter?.pages ?? []).map(page => (
+                    <option key={page.id} value={page.id}>
+                      {page.title ?? page.id}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="flex items-center justify-center rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
+                  onClick={handleAddPage}
+                  title="Add page"
+                >
+                  <Plus size={12} />
+                </button>
+              </div>
+
               <button
                 type="button"
                 className="flex items-center gap-1 rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-secondary hover:text-df-text-primary"
@@ -686,6 +686,15 @@ export function NarrativeWorkspace({
               <button
                 type="button"
                 className="flex items-center gap-1 rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-secondary hover:text-df-text-primary"
+                onClick={() => setShowNarrativeMiniMap(prev => !prev)}
+                title={showNarrativeMiniMap ? 'Hide minimap' : 'Show minimap'}
+              >
+                <Map size={12} />
+                Mini
+              </button>
+              <button
+                type="button"
+                className="flex items-center gap-1 rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-secondary hover:text-df-text-primary"
                 onClick={() => handleExportYarn(dialogueTree)}
                 title="Export yarn"
               >
@@ -694,14 +703,55 @@ export function NarrativeWorkspace({
               </button>
             </div>
           </div>
-          <div className="h-[220px] min-h-[200px]">
+          <div className="h-[220px] min-h-[200px] rounded-lg border border-df-node-border bg-df-editor-bg p-1">
             {narrativeViewMode === VIEW_MODE.GRAPH ? (
-              <NarrativeGraphView thread={thread} className="h-full" />
+              <NarrativeGraphView
+                thread={thread}
+                className="h-full"
+                showMiniMap={showNarrativeMiniMap}
+                onSelectElement={(elementType, elementId) => {
+                  if (elementType === NARRATIVE_ELEMENT.ACT) {
+                    const act = thread.acts.find(item => item.id === elementId);
+                    setSelection(prev => ({
+                      ...prev,
+                      actId: elementId,
+                      chapterId: act?.chapters[0]?.id,
+                      pageId: act?.chapters[0]?.pages[0]?.id,
+                    }));
+                  }
+                  if (elementType === NARRATIVE_ELEMENT.CHAPTER) {
+                    const actForChapter = thread.acts.find(act =>
+                      act.chapters.some(item => item.id === elementId)
+                    );
+                    const chapter = actForChapter?.chapters.find(item => item.id === elementId);
+                    setSelection(prev => ({
+                      ...prev,
+                      actId: actForChapter?.id ?? prev.actId,
+                      chapterId: elementId,
+                      pageId: chapter?.pages[0]?.id,
+                    }));
+                  }
+                  if (elementType === NARRATIVE_ELEMENT.PAGE) {
+                    const actForPage = thread.acts.find(act =>
+                      act.chapters.some(chapter => chapter.pages.some(page => page.id === elementId))
+                    );
+                    const chapterForPage = actForPage?.chapters.find(chapter =>
+                      chapter.pages.some(page => page.id === elementId)
+                    );
+                    setSelection(prev => ({
+                      ...prev,
+                      actId: actForPage?.id ?? prev.actId,
+                      chapterId: chapterForPage?.id ?? prev.chapterId,
+                      pageId: elementId,
+                    }));
+                  }
+                }}
+              />
             ) : (
               <YarnView dialogue={dialogueTree} onExport={() => handleExportYarn(dialogueTree)} />
             )}
           </div>
-          <div className="flex items-center justify-between rounded-lg border border-df-node-border bg-df-editor-bg px-3 py-2">
+          <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-df-node-border bg-df-editor-bg px-2 py-1.5">
             <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-df-text-tertiary">
               <LayoutPanelTop size={12} />
               Dialogue Graph
@@ -711,7 +761,7 @@ export function NarrativeWorkspace({
                 <Info size={12} />
               </span>
             </div>
-            <div className="flex items-center gap-2 text-[11px] text-df-text-tertiary">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-df-text-tertiary">
               <span className="inline-flex items-center gap-1 rounded-full border border-df-control-border bg-df-control-bg px-2 py-1">
                 {selectedPage?.title ?? 'Page'}
               </span>
@@ -741,6 +791,15 @@ export function NarrativeWorkspace({
               <button
                 type="button"
                 className="flex items-center gap-1 rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-secondary hover:text-df-text-primary"
+                onClick={() => setShowDialogueMiniMap(prev => !prev)}
+                title={showDialogueMiniMap ? 'Hide minimap' : 'Show minimap'}
+              >
+                <Map size={12} />
+                Mini
+              </button>
+              <button
+                type="button"
+                className="flex items-center gap-1 rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-secondary hover:text-df-text-primary"
                 onClick={() => handleExportYarn(scopedDialogue)}
                 title="Export yarn"
               >
@@ -749,7 +808,7 @@ export function NarrativeWorkspace({
               </button>
             </div>
           </div>
-          <div className="flex-1 min-h-0">
+          <div className="flex-1 min-h-0 rounded-lg border border-df-node-border bg-df-editor-bg p-1">
             {dialogueViewMode === VIEW_MODE.GRAPH ? (
               <DialogueEditorV2
                 dialogue={scopedDialogue}
@@ -758,6 +817,7 @@ export function NarrativeWorkspace({
                 characters={characters}
                 viewMode={VIEW_MODE.GRAPH}
                 className="h-full"
+                showMiniMap={showDialogueMiniMap}
               />
             ) : (
               <YarnView dialogue={scopedDialogue} onExport={() => handleExportYarn(scopedDialogue)} />
@@ -765,8 +825,8 @@ export function NarrativeWorkspace({
           </div>
         </div>
 
-        <div className="flex w-[320px] min-w-[280px] flex-col gap-3">
-          <div className="flex items-center justify-between rounded-lg border border-df-node-border bg-df-editor-bg px-3 py-2">
+        <div className="flex w-[320px] min-w-[280px] flex-col gap-2">
+          <div className="flex items-center justify-between rounded-lg border border-df-node-border bg-df-editor-bg px-2 py-1.5">
             <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-df-text-tertiary">
               <BookOpen size={12} />
               Storylets
@@ -793,7 +853,7 @@ export function NarrativeWorkspace({
               </button>
             </div>
           </div>
-          <div className="flex-1 min-h-0 rounded-lg border border-df-node-border bg-df-editor-bg p-3">
+          <div className="flex-1 min-h-0 rounded-lg border border-df-node-border bg-df-editor-bg p-2">
             {storyletTab === 'storylets' ? (
               <div className="flex h-full flex-col gap-3">
                 <div className="flex items-center gap-2">
@@ -955,7 +1015,7 @@ export function NarrativeWorkspace({
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-6">
           <div className="relative flex h-full max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-xl border border-df-editor-border bg-df-editor-bg">
             <div className="flex items-center justify-between border-b border-df-node-border px-4 py-3">
-              <div className="text-sm font-semibold text-df-text-primary">Flag Manager</div>
+              <div className="text-sm font-semibold text-df-text-primary">Game State</div>
               <button
                 type="button"
                 className="rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
@@ -965,13 +1025,49 @@ export function NarrativeWorkspace({
                 <X size={16} />
               </button>
             </div>
-            <div className="flex-1 min-h-0">
-              <FlagManager
-                flagSchema={activeFlagSchema}
-                dialogue={dialogueTree}
-                onUpdate={setActiveFlagSchema}
-                onClose={() => setShowFlagManager(false)}
-              />
+            <div className="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-[1fr_280px]">
+              <div className="min-h-0">
+                <FlagManager
+                  flagSchema={activeFlagSchema}
+                  dialogue={dialogueTree}
+                  onUpdate={setActiveFlagSchema}
+                  onClose={() => setShowFlagManager(false)}
+                />
+              </div>
+              <div className="border-l border-df-node-border bg-df-base/60 p-4 space-y-4 text-xs text-df-text-secondary">
+                <div>
+                  <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-df-text-tertiary">
+                    <CircleDot size={12} />
+                    Player
+                  </div>
+                  <div className="mt-2 rounded-md border border-df-control-border bg-df-control-bg px-3 py-2 text-[11px] text-df-text-secondary">
+                    Player profile settings coming soon.
+                  </div>
+                </div>
+                <div>
+                  <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-df-text-tertiary">
+                    <BookOpen size={12} />
+                    Characters
+                  </div>
+                  <div className="mt-2 space-y-2 max-h-64 overflow-y-auto">
+                    {characters && Object.values(characters).length > 0 ? (
+                      Object.values(characters).map(character => (
+                        <div
+                          key={character.id}
+                          className="rounded-md border border-df-control-border bg-df-control-bg px-3 py-2 text-[11px]"
+                        >
+                          <div className="text-df-text-primary font-semibold">{character.name}</div>
+                          <div className="text-df-text-tertiary">{character.id}</div>
+                        </div>
+                      ))
+                    ) : (
+                      <div className="rounded-md border border-df-control-border bg-df-control-bg px-3 py-2 text-[11px] text-df-text-tertiary">
+                        No characters loaded.
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/NarrativeWorkspace.tsx
+++ b/src/components/NarrativeWorkspace.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
+import { BookOpen, CircleDot, LayoutPanelTop, Play, Settings, X } from 'lucide-react';
 import { DialogueEditorV2 } from './DialogueEditorV2';
 import { NarrativeEditor, type NarrativeSelection } from './NarrativeEditor';
 import { NarrativeGraphView } from './NarrativeGraphView';
@@ -7,9 +8,18 @@ import type { DialogueTree } from '../types';
 import type { GameFlagState } from '../types/game-state';
 import type { Character } from '../types/characters';
 import type { FlagSchema } from '../types/flags';
-import type { NarrativePage, StoryThread } from '../types/narrative';
+import {
+  NARRATIVE_ELEMENT,
+  STORYLET_SELECTION_MODE,
+  type NarrativePage,
+  type StoryThread,
+  type Storylet,
+  type StoryletPool,
+} from '../types/narrative';
 import { VIEW_MODE } from '../types/constants';
 import { createNarrativeThreadClient } from '../utils/narrative-client';
+import { createUniqueId, moveItem } from '../utils/narrative-editor-utils';
+import { StoryletPanel } from './narrative-editor';
 
 interface NarrativeWorkspaceProps {
   initialThread: StoryThread;
@@ -18,6 +28,7 @@ interface NarrativeWorkspaceProps {
   characters?: Record<string, Character>;
   gameStateFlags?: GameFlagState;
   className?: string;
+  toolbarActions?: React.ReactNode;
 }
 
 const getInitialSelection = (thread: StoryThread): NarrativeSelection => ({
@@ -58,10 +69,13 @@ export function NarrativeWorkspace({
   characters,
   gameStateFlags,
   className = '',
+  toolbarActions,
 }: NarrativeWorkspaceProps) {
   const [thread, setThread] = useState<StoryThread>(initialThread);
   const [dialogueTree, setDialogueTree] = useState<DialogueTree>(initialDialogue);
   const [selection, setSelection] = useState<NarrativeSelection>(() => getInitialSelection(initialThread));
+  const [showStructureEditor, setShowStructureEditor] = useState(false);
+  const [showPlayModal, setShowPlayModal] = useState(false);
 
   const selectedAct = useMemo(
     () => thread.acts.find(act => act.id === selection.actId) ?? thread.acts[0],
@@ -82,6 +96,24 @@ export function NarrativeWorkspace({
     () => buildScopedDialogue(dialogueTree, selectedPage),
     [dialogueTree, selectedPage]
   );
+
+  const storyletEntries = useMemo(() => {
+    const pools = selectedChapter?.storyletPools ?? [];
+    return pools.flatMap(pool =>
+      pool.storylets.map(storylet => ({ poolId: pool.id, storylet }))
+    );
+  }, [selectedChapter]);
+
+  const selectedStoryletEntry = useMemo(() => {
+    if (!selection.storyletKey) return storyletEntries[0];
+    return storyletEntries.find(
+      entry => `${entry.poolId}:${entry.storylet.id}` === selection.storyletKey
+    );
+  }, [selection.storyletKey, storyletEntries]);
+
+  const selectedPool = selectedStoryletEntry
+    ? (selectedChapter?.storyletPools ?? []).find(pool => pool.id === selectedStoryletEntry.poolId)
+    : undefined;
 
   const handleDialogueChange = useCallback((nextScopedDialogue: DialogueTree) => {
     if (!selectedPage || !selectedAct || !selectedChapter) {
@@ -127,67 +159,337 @@ export function NarrativeWorkspace({
     );
   }, [selectedAct, selectedChapter, selectedPage]);
 
+  const updateThread = useCallback((nextThread: StoryThread) => {
+    setThread({
+      ...nextThread,
+      type: nextThread.type ?? NARRATIVE_ELEMENT.THREAD,
+    });
+  }, []);
+
+  const updateChapter = useCallback((
+    actId: string,
+    chapterId: string,
+    updates: Partial<StoryThread['acts'][number]['chapters'][number]>
+  ) => {
+    updateThread(createNarrativeThreadClient(thread).updateChapter(actId, chapterId, updates));
+  }, [thread, updateThread]);
+
+  const updateStorylet = useCallback((
+    actId: string,
+    chapterId: string,
+    poolId: string,
+    storyletId: string,
+    updates: Partial<Storylet>
+  ) => {
+    updateThread(createNarrativeThreadClient(thread).updateStorylet(actId, chapterId, poolId, storyletId, updates));
+  }, [thread, updateThread]);
+
+  const updateStoryletPool = useCallback((
+    actId: string,
+    chapterId: string,
+    poolId: string,
+    updates: Partial<StoryletPool>
+  ) => {
+    updateThread(createNarrativeThreadClient(thread).updateStoryletPool(actId, chapterId, poolId, updates));
+  }, [thread, updateThread]);
+
+  const handleAddStoryletPool = () => {
+    if (!selectedAct || !selectedChapter) return;
+    const existingPools = selectedChapter.storyletPools ?? [];
+    const nextId = createUniqueId(
+      existingPools.map(pool => pool.id),
+      'pool'
+    );
+    const nextPool: StoryletPool = {
+      id: nextId,
+      title: 'Storylet Pool',
+      summary: '',
+      selectionMode: STORYLET_SELECTION_MODE.WEIGHTED,
+      storylets: [],
+    };
+
+    updateChapter(selectedAct.id, selectedChapter.id, {
+      storyletPools: [...existingPools, nextPool],
+    });
+  };
+
+  const handleAddStorylet = () => {
+    if (!selectedAct || !selectedChapter) return;
+    const pools = selectedChapter.storyletPools ?? [];
+    let targetPoolId = pools[0]?.id;
+
+    if (!targetPoolId) {
+      const nextPoolId = createUniqueId([], 'pool');
+      targetPoolId = nextPoolId;
+      updateChapter(selectedAct.id, selectedChapter.id, {
+        storyletPools: [
+          {
+            id: nextPoolId,
+            title: 'Storylet Pool',
+            summary: '',
+            selectionMode: STORYLET_SELECTION_MODE.WEIGHTED,
+            storylets: [],
+          },
+        ],
+      });
+    }
+
+    const currentStoryletIds = pools.flatMap(pool => pool.storylets.map(storylet => storylet.id));
+    const nextId = createUniqueId(currentStoryletIds, 'storylet');
+    const nextStorylet: Storylet = {
+      id: nextId,
+      title: 'New Storylet',
+      summary: '',
+      weight: 1,
+      type: NARRATIVE_ELEMENT.STORYLET,
+    };
+
+    const updatedPools = (selectedChapter.storyletPools ?? []).map(pool =>
+      pool.id === targetPoolId
+        ? { ...pool, storylets: [...pool.storylets, nextStorylet] }
+        : pool
+    );
+
+    updateChapter(selectedAct.id, selectedChapter.id, {
+      storyletPools: updatedPools,
+    });
+    setSelection(prev => ({
+      ...prev,
+      storyletKey: `${targetPoolId}:${nextStorylet.id}`,
+    }));
+  };
+
+  const handleDeleteStorylet = () => {
+    if (!selectedAct || !selectedChapter || !selectedStoryletEntry) return;
+    const { poolId, storylet } = selectedStoryletEntry;
+    updateChapter(selectedAct.id, selectedChapter.id, {
+      storyletPools: (selectedChapter.storyletPools ?? []).map(pool =>
+        pool.id === poolId
+          ? { ...pool, storylets: pool.storylets.filter(item => item.id !== storylet.id) }
+          : pool
+      ),
+    });
+  };
+
+  const handleMoveStorylet = (direction: 'up' | 'down') => {
+    if (!selectedAct || !selectedChapter || !selectedStoryletEntry) return;
+    const { poolId, storylet } = selectedStoryletEntry;
+    const pool = (selectedChapter.storyletPools ?? []).find(item => item.id === poolId);
+    if (!pool) return;
+    const index = pool.storylets.findIndex(item => item.id === storylet.id);
+    const nextIndex = direction === 'up' ? index - 1 : index + 1;
+    if (nextIndex < 0 || nextIndex >= pool.storylets.length) return;
+
+    updateChapter(selectedAct.id, selectedChapter.id, {
+      storyletPools: (selectedChapter.storyletPools ?? []).map(item =>
+        item.id === poolId
+          ? { ...item, storylets: moveItem(item.storylets, index, nextIndex) }
+          : item
+      ),
+    });
+  };
+
+  const handleStoryletUpdate = (updates: Partial<Storylet>) => {
+    if (!selectedAct || !selectedChapter || !selectedStoryletEntry) return;
+    const { poolId, storylet } = selectedStoryletEntry;
+    const nextId = updates.id ?? storylet.id;
+    updateStorylet(selectedAct.id, selectedChapter.id, poolId, storylet.id, updates);
+    if (updates.id && nextId !== storylet.id) {
+      setSelection(prev => ({
+        ...prev,
+        storyletKey: `${poolId}:${nextId}`,
+      }));
+    }
+  };
+
+  const handleStoryletPoolUpdate = (updates: Partial<StoryletPool>) => {
+    if (!selectedAct || !selectedChapter || !selectedPool) return;
+    updateStoryletPool(selectedAct.id, selectedChapter.id, selectedPool.id, updates);
+  };
+
+  const handleStoryletPoolChange = (nextPoolId: string) => {
+    if (!selectedAct || !selectedChapter || !selectedStoryletEntry) return;
+
+    const { poolId, storylet } = selectedStoryletEntry;
+    if (poolId === nextPoolId) return;
+
+    const updatedPools = (selectedChapter.storyletPools ?? []).map(pool => {
+      if (pool.id === poolId) {
+        return {
+          ...pool,
+          storylets: pool.storylets.filter(item => item.id !== storylet.id),
+        };
+      }
+      if (pool.id === nextPoolId) {
+        return {
+          ...pool,
+          storylets: [...pool.storylets, storylet],
+        };
+      }
+      return pool;
+    });
+
+    updateChapter(selectedAct.id, selectedChapter.id, {
+      storyletPools: updatedPools,
+    });
+    setSelection(prev => ({
+      ...prev,
+      storyletKey: `${nextPoolId}:${storylet.id}`,
+    }));
+  };
+
   const playTitle = selectedPage?.title ?? 'Play Page';
   const playSubtitle = selectedPage?.summary ?? 'Preview the dialogue for this page.';
 
   return (
-    <div className={`flex h-full w-full gap-4 p-4 ${className}`}>
-      <div className="flex w-[320px] min-w-[280px] flex-col gap-4">
-        <div className="flex items-center justify-between rounded-xl border border-df-sidebar-border bg-df-sidebar-bg px-4 py-2">
-          <div>
-            <div className="text-xs uppercase tracking-wide text-df-text-tertiary">Narrative</div>
-            <div className="text-sm font-semibold text-df-text-primary">Acts • Chapters • Pages</div>
+    <div className={`flex h-full w-full flex-col ${className}`}>
+      <div className="flex items-center justify-between border-b border-df-sidebar-border bg-df-base/80 px-4 py-2">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            className="flex items-center justify-center rounded-md border border-df-control-border bg-df-control-bg p-2 text-df-text-secondary hover:text-df-text-primary"
+            onClick={() => setShowStructureEditor(true)}
+            title="Open narrative structure"
+          >
+            <Settings size={16} />
+          </button>
+          <button
+            type="button"
+            className="flex items-center justify-center rounded-md border border-df-control-border bg-df-control-bg p-2 text-df-text-secondary hover:text-df-text-primary"
+            onClick={() => setShowPlayModal(true)}
+            title="Play selected page"
+          >
+            <Play size={16} />
+          </button>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-df-text-tertiary">
+          <span className="inline-flex items-center gap-1">
+            <CircleDot size={12} />
+            {selectedAct?.title ?? 'Act'}
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <BookOpen size={12} />
+            {selectedChapter?.title ?? 'Chapter'}
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <LayoutPanelTop size={12} />
+            {selectedPage?.title ?? 'Page'}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">{toolbarActions}</div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 gap-4 p-4">
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-df-text-tertiary">
+            <CircleDot size={12} />
+            Narrative Graph
+          </div>
+          <div className="h-[220px] min-h-[200px]">
+            <NarrativeGraphView thread={thread} className="h-full" />
+          </div>
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-df-text-tertiary">
+            <LayoutPanelTop size={12} />
+            Dialogue Graph
+          </div>
+          <div className="flex-1 min-h-0">
+            <DialogueEditorV2
+              dialogue={scopedDialogue}
+              onChange={handleDialogueChange}
+              flagSchema={flagSchema}
+              characters={characters}
+              viewMode={VIEW_MODE.GRAPH}
+              className="h-full"
+            />
           </div>
         </div>
-        <div className="flex-1 min-h-0">
-          <NarrativeEditor
-            thread={thread}
-            onChange={setThread}
-            selection={selection}
-            onSelectionChange={setSelection}
-            className="h-full"
-          />
+
+        <div className="flex w-[320px] min-w-[280px] flex-col gap-3">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-df-text-tertiary">
+            <BookOpen size={12} />
+            Storylets
+          </div>
+          <div className="flex-1 min-h-0">
+            <StoryletPanel
+              entries={storyletEntries}
+              pools={selectedChapter?.storyletPools ?? []}
+              selectedKey={selection.storyletKey}
+              selectedPool={selectedPool}
+              onSelect={storyletKey =>
+                setSelection(prev => ({
+                  ...prev,
+                  storyletKey,
+                }))
+              }
+              onAddPool={handleAddStoryletPool}
+              onAddStorylet={handleAddStorylet}
+              onMove={handleMoveStorylet}
+              onDelete={handleDeleteStorylet}
+              onUpdateStorylet={handleStoryletUpdate}
+              onUpdatePool={handleStoryletPoolUpdate}
+              onChangePool={handleStoryletPoolChange}
+            />
+          </div>
         </div>
       </div>
 
-      <div className="flex min-w-0 flex-1 flex-col gap-4">
-        <div className="flex items-center justify-between rounded-xl border border-df-editor-border bg-df-editor-bg px-4 py-2">
-          <div>
-            <div className="text-xs uppercase tracking-wide text-df-text-tertiary">Dialogue</div>
-            <div className="text-sm font-semibold text-df-text-primary">Page Editing & Narrative Context</div>
+      {showStructureEditor && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-6">
+          <div className="relative flex h-full max-h-[90vh] w-full max-w-6xl flex-col overflow-hidden rounded-xl border border-df-editor-border bg-df-editor-bg">
+            <div className="flex items-center justify-between border-b border-df-node-border px-4 py-3">
+              <div className="text-sm font-semibold text-df-text-primary">Narrative Structure</div>
+              <button
+                type="button"
+                className="rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
+                onClick={() => setShowStructureEditor(false)}
+                title="Close narrative structure"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="flex-1 min-h-0 overflow-hidden p-4">
+              <NarrativeEditor
+                thread={thread}
+                onChange={setThread}
+                selection={selection}
+                onSelectionChange={setSelection}
+                className="h-full"
+              />
+            </div>
           </div>
         </div>
-        <div className="h-[240px] min-h-[200px]">
-          <NarrativeGraphView thread={thread} className="h-full" />
-        </div>
-        <div className="flex-1 min-h-0">
-          <DialogueEditorV2
-            dialogue={scopedDialogue}
-            onChange={handleDialogueChange}
-            flagSchema={flagSchema}
-            characters={characters}
-            viewMode={VIEW_MODE.GRAPH}
-            className="h-full"
-          />
-        </div>
-      </div>
+      )}
 
-      <div className="flex w-[360px] min-w-[300px] flex-col gap-4">
-        <div className="rounded-xl border border-df-editor-border bg-df-editor-bg px-4 py-2">
-          <div className="text-xs uppercase tracking-wide text-df-text-tertiary">Play</div>
-          <div className="text-sm font-semibold text-df-text-primary">{playTitle}</div>
-          <div className="text-xs text-df-text-secondary">{playSubtitle}</div>
+      {showPlayModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-6">
+          <div className="relative flex h-full max-h-[90vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl border border-df-editor-border bg-df-editor-bg">
+            <div className="flex items-center justify-between border-b border-df-node-border px-4 py-3">
+              <div>
+                <div className="text-xs uppercase tracking-wide text-df-text-tertiary">Play</div>
+                <div className="text-sm font-semibold text-df-text-primary">{playTitle}</div>
+                <div className="text-xs text-df-text-secondary">{playSubtitle}</div>
+              </div>
+              <button
+                type="button"
+                className="rounded-md border border-df-control-border bg-df-control-bg p-1 text-df-text-secondary hover:text-df-text-primary"
+                onClick={() => setShowPlayModal(false)}
+                title="Close play view"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="flex-1 min-h-0">
+              <PlayView
+                dialogue={scopedDialogue}
+                startNodeId={scopedDialogue.startNodeId}
+                flagSchema={flagSchema}
+                gameStateFlags={gameStateFlags}
+                narrativeThread={thread}
+              />
+            </div>
+          </div>
         </div>
-        <div className="flex-1 min-h-0 rounded-xl border border-df-editor-border bg-df-editor-bg">
-          <PlayView
-            dialogue={scopedDialogue}
-            startNodeId={scopedDialogue.startNodeId}
-            flagSchema={flagSchema}
-            gameStateFlags={gameStateFlags}
-            narrativeThread={thread}
-          />
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/NarrativeWorkspace.tsx
+++ b/src/components/NarrativeWorkspace.tsx
@@ -1,0 +1,193 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { DialogueEditorV2 } from './DialogueEditorV2';
+import { NarrativeEditor, type NarrativeSelection } from './NarrativeEditor';
+import { NarrativeGraphView } from './NarrativeGraphView';
+import { PlayView } from './PlayView';
+import type { DialogueTree } from '../types';
+import type { GameFlagState } from '../types/game-state';
+import type { Character } from '../types/characters';
+import type { FlagSchema } from '../types/flags';
+import type { NarrativePage, StoryThread } from '../types/narrative';
+import { VIEW_MODE } from '../types/constants';
+import { createNarrativeThreadClient } from '../utils/narrative-client';
+
+interface NarrativeWorkspaceProps {
+  initialThread: StoryThread;
+  initialDialogue: DialogueTree;
+  flagSchema?: FlagSchema;
+  characters?: Record<string, Character>;
+  gameStateFlags?: GameFlagState;
+  className?: string;
+}
+
+const getInitialSelection = (thread: StoryThread): NarrativeSelection => ({
+  actId: thread.acts[0]?.id,
+  chapterId: thread.acts[0]?.chapters[0]?.id,
+  pageId: thread.acts[0]?.chapters[0]?.pages[0]?.id,
+  storyletKey: undefined,
+});
+
+const buildScopedDialogue = (dialogue: DialogueTree, page?: NarrativePage): DialogueTree => {
+  if (!page) return dialogue;
+  const scopedNodes = page.nodeIds.reduce<Record<string, DialogueTree['nodes'][string]>>(
+    (acc, nodeId) => {
+      const node = dialogue.nodes[nodeId];
+      if (node) {
+        acc[nodeId] = node;
+      }
+      return acc;
+    },
+    {}
+  );
+  const fallbackStartNodeId = page.nodeIds.find(nodeId => scopedNodes[nodeId]) ?? '';
+  const startNodeId = scopedNodes[dialogue.startNodeId]
+    ? dialogue.startNodeId
+    : fallbackStartNodeId;
+
+  return {
+    ...dialogue,
+    nodes: scopedNodes,
+    startNodeId,
+  };
+};
+
+export function NarrativeWorkspace({
+  initialThread,
+  initialDialogue,
+  flagSchema,
+  characters,
+  gameStateFlags,
+  className = '',
+}: NarrativeWorkspaceProps) {
+  const [thread, setThread] = useState<StoryThread>(initialThread);
+  const [dialogueTree, setDialogueTree] = useState<DialogueTree>(initialDialogue);
+  const [selection, setSelection] = useState<NarrativeSelection>(() => getInitialSelection(initialThread));
+
+  const selectedAct = useMemo(
+    () => thread.acts.find(act => act.id === selection.actId) ?? thread.acts[0],
+    [thread.acts, selection.actId]
+  );
+  const selectedChapter = useMemo(
+    () => selectedAct?.chapters.find(chapter => chapter.id === selection.chapterId)
+      ?? selectedAct?.chapters[0],
+    [selectedAct, selection.chapterId]
+  );
+  const selectedPage = useMemo(
+    () => selectedChapter?.pages.find(page => page.id === selection.pageId)
+      ?? selectedChapter?.pages[0],
+    [selectedChapter, selection.pageId]
+  );
+
+  const scopedDialogue = useMemo(
+    () => buildScopedDialogue(dialogueTree, selectedPage),
+    [dialogueTree, selectedPage]
+  );
+
+  const handleDialogueChange = useCallback((nextScopedDialogue: DialogueTree) => {
+    if (!selectedPage || !selectedAct || !selectedChapter) {
+      setDialogueTree(nextScopedDialogue);
+      return;
+    }
+
+    setDialogueTree(prevDialogue => {
+      const updatedNodes = { ...prevDialogue.nodes };
+      selectedPage.nodeIds.forEach(nodeId => {
+        if (!nextScopedDialogue.nodes[nodeId]) {
+          delete updatedNodes[nodeId];
+        }
+      });
+      Object.entries(nextScopedDialogue.nodes).forEach(([nodeId, node]) => {
+        updatedNodes[nodeId] = node;
+      });
+
+      const fallbackStartNodeId = Object.keys(updatedNodes)[0] ?? '';
+      const nextStartNodeId = updatedNodes[prevDialogue.startNodeId]
+        ? prevDialogue.startNodeId
+        : nextScopedDialogue.startNodeId || fallbackStartNodeId;
+
+      return {
+        ...prevDialogue,
+        nodes: updatedNodes,
+        startNodeId: nextStartNodeId,
+      };
+    });
+
+    const scopedNodeIds = Object.keys(nextScopedDialogue.nodes);
+    const retainedNodeIds = selectedPage.nodeIds.filter(nodeId => nextScopedDialogue.nodes[nodeId]);
+    const addedNodeIds = scopedNodeIds.filter(nodeId => !selectedPage.nodeIds.includes(nodeId));
+    const nextNodeIds = [...retainedNodeIds, ...addedNodeIds];
+
+    setThread(prevThread =>
+      createNarrativeThreadClient(prevThread).updatePage(
+        selectedAct.id,
+        selectedChapter.id,
+        selectedPage.id,
+        { nodeIds: nextNodeIds }
+      )
+    );
+  }, [selectedAct, selectedChapter, selectedPage]);
+
+  const playTitle = selectedPage?.title ?? 'Play Page';
+  const playSubtitle = selectedPage?.summary ?? 'Preview the dialogue for this page.';
+
+  return (
+    <div className={`flex h-full w-full gap-4 p-4 ${className}`}>
+      <div className="flex w-[320px] min-w-[280px] flex-col gap-4">
+        <div className="flex items-center justify-between rounded-xl border border-df-sidebar-border bg-df-sidebar-bg px-4 py-2">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-df-text-tertiary">Narrative</div>
+            <div className="text-sm font-semibold text-df-text-primary">Acts • Chapters • Pages</div>
+          </div>
+        </div>
+        <div className="flex-1 min-h-0">
+          <NarrativeEditor
+            thread={thread}
+            onChange={setThread}
+            selection={selection}
+            onSelectionChange={setSelection}
+            className="h-full"
+          />
+        </div>
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-4">
+        <div className="flex items-center justify-between rounded-xl border border-df-editor-border bg-df-editor-bg px-4 py-2">
+          <div>
+            <div className="text-xs uppercase tracking-wide text-df-text-tertiary">Dialogue</div>
+            <div className="text-sm font-semibold text-df-text-primary">Page Editing & Narrative Context</div>
+          </div>
+        </div>
+        <div className="h-[240px] min-h-[200px]">
+          <NarrativeGraphView thread={thread} className="h-full" />
+        </div>
+        <div className="flex-1 min-h-0">
+          <DialogueEditorV2
+            dialogue={scopedDialogue}
+            onChange={handleDialogueChange}
+            flagSchema={flagSchema}
+            characters={characters}
+            viewMode={VIEW_MODE.GRAPH}
+            className="h-full"
+          />
+        </div>
+      </div>
+
+      <div className="flex w-[360px] min-w-[300px] flex-col gap-4">
+        <div className="rounded-xl border border-df-editor-border bg-df-editor-bg px-4 py-2">
+          <div className="text-xs uppercase tracking-wide text-df-text-tertiary">Play</div>
+          <div className="text-sm font-semibold text-df-text-primary">{playTitle}</div>
+          <div className="text-xs text-df-text-secondary">{playSubtitle}</div>
+        </div>
+        <div className="flex-1 min-h-0 rounded-xl border border-df-editor-border bg-df-editor-bg">
+          <PlayView
+            dialogue={scopedDialogue}
+            startNodeId={scopedDialogue.startNodeId}
+            flagSchema={flagSchema}
+            gameStateFlags={gameStateFlags}
+            narrativeThread={thread}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { DialogueEditorV2 } from './components/DialogueEditorV2';
 export { NarrativeEditor } from './components/NarrativeEditor';
 export { NarrativeGraphView } from './components/NarrativeGraphView';
+export { NarrativeWorkspace } from './components/NarrativeWorkspace';
 // Legacy scene player (use GamePlayer for new experiences)
 export { ScenePlayer } from './components/ScenePlayer';
 export type { ScenePlayerProps } from './components/ScenePlayer';


### PR DESCRIPTION
### Motivation

- Provide a single workspace that combines narrative structure, dialogue editing, and an in-editor play preview so authors can author per-page dialogue in context.
- Scope `DialogueTree` edits to the selected narrative page so page selection controls which nodes are shown/edited.
- Lift narrative + dialogue state into a parent workspace so the selected page can control dialogue scope and the play preview.
- Replace ad-hoc string operators / view values in the demo with exported constants for consistency and type-safety (`CONDITION_OPERATOR`, `FLAG_TYPE`, `VIEW_MODE`).

### Description

- Added a new workspace component `src/components/NarrativeWorkspace.tsx` that composes `NarrativeEditor`, `NarrativeGraphView`, `DialogueEditorV2` (scoped to the selected page), and `PlayView`, and implements a three-column Narrative / Dialogue / Play layout using existing theme tokens.
- Refactored `src/components/NarrativeEditor.tsx` to accept a controlled `selection` (`NarrativeSelection`) and `onSelectionChange`, and to keep an internal fallback selection when uncontrolled so the workspace can drive selection state.
- Scoped dialogue edits: `NarrativeWorkspace` builds a scoped `DialogueTree` for the currently selected page and reconciles edits back into the full dialogue and narrative thread (`createNarrativeThreadClient` used to update page `nodeIds`).
- Updated the demo entry (`app/page.tsx`) to render the new `NarrativeWorkspace` with a demo `StoryThread` and demo dialogue, switched condition operators / flag types to use constants, and exported `NarrativeWorkspace` from `src/index.ts`.

### Testing

- Ran `npm run build` (Next.js production build) and the build completed successfully including TypeScript checks.
- The build output shows static page generation/prerendering completed without TypeScript or compilation errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e73100d50832d942eb949aaa13076)