### PR TITLE
Add JSON content fields to Acts, Chapters, and Pages collections

### DIFF
--- a/app/payload-collections/collection-configs/acts.ts
+++ b/app/payload-collections/collection-configs/acts.ts
@@ -31,6 +31,10 @@ export const Acts: CollectionConfig = {
       type: 'textarea',
     },
     {
+      name: 'content',
+      type: 'json',
+    },
+    {
       name: 'order',
       type: 'number',
       required: true,

--- a/app/payload-collections/collection-configs/chapters.ts
+++ b/app/payload-collections/collection-configs/chapters.ts
@@ -38,6 +38,10 @@ export const Chapters: CollectionConfig = {
       type: 'textarea',
     },
     {
+      name: 'content',
+      type: 'json',
+    },
+    {
       name: 'order',
       type: 'number',
       required: true,

--- a/app/payload-collections/collection-configs/pages.ts
+++ b/app/payload-collections/collection-configs/pages.ts
@@ -38,6 +38,10 @@ export const Pages: CollectionConfig = {
       type: 'textarea',
     },
     {
+      name: 'content',
+      type: 'json',
+    },
+    {
       name: 'order',
       type: 'number',
       required: true,


### PR DESCRIPTION
### Motivation

- Provide a structured `content` area for narrative documents so acts, chapters, and pages can store JSON-serializable content without removing existing textual fields.
- Keep existing UX/ordering metadata intact by preserving `title`, `order`, `summary`, and `bookBody` fields.

### Description

- Added a `content` field with `type: 'json'` to the Payload collection configs `app/payload-collections/collection-configs/acts.ts`, `app/payload-collections/collection-configs/chapters.ts`, and `app/payload-collections/collection-configs/pages.ts`.
- No existing fields were removed or modified other than inserting the new `content` field; `title`, `order`, `summary`, and `bookBody` remain unchanged.
- Collection config `versions` and access/admin settings were left as-is.

### Testing

- Attempted to regenerate Payload types with `npm run build:types`, but the step failed because the `payload` CLI was not available in the environment (`sh: 1: payload: not found`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696714974c1c832daf92b0e24979cefe)