### PR TITLE
Add writer page and payload adapter

### DIFF
--- a/app/lib/writer/data-adapter/payload-writer-adapter.ts
+++ b/app/lib/writer/data-adapter/payload-writer-adapter.ts
@@ -1,0 +1,8 @@
+import type { ForgeDataAdapter } from '@/src/components/forge/forge-data-adapter/forge-data-adapter';
+import { makePayloadForgeAdapter } from '@/app/lib/forge/data-adapter/payload-forge-adapter';
+
+export function makePayloadWriterAdapter(opts?: {
+  baseUrl?: string;
+}): ForgeDataAdapter {
+  return makePayloadForgeAdapter(opts);
+}

--- a/app/writer/page.tsx
+++ b/app/writer/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { ProjectSwitcher } from '@/components/ProjectSwitcher';
+import { ForgeWorkspace as WriterWorkspace } from '@/src/components/ForgeWorkspace/ForgeWorkspace';
+import { useState } from 'react';
+import { makePayloadWriterAdapter } from '../lib/writer/data-adapter/payload-writer-adapter';
+
+// Tell Next.js this page is static (no dynamic params/searchParams)
+export const dynamic = 'force-static';
+
+export default function WriterApp() {
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+
+  return (
+    <div className="w-full h-screen flex flex-col">
+      <ProjectSwitcher
+        selectedProjectId={selectedProjectId}
+        onProjectChange={setSelectedProjectId}
+      />
+
+      <div className="flex-1 w-full min-h-0">
+        <WriterWorkspace
+          className="h-full"
+          dataAdapter={makePayloadWriterAdapter()}
+          selectedProjectId={selectedProjectId}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a Writer entry page that mirrors the Forge layout and composes the writer workspace with project selection and a Payload-backed adapter.
- Reuse the existing Payload adapter logic by exposing a writer-specific factory to keep app composition consistent and avoid duplicating adapter code.

### Description
- Add `app/writer/page.tsx` as a client page that renders `ProjectSwitcher` and a `WriterWorkspace` (aliasing `ForgeWorkspace`) while maintaining layout classes `w-full h-screen flex flex-col` and `flex-1 w-full min-h-0`.
- Wire local state `selectedProjectId` and pass it into the workspace via the `selectedProjectId` prop and `ProjectSwitcher` callbacks.
- Add `app/lib/writer/data-adapter/payload-writer-adapter.ts` implementing `makePayloadWriterAdapter()` which currently delegates to `makePayloadForgeAdapter()` to provide a `ForgeDataAdapter` implementation.
- Keep page logic composition-only and avoid introducing domain changes in the workspace implementation.

### Testing
- Ran `npm run build` to verify the app builds, but it failed due to a missing package error: `Cannot find package '@payloadcms/next'` reported by `next.config.mjs` (build did not complete).
- No unit tests were added or executed for these new files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69670b80c394832db5290af094474010)