### PR TITLE
Add AI API route handlers and ai-adapter utilities

### DIFF
--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -1,0 +1,8 @@
+import { getAiAdapter, streamResponse } from '@/app/lib/ai/ai-adapter';
+
+export async function POST(request: Request) {
+  const payload = await request.json();
+  const adapter = getAiAdapter();
+  const response = await adapter.streamChat(payload);
+  return streamResponse(response);
+}

--- a/app/api/ai/writer/edits:propose/route.ts
+++ b/app/api/ai/writer/edits:propose/route.ts
@@ -1,0 +1,8 @@
+import { getAiAdapter, jsonResponse } from '@/app/lib/ai/ai-adapter';
+
+export async function POST(request: Request) {
+  const payload = await request.json();
+  const adapter = getAiAdapter();
+  const response = await adapter.proposeEdits(payload);
+  return jsonResponse(response);
+}

--- a/app/api/ai/writer/plans/[planId]/steps/[stepId]:apply/route.ts
+++ b/app/api/ai/writer/plans/[planId]/steps/[stepId]:apply/route.ts
@@ -1,0 +1,46 @@
+import {
+  getAiAdapter,
+  isServerSideApplyEnabled,
+  jsonResponse,
+} from '@/app/lib/ai/ai-adapter';
+
+type RouteParams = {
+  params: {
+    planId: string;
+    stepId: string;
+  };
+};
+
+const APPLY_DISABLED_MESSAGE = 'Server-side apply is disabled.';
+
+export async function POST(request: Request, { params }: RouteParams) {
+  if (!isServerSideApplyEnabled()) {
+    return jsonResponse({
+      ok: false,
+      error: {
+        message: APPLY_DISABLED_MESSAGE,
+        status: 404,
+      },
+    });
+  }
+
+  const payload = await request.json();
+  const adapter = getAiAdapter();
+  const response = await adapter.applyPlanStep?.({
+    planId: params.planId,
+    stepId: params.stepId,
+    payload,
+  });
+
+  if (!response) {
+    return jsonResponse({
+      ok: false,
+      error: {
+        message: APPLY_DISABLED_MESSAGE,
+        status: 404,
+      },
+    });
+  }
+
+  return jsonResponse(response);
+}

--- a/app/api/ai/writer/plans/[planId]/steps/[stepId]:propose/route.ts
+++ b/app/api/ai/writer/plans/[planId]/steps/[stepId]:propose/route.ts
@@ -1,0 +1,19 @@
+import { getAiAdapter, jsonResponse } from '@/app/lib/ai/ai-adapter';
+
+type RouteParams = {
+  params: {
+    planId: string;
+    stepId: string;
+  };
+};
+
+export async function POST(request: Request, { params }: RouteParams) {
+  const payload = await request.json();
+  const adapter = getAiAdapter();
+  const response = await adapter.proposePlanStep({
+    planId: params.planId,
+    stepId: params.stepId,
+    payload,
+  });
+  return jsonResponse(response);
+}

--- a/app/api/ai/writer/plans/route.ts
+++ b/app/api/ai/writer/plans/route.ts
@@ -1,0 +1,8 @@
+import { getAiAdapter, jsonResponse } from '@/app/lib/ai/ai-adapter';
+
+export async function POST(request: Request) {
+  const payload = await request.json();
+  const adapter = getAiAdapter();
+  const response = await adapter.createPlan(payload);
+  return jsonResponse(response);
+}

