### PR TITLE
Add AI patch proposal flow to writer store

### DIFF
--- a/src/store/writer/writer-patches.ts
+++ b/src/store/writer/writer-patches.ts
@@ -1,0 +1,66 @@
+export const WRITER_PATCH_OP = {
+  REPLACE_CONTENT: 'replace_content',
+  SPLICE_CONTENT: 'splice_content',
+  REPLACE_BLOCKS: 'replace_blocks',
+} as const;
+
+export type WriterPatchOp =
+  | {
+      type: typeof WRITER_PATCH_OP.REPLACE_CONTENT;
+      content: string | null;
+    }
+  | {
+      type: typeof WRITER_PATCH_OP.SPLICE_CONTENT;
+      start: number;
+      end: number;
+      text: string;
+    }
+  | {
+      type: typeof WRITER_PATCH_OP.REPLACE_BLOCKS;
+      blocks: unknown[] | null;
+    };
+
+export type WriterSelectionRange = {
+  start: number;
+  end: number;
+};
+
+export type WriterDocSnapshot = {
+  content: string | null;
+  blocks?: unknown[] | null;
+};
+
+export function applyWriterPatchOps(
+  snapshot: WriterDocSnapshot,
+  ops: WriterPatchOp[]
+): WriterDocSnapshot {
+  let content = snapshot.content ?? '';
+  let blocks = snapshot.blocks ?? null;
+
+  ops.forEach((op) => {
+    switch (op.type) {
+      case WRITER_PATCH_OP.REPLACE_CONTENT:
+        content = op.content ?? '';
+        break;
+      case WRITER_PATCH_OP.SPLICE_CONTENT: {
+        const safeContent = content ?? '';
+        const start = Math.max(0, Math.min(safeContent.length, op.start));
+        const end = Math.max(start, Math.min(safeContent.length, op.end));
+        content = `${safeContent.slice(0, start)}${op.text}${safeContent.slice(
+          end
+        )}`;
+        break;
+      }
+      case WRITER_PATCH_OP.REPLACE_BLOCKS:
+        blocks = op.blocks ?? null;
+        break;
+      default:
+        break;
+    }
+  });
+
+  return {
+    content,
+    blocks,
+  };
+}


### PR DESCRIPTION
### Motivation

- Add an AI-driven edit workflow so users can request, preview, and apply AI-generated patch operations to writer drafts while preserving selection/snapshot context.
- Provide a small, deterministic patch application helper to transform `WriterPatchOp[]` into updated draft content/blocks before committing changes.

### Description

- Add `src/store/writer/writer-patches.ts` with `WRITER_PATCH_OP`, `WriterPatchOp` types, `WriterSelectionRange`, `WriterDocSnapshot`, and the `applyWriterPatchOps` helper for applying patch ops to snapshots.
- Extend `src/store/writer/writer-store.ts` to track AI state with `aiPreview`, `aiProposalStatus`, `aiError`, `aiSelection`, and `aiSnapshot`, and add `WRITER_AI_PROPOSAL_STATUS` constants.
- Add store actions `setAiSelection`, `setAiSnapshot`, `proposeAiEdits`, and `applyAiEdits`, where `proposeAiEdits` POSTs to `/api/ai/writer/edits:propose` with the current `selection`/`snapshot`, and `applyAiEdits` uses `applyWriterPatchOps` then updates the active draft via `setDraftContent` and schedules autosave.
- Handle API failures and invalid responses by setting `aiProposalStatus`/`aiError` appropriately and preserving snapshot/preview state for user review.

### Testing

- Ran `npm run build` which attempted a Next build but failed due to a missing dependency: `Cannot find package '@payloadcms/next' imported from next.config.mjs` so the build could not complete.
- No new unit tests were added and no other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69673329744c832d8870ec01bf3a17fb)