### PR TITLE
Add writer data adapter interface and PayloadCMS implementation

### DIFF
--- a/app/lib/writer/data-adapter/payload-writer-adapter.ts
+++ b/app/lib/writer/data-adapter/payload-writer-adapter.ts
@@ -1,8 +1,170 @@
-import type { ForgeDataAdapter } from '@/src/components/forge/forge-data-adapter/forge-data-adapter';
-import { makePayloadForgeAdapter } from '@/app/lib/forge/data-adapter/payload-forge-adapter';
+import { PayloadSDK } from '@payloadcms/sdk';
+import type { WriterDataAdapter, WriterActDoc, WriterChapterDoc, WriterPageDoc } from '@/src/lib/writer/data-adapter/writer-adapter';
+import type { Act, Chapter, Page } from '@/app/payload-types';
+import { PAYLOAD_COLLECTIONS } from '@/app/payload-collections/enums';
+
+function mapAct(doc: Act): WriterActDoc {
+  return {
+    id: doc.id,
+    title: doc.title,
+    summary: doc.summary ?? null,
+    order: doc.order,
+    project: typeof doc.project === 'number' ? doc.project : doc.project.id,
+    bookHeading: doc.bookHeading ?? null,
+    bookBody: doc.bookBody ?? null,
+    _status: doc._status as 'draft' | 'published' | null,
+  };
+}
+
+function mapChapter(doc: Chapter): WriterChapterDoc {
+  return {
+    id: doc.id,
+    title: doc.title,
+    summary: doc.summary ?? null,
+    order: doc.order,
+    project: typeof doc.project === 'number' ? doc.project : doc.project.id,
+    act: typeof doc.act === 'number' ? doc.act : doc.act.id,
+    bookHeading: doc.bookHeading ?? null,
+    bookBody: doc.bookBody ?? null,
+    _status: doc._status as 'draft' | 'published' | null,
+  };
+}
+
+function mapPage(doc: Page): WriterPageDoc {
+  return {
+    id: doc.id,
+    title: doc.title,
+    summary: doc.summary ?? null,
+    order: doc.order,
+    project: typeof doc.project === 'number' ? doc.project : doc.project.id,
+    chapter: typeof doc.chapter === 'number' ? doc.chapter : doc.chapter.id,
+    dialogueGraph: typeof doc.dialogueGraph === 'number' ? doc.dialogueGraph : doc.dialogueGraph?.id ?? null,
+    bookBody: doc.bookBody ?? null,
+    archivedAt: doc.archivedAt ?? null,
+    _status: doc._status as 'draft' | 'published' | null,
+  };
+}
+
+function sortByOrder<T extends { order: number }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.order - b.order);
+}
 
 export function makePayloadWriterAdapter(opts?: {
   baseUrl?: string;
-}): ForgeDataAdapter {
-  return makePayloadForgeAdapter(opts);
+}): WriterDataAdapter {
+  const baseURL = opts?.baseUrl ?? (typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000');
+  const payload = new PayloadSDK({
+    baseURL: `${baseURL}/api`,
+  });
+
+  return {
+    async listActs(projectId: number): Promise<WriterActDoc[]> {
+      const result = await payload.find({
+        collection: PAYLOAD_COLLECTIONS.ACTS,
+        where: {
+          project: {
+            equals: projectId,
+          },
+        },
+        limit: 200,
+      });
+      const acts = result.docs.map((doc) => mapAct(doc as Act));
+      return sortByOrder(acts);
+    },
+
+    async listChapters(projectId: number, actId?: number): Promise<WriterChapterDoc[]> {
+      const where: Record<string, unknown> = {
+        project: {
+          equals: projectId,
+        },
+      };
+
+      if (actId) {
+        where.act = {
+          equals: actId,
+        };
+      }
+
+      const result = await payload.find({
+        collection: PAYLOAD_COLLECTIONS.CHAPTERS,
+        where,
+        limit: 200,
+      });
+      const chapters = result.docs.map((doc) => mapChapter(doc as Chapter));
+      return sortByOrder(chapters);
+    },
+
+    async listPages(projectId: number, chapterId?: number): Promise<WriterPageDoc[]> {
+      const where: Record<string, unknown> = {
+        project: {
+          equals: projectId,
+        },
+      };
+
+      if (chapterId) {
+        where.chapter = {
+          equals: chapterId,
+        };
+      }
+
+      const result = await payload.find({
+        collection: PAYLOAD_COLLECTIONS.PAGES,
+        where,
+        limit: 200,
+      });
+      const pages = result.docs.map((doc) => mapPage(doc as Page));
+      return sortByOrder(pages);
+    },
+
+    async getAct(actId: number): Promise<WriterActDoc> {
+      const doc = await payload.findByID({
+        collection: PAYLOAD_COLLECTIONS.ACTS,
+        id: actId,
+      }) as Act;
+      return mapAct(doc);
+    },
+
+    async getChapter(chapterId: number): Promise<WriterChapterDoc> {
+      const doc = await payload.findByID({
+        collection: PAYLOAD_COLLECTIONS.CHAPTERS,
+        id: chapterId,
+      }) as Chapter;
+      return mapChapter(doc);
+    },
+
+    async getPage(pageId: number): Promise<WriterPageDoc> {
+      const doc = await payload.findByID({
+        collection: PAYLOAD_COLLECTIONS.PAGES,
+        id: pageId,
+      }) as Page;
+      return mapPage(doc);
+    },
+
+    async updateAct(actId: number, patch: Partial<WriterActDoc>): Promise<WriterActDoc> {
+      const doc = await payload.update({
+        collection: PAYLOAD_COLLECTIONS.ACTS,
+        id: actId,
+        data: patch,
+      }) as Act;
+      return mapAct(doc);
+    },
+
+    async updateChapter(chapterId: number, patch: Partial<WriterChapterDoc>): Promise<WriterChapterDoc> {
+      const doc = await payload.update({
+        collection: PAYLOAD_COLLECTIONS.CHAPTERS,
+        id: chapterId,
+        data: patch,
+      }) as Chapter;
+      return mapChapter(doc);
+    },
+
+    async updatePage(pageId: number, patch: Partial<WriterPageDoc>): Promise<WriterPageDoc> {
+      const doc = await payload.update({
+        collection: PAYLOAD_COLLECTIONS.PAGES,
+        id: pageId,
+        data: patch,
+      }) as Page;
+      return mapPage(doc);
+    },
+  };
 }

--- a/src/lib/writer/data-adapter/writer-adapter.ts
+++ b/src/lib/writer/data-adapter/writer-adapter.ts
@@ -1,0 +1,20 @@
+import type { ForgeAct, ForgeChapter, ForgePage } from '@/src/types/narrative';
+
+export type WriterActDoc = ForgeAct;
+export type WriterChapterDoc = ForgeChapter;
+export type WriterPageDoc = ForgePage;
+export type WriterDoc = WriterActDoc | WriterChapterDoc | WriterPageDoc;
+
+export interface WriterDataAdapter {
+  listActs(projectId: number): Promise<WriterActDoc[]>;
+  listChapters(projectId: number, actId?: number): Promise<WriterChapterDoc[]>;
+  listPages(projectId: number, chapterId?: number): Promise<WriterPageDoc[]>;
+
+  getAct(actId: number): Promise<WriterActDoc>;
+  getChapter(chapterId: number): Promise<WriterChapterDoc>;
+  getPage(pageId: number): Promise<WriterPageDoc>;
+
+  updateAct(actId: number, patch: Partial<WriterActDoc>): Promise<WriterActDoc>;
+  updateChapter(chapterId: number, patch: Partial<WriterChapterDoc>): Promise<WriterChapterDoc>;
+  updatePage(pageId: number, patch: Partial<WriterPageDoc>): Promise<WriterPageDoc>;
+}


### PR DESCRIPTION
### Motivation
- Provide a clear, host-independent interface for Writer authored content (acts/chapters/pages) so the Writer workspace can consume storage-agnostic adapters.
- Implement a PayloadCMS-backed adapter to support REST persistence for the Writer UI while returning normalized library DTOs that match internal `Forge*` narrative types.
- Keep transformations pure and stateless so the adapter can be used anywhere without side-effects.

### Description
- Added `src/lib/writer/data-adapter/writer-adapter.ts` which defines `WriterDataAdapter` and DTO aliases `WriterActDoc`, `WriterChapterDoc`, `WriterPageDoc`, and `WriterDoc` that map to internal `ForgeAct/ForgeChapter/ForgePage` types.
- Implemented `app/lib/writer/data-adapter/payload-writer-adapter.ts` which uses `PayloadSDK` to perform REST calls against PayloadCMS collections and maps `Act`, `Chapter`, and `Page` documents into the normalized `Writer*` DTOs.
- Ensured list methods (`listActs`, `listChapters`, `listPages`) sort results by the `order` field, and all functions are implemented as pure `async` operations that return normalized DTOs.
- Respected type independence: no host app types are imported into `src/`; the Payload-backed implementation lives under `app/` and imports `@/app/payload-types` as appropriate.

### Testing
- Ran `npm run build` to validate the change in this environment, which failed due to a missing dependency error for `@payloadcms/next` in the current environment (build error: `Cannot find package '@payloadcms/next'`).
- No new unit tests were added for this change and no other automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967108ca590832d979f16a5143d311d)