--- a/app/lib/ai/ai-adapter.ts
+++ b/app/lib/ai/ai-adapter.ts
@@ -1,0 +1,128 @@
+export type AiError = {
+  message: string;
+  code?: string;
+  status?: number;
+  details?: unknown;
+};
+
+export type AiSuccessResponse<T> = {
+  ok: true;
+  data: T;
+};
+
+export type AiFailureResponse = {
+  ok: false;
+  error: AiError;
+};
+
+export type AiResponse<T> = AiSuccessResponse<T> | AiFailureResponse;
+
+export type AiEditProposal = {
+  patch: string;
+  summary?: string;
+};
+
+export type AiPlanStep = {
+  id: string;
+  title: string;
+  description?: string;
+};
+
+export type AiPlan = {
+  id: string;
+  title: string;
+  steps: AiPlanStep[];
+};
+
+export type AiPlanStepProposal = {
+  patch: string;
+  summary?: string;
+};
+
+export type AiPlanStepApplyResult = {
+  applied: boolean;
+  message?: string;
+  patch?: string;
+};
+
+export type AiStreamResponse = {
+  stream: ReadableStream<Uint8Array>;
+  status?: number;
+  headers?: HeadersInit;
+};
+
+export type AiPlanStepRequest = {
+  planId: string;
+  stepId: string;
+  payload: unknown;
+};
+
+export interface AiAdapter {
+  streamChat: (payload: unknown) => Promise<AiStreamResponse>;
+  proposeEdits: (payload: unknown) => Promise<AiResponse<AiEditProposal>>;
+  createPlan: (payload: unknown) => Promise<AiResponse<AiPlan>>;
+  proposePlanStep: (payload: AiPlanStepRequest) => Promise<AiResponse<AiPlanStepProposal>>;
+  applyPlanStep?: (payload: AiPlanStepRequest) => Promise<AiResponse<AiPlanStepApplyResult>>;
+}
+
+const DEFAULT_STREAM_HEADERS: HeadersInit = {
+  'Content-Type': 'text/event-stream',
+  'Cache-Control': 'no-cache, no-transform',
+  Connection: 'keep-alive',
+};
+
+const NOT_CONFIGURED_MESSAGE = 'AI adapter is not configured.';
+
+const errorResponse = (message: string, status?: number): AiFailureResponse => ({
+  ok: false,
+  error: {
+    message,
+    status,
+  },
+});
+
+export const jsonResponse = <T>(response: AiResponse<T>, init: ResponseInit = {}) => {
+  const status = response.ok ? 200 : response.error.status ?? 500;
+  return Response.json(response, { ...init, status });
+};
+
+export const streamResponse = (response: AiStreamResponse) => {
+  const headers = {
+    ...DEFAULT_STREAM_HEADERS,
+    ...(response.headers ?? {}),
+  };
+  return new Response(response.stream, { status: response.status ?? 200, headers });
+};
+
+const encodeSse = (payload: unknown) => {
+  const data = JSON.stringify(payload);
+  return `data: ${data}\n\n`;
+};
+
+const createSseErrorStream = (message: string, status?: number): AiStreamResponse => {
+  const encoder = new TextEncoder();
+  const payload = errorResponse(message, status);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(encodeSse(payload)));
+      controller.close();
+    },
+  });
+  return {
+    stream,
+    status: status ?? 500,
+  };
+};
+
+const defaultAdapter: AiAdapter = {
+  streamChat: async () => createSseErrorStream(NOT_CONFIGURED_MESSAGE, 501),
+  proposeEdits: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+  createPlan: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+  proposePlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+  applyPlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+};
+
+export const isServerSideApplyEnabled = () =>
+  process.env.AI_SERVER_APPLY_ENABLED === 'true';
+
+export const getAiAdapter = (): AiAdapter => defaultAdapter;


### PR DESCRIPTION
### Motivation

- Provide Next.js API endpoints under `/api/ai/...` to support streaming chat, edit proposals, plan creation, and plan-step propose/apply flows that delegate to a shared internal adapter. 
- Standardize AI responses and streaming behaviour (SSE) across handlers so frontends can consume a consistent shape. 
- Gate server-side apply behind a runtime flag so apply behavior can be enabled/disabled safely.

### Description

- Add `app/lib/ai/ai-adapter.ts` which defines `AiAdapter` and typed response shapes (`AiResponse`, `AiStreamResponse`, etc.), `jsonResponse` and `streamResponse` helpers, SSE error stream helper, a default stub adapter returning 501/not-configured responses, and `isServerSideApplyEnabled` for feature gating. 
- Add `POST /api/ai/chat` handler that forwards the request body to `adapter.streamChat` and returns an SSE stream via `streamResponse`. 
- Add `POST /api/ai/writer/edits:propose` handler that forwards to `adapter.proposeEdits` and returns the standardized JSON response. 
- Add `POST /api/ai/writer/plans` handler that forwards to `adapter.createPlan` and returns the standardized JSON response. 
- Add `POST /api/ai/writer/plans/[planId]/steps/[stepId]:propose` handler that forwards a `{planId, stepId, payload}` request to `adapter.proposePlanStep` and returns the standardized JSON response. 
- Add `POST /api/ai/writer/plans/[planId]/steps/[stepId]:apply` handler that checks `isServerSideApplyEnabled`, returns a 404-style error when disabled, and otherwise forwards to `adapter.applyPlanStep` and returns the standardized JSON response.

### Testing

- Ran `npm run build` to validate the Next.js app build, which failed due to a missing dependency error: `Cannot find package '@payloadcms/next' imported from next.config.mjs`.
- No further automated tests were run in this rollout due to the build failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69672e2abd04832d9160b59b67f7207d)