### PR TITLE
Introduce storylet templates and pool members; refactor narrative editor to use template-based membership

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -261,26 +261,36 @@ const demoNarrativeThread: StoryThread = {
               type: NARRATIVE_ELEMENT.PAGE,
             },
           ],
+          storyletTemplates: [
+            {
+              id: 'storylet-whisper',
+              title: 'Whispered Warning',
+              summary: 'A spectral whisper hints at a hidden path.',
+              dialogueId: 'mysterious-stranger',
+              type: NARRATIVE_ELEMENT.STORYLET,
+            },
+            {
+              id: 'storylet-shadow',
+              title: 'Shadowy Observer',
+              summary: 'A lurking shadow tests the traveler’s resolve.',
+              dialogueId: 'mysterious-stranger',
+              type: NARRATIVE_ELEMENT.STORYLET,
+            },
+          ],
           storyletPools: [
             {
               id: 'storylet-pool-crossroads',
               title: 'Crossroads Encounters',
               summary: 'Optional beats triggered at the crossroads.',
               selectionMode: STORYLET_SELECTION_MODE.WEIGHTED,
-              storylets: [
+              members: [
                 {
-                  id: 'storylet-whisper',
-                  title: 'Whispered Warning',
-                  summary: 'A spectral whisper hints at a hidden path.',
+                  templateId: 'storylet-whisper',
                   weight: 3,
-                  type: NARRATIVE_ELEMENT.STORYLET,
                 },
                 {
-                  id: 'storylet-shadow',
-                  title: 'Shadowy Observer',
-                  summary: 'A lurking shadow tests the traveler’s resolve.',
+                  templateId: 'storylet-shadow',
                   weight: 1,
-                  type: NARRATIVE_ELEMENT.STORYLET,
                 },
               ],
             },

--- a/src/components/narrative-editor/StoryletPanel.tsx
+++ b/src/components/narrative-editor/StoryletPanel.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { Trash2 } from 'lucide-react';
 import {
   STORYLET_SELECTION_MODE,
-  type Storylet,
+  type StoryletPoolMember,
   type StoryletPool,
+  type StoryletTemplate,
 } from '../../types/narrative';
 import { DetailField, ListItem, ListPanel } from './ListPanel';
 
 interface StoryletEntry {
   poolId: string;
-  storylet: Storylet;
+  member: StoryletPoolMember;
+  template: StoryletTemplate;
 }
 
 interface StoryletPanelProps {
@@ -22,7 +24,8 @@ interface StoryletPanelProps {
   onAddStorylet: () => void;
   onMove: (direction: 'up' | 'down') => void;
   onDelete: () => void;
-  onUpdateStorylet: (updates: Partial<Storylet>) => void;
+  onUpdateTemplate: (updates: Partial<StoryletTemplate>) => void;
+  onUpdateMember: (updates: Partial<StoryletPoolMember>) => void;
   onUpdatePool: (updates: Partial<StoryletPool>) => void;
   onChangePool: (poolId: string) => void;
 }
@@ -37,11 +40,12 @@ export function StoryletPanel({
   onAddStorylet,
   onMove,
   onDelete,
-  onUpdateStorylet,
+  onUpdateTemplate,
+  onUpdateMember,
   onUpdatePool,
   onChangePool,
 }: StoryletPanelProps) {
-  const selectedEntry = entries.find(entry => `${entry.poolId}:${entry.storylet.id}` === selectedKey)
+  const selectedEntry = entries.find(entry => `${entry.poolId}:${entry.template.id}` === selectedKey)
     ?? entries[0];
 
   return (
@@ -63,12 +67,12 @@ export function StoryletPanel({
       <div className="flex-1 overflow-y-auto p-2 space-y-2">
         {entries.map((entry, index) => (
           <ListItem
-            key={`${entry.poolId}-${entry.storylet.id}`}
-            title={entry.storylet.title || `Storylet ${index + 1}`}
-            subtitle={entry.storylet.id}
+            key={`${entry.poolId}-${entry.template.id}`}
+            title={entry.template.title || `Storylet ${index + 1}`}
+            subtitle={entry.template.id}
             badge={entry.poolId}
-            selected={`${entry.poolId}:${entry.storylet.id}` === selectedKey}
-            onSelect={() => onSelect(`${entry.poolId}:${entry.storylet.id}`)}
+            selected={`${entry.poolId}:${entry.template.id}` === selectedKey}
+            onSelect={() => onSelect(`${entry.poolId}:${entry.template.id}`)}
             onMoveUp={() => onMove('up')}
             onMoveDown={() => onMove('down')}
           />
@@ -86,37 +90,37 @@ export function StoryletPanel({
             </div>
             <DetailField label="ID">
               <input
-                value={selectedEntry.storylet.id}
-                onChange={event => onUpdateStorylet({ id: event.target.value })}
+                value={selectedEntry.template.id}
+                onChange={event => onUpdateTemplate({ id: event.target.value })}
                 className="w-full bg-[#12121a] border border-[#2a2a3e] rounded px-2 py-1 text-xs text-gray-200"
               />
             </DetailField>
             <DetailField label="Title">
               <input
-                value={selectedEntry.storylet.title ?? ''}
-                onChange={event => onUpdateStorylet({ title: event.target.value })}
+                value={selectedEntry.template.title ?? ''}
+                onChange={event => onUpdateTemplate({ title: event.target.value })}
                 className="w-full bg-[#12121a] border border-[#2a2a3e] rounded px-2 py-1 text-xs text-gray-200"
               />
             </DetailField>
             <DetailField label="Summary">
               <textarea
-                value={selectedEntry.storylet.summary ?? ''}
-                onChange={event => onUpdateStorylet({ summary: event.target.value })}
+                value={selectedEntry.template.summary ?? ''}
+                onChange={event => onUpdateTemplate({ summary: event.target.value })}
                 className="w-full bg-[#12121a] border border-[#2a2a3e] rounded px-2 py-1 text-xs text-gray-200 min-h-[60px]"
+              />
+            </DetailField>
+            <DetailField label="Dialogue ID">
+              <input
+                value={selectedEntry.template.dialogueId}
+                onChange={event => onUpdateTemplate({ dialogueId: event.target.value })}
+                className="w-full bg-[#12121a] border border-[#2a2a3e] rounded px-2 py-1 text-xs text-gray-200"
               />
             </DetailField>
             <DetailField label="Weight">
               <input
                 type="number"
-                value={selectedEntry.storylet.weight ?? 1}
-                onChange={event => onUpdateStorylet({ weight: Number(event.target.value) })}
-                className="w-full bg-[#12121a] border border-[#2a2a3e] rounded px-2 py-1 text-xs text-gray-200"
-              />
-            </DetailField>
-            <DetailField label="Next Node ID">
-              <input
-                value={selectedEntry.storylet.nextNodeId ?? ''}
-                onChange={event => onUpdateStorylet({ nextNodeId: event.target.value })}
+                value={selectedEntry.member.weight ?? 1}
+                onChange={event => onUpdateMember({ weight: Number(event.target.value) })}
                 className="w-full bg-[#12121a] border border-[#2a2a3e] rounded px-2 py-1 text-xs text-gray-200"
               />
             </DetailField>
@@ -154,14 +158,13 @@ export function StoryletPanel({
                       className="w-full bg-[#12121a] border border-[#2a2a3e] rounded px-2 py-1 text-xs text-gray-200"
                     >
                       <option value={STORYLET_SELECTION_MODE.WEIGHTED}>Weighted</option>
-                      <option value={STORYLET_SELECTION_MODE.SEQUENTIAL}>Sequential</option>
-                      <option value={STORYLET_SELECTION_MODE.RANDOM}>Random</option>
+                      <option value={STORYLET_SELECTION_MODE.UNIFORM}>Uniform</option>
                     </select>
                   </DetailField>
-                  <DetailField label="Fallback Node ID">
+                  <DetailField label="Fallback Template ID">
                     <input
-                      value={selectedPool.fallbackNodeId ?? ''}
-                      onChange={event => onUpdatePool({ fallbackNodeId: event.target.value })}
+                      value={selectedPool.fallbackTemplateId ?? ''}
+                      onChange={event => onUpdatePool({ fallbackTemplateId: event.target.value })}
                       className="w-full bg-[#12121a] border border-[#2a2a3e] rounded px-2 py-1 text-xs text-gray-200"
                     />
                   </DetailField>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,8 @@ export type {
   NarrativeThread,
   RandomizerBranch,
   StoryThread,
-  Storylet,
+  StoryletPoolMember,
+  StoryletTemplate,
   StoryletPool,
   StoryletSelectionMode,
 } from './narrative';

--- a/src/types/narrative.ts
+++ b/src/types/narrative.ts
@@ -11,9 +11,8 @@ export const NARRATIVE_ELEMENT = {
 export type NarrativeElement = typeof NARRATIVE_ELEMENT[keyof typeof NARRATIVE_ELEMENT];
 
 export const STORYLET_SELECTION_MODE = {
-  WEIGHTED: 'weighted',
-  SEQUENTIAL: 'sequential',
-  RANDOM: 'random',
+  WEIGHTED: 'WEIGHTED',
+  UNIFORM: 'UNIFORM',
 } as const;
 
 export type StoryletSelectionMode =
@@ -32,6 +31,7 @@ export interface NarrativeChapter {
   title?: string;
   summary?: string;
   pages: NarrativePage[];
+  storyletTemplates?: StoryletTemplate[];
   storyletPools?: StoryletPool[];
   type?: typeof NARRATIVE_ELEMENT.CHAPTER;
 }
@@ -54,14 +54,18 @@ export interface StoryThread {
 
 export type NarrativeThread = StoryThread;
 
-export interface Storylet {
+export interface StoryletTemplate {
   id: string;
   title?: string;
   summary?: string;
+  dialogueId: string;
   conditions?: Condition[];
-  weight?: number;
-  nextNodeId?: string;
   type?: typeof NARRATIVE_ELEMENT.STORYLET;
+}
+
+export interface StoryletPoolMember {
+  templateId: string;
+  weight?: number;
 }
 
 export interface StoryletPool {
@@ -69,8 +73,8 @@ export interface StoryletPool {
   title?: string;
   summary?: string;
   selectionMode?: StoryletSelectionMode;
-  storylets: Storylet[];
-  fallbackNodeId?: string;
+  members: StoryletPoolMember[];
+  fallbackTemplateId?: string;
 }
 
 export interface RandomizerBranch {

--- a/src/utils/narrative-converter.ts
+++ b/src/utils/narrative-converter.ts
@@ -6,8 +6,9 @@ import {
   type NarrativeElement,
   type NarrativePage,
   type StoryThread,
-  type Storylet,
   type StoryletPool,
+  type StoryletPoolMember,
+  type StoryletTemplate,
 } from '../types/narrative';
 
 export interface NarrativeFlowNodeData {
@@ -30,15 +31,21 @@ const PAGE_SPACING = 140;
 const CHAPTER_GAP = 80;
 const ACT_GAP = 140;
 
-function normalizeStorylet(storylet: Storylet): Storylet {
+function normalizeStoryletTemplate(storylet: StoryletTemplate): StoryletTemplate {
   return {
     id: storylet.id,
     title: storylet.title,
     summary: storylet.summary,
+    dialogueId: storylet.dialogueId,
     conditions: storylet.conditions ? [...storylet.conditions] : undefined,
-    weight: storylet.weight,
-    nextNodeId: storylet.nextNodeId,
     type: NARRATIVE_ELEMENT.STORYLET,
+  };
+}
+
+function normalizeStoryletMember(member: StoryletPoolMember): StoryletPoolMember {
+  return {
+    templateId: member.templateId,
+    weight: member.weight,
   };
 }
 
@@ -48,8 +55,8 @@ function normalizeStoryletPool(pool: StoryletPool): StoryletPool {
     title: pool.title,
     summary: pool.summary,
     selectionMode: pool.selectionMode,
-    storylets: pool.storylets.map(normalizeStorylet),
-    fallbackNodeId: pool.fallbackNodeId,
+    members: pool.members.map(normalizeStoryletMember),
+    fallbackTemplateId: pool.fallbackTemplateId,
   };
 }
 
@@ -79,6 +86,9 @@ function stripChapter(chapter: NarrativeChapter): NarrativeChapter {
     title: chapter.title,
     summary: chapter.summary,
     pages: [],
+    storyletTemplates: chapter.storyletTemplates
+      ? chapter.storyletTemplates.map(normalizeStoryletTemplate)
+      : undefined,
     storyletPools: chapter.storyletPools
       ? chapter.storyletPools.map(normalizeStoryletPool)
       : undefined,
@@ -224,6 +234,9 @@ function coerceChapter(node: Node<NarrativeFlowNodeData>): NarrativeChapter {
     title: element?.title,
     summary: element?.summary,
     pages: [],
+    storyletTemplates: element?.storyletTemplates
+      ? element.storyletTemplates.map(normalizeStoryletTemplate)
+      : undefined,
     storyletPools: element?.storyletPools
       ? element.storyletPools.map(normalizeStoryletPool)
       : undefined,


### PR DESCRIPTION
### Motivation

- Replace inline storylet entries in pools with reusable templates and pool membership records to match the narrative spec and simplify reuse across pools. 
- Expose `dialogueId` on templates so pools can reference dialogues by template rather than inline node links. 
- Update UI and helpers to operate on `templateId` membership instead of editing inline storylet objects with `nextNodeId`. 
- Provide a compact selection mode set (`WEIGHTED | UNIFORM`) for pools.

### Description

- Added new types: `StoryletTemplate` and `StoryletPoolMember` and updated `STORYLET_SELECTION_MODE` to use `WEIGHTED` / `UNIFORM` in `src/types/narrative.ts` and re-exported from `src/types/index.ts`.
- Reworked domain helpers and converters to support templates and members by updating `src/utils/narrative-helpers.ts`, `src/utils/narrative-converter.ts`, and `src/utils/narrative-client.ts` to normalize, read, and update `storyletTemplates` and pool `members` (and `fallbackTemplateId`).
- Updated narrative UI to edit templates and pool membership: `StoryletPanel.tsx`, `NarrativeEditor.tsx`, and `NarrativeWorkspace.tsx` now show/edit `template.dialogueId`, template metadata, and per-pool `member.weight` and use `poolId:templateId` keys for selection and movement.
- Updated demo data in `app/page.tsx` to publish separate `storyletTemplates` and pool `members` (using `templateId`) instead of inline storylets.

### Testing

- Ran `npm run build` which compiled TypeScript and produced a successful Next.js production build (build completed and pages generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f2309f1f4832d9ec68f30f3d330e2)