### PR TITLE
Add Writer AI contract types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export * from './types/flags';
 export * from './types/forge-game-state';
 export * from './types/characters';
 export * from './types/constants';
+export * from './types/writer-ai';
 
 // Export game state utilities
 export { 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,16 @@ export {
   NARRATIVE_FORGE_NODE_TYPE,
 } from './forge/forge-graph';
 
+export type {
+  WriterScope,
+  WriterSnapshot,
+  WriterSelection,
+  WriterPatchOp,
+  WriterPatchProposal,
+  WriterPlan,
+  WriterPlanStep,
+} from './writer-ai';
+
 
 import { FlagSchema, type FlagSchema as FlagSchemaType } from './flags';
 

--- a/src/types/writer-ai.ts
+++ b/src/types/writer-ai.ts
@@ -1,0 +1,60 @@
+export type WriterScope = {
+  projectId?: number;
+  actId?: number;
+  chapterId?: number;
+  pageId?: number;
+  docId?: number;
+  docKind?: string;
+  locale?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type WriterSnapshot = {
+  id: string;
+  scope: WriterScope;
+  title?: string;
+  content: string;
+  createdAt?: string;
+  updatedAt?: string;
+  revisionId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type WriterSelection = {
+  scope: WriterScope;
+  anchorOffset: number;
+  focusOffset: number;
+  selectedText?: string;
+  path?: Array<string | number>;
+};
+
+export type WriterPatchOp = {
+  op: string;
+  path: string;
+  value?: unknown;
+  from?: string;
+};
+
+export type WriterPatchProposal = {
+  id: string;
+  scope: WriterScope;
+  ops: WriterPatchOp[];
+  summary?: string;
+  rationale?: string;
+  selection?: WriterSelection;
+};
+
+export type WriterPlanStep = {
+  id: string;
+  description: string;
+  status?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type WriterPlan = {
+  id: string;
+  scope: WriterScope;
+  summary: string;
+  steps: WriterPlanStep[];
+  metadata?: Record<string, unknown>;
+};


### PR DESCRIPTION
### Motivation

- Provide a small set of library-level types to represent Writer AI contracts (scopes, snapshots, selections, patch proposals, patch ops, and plans) so consumers and writer-related components can share a stable surface without depending on host app payload types. 

### Description

- Add a new type file `src/types/writer-ai.ts` containing `WriterScope`, `WriterSnapshot`, `WriterSelection`, `WriterPatchOp`, `WriterPatchProposal`, `WriterPlanStep`, and `WriterPlan` definitions implemented using only primitives and generic records to remain independent from app-specific payload types.  
- Re-export the new types from the public types barrel `src/types/index.ts`.  
- Re-export the new types from the package entrypoint `src/index.ts` so they are available to consumers of the package.  

### Testing

- Ran `npm run build` (Next.js build) which failed due to a missing dev dependency: `Cannot find package '@payloadcms/next' imported from /workspace/dialogue-forge/next.config.mjs`, so the package build did not complete.  
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69673230e3c4832db4d855a509815405)