### PR TITLE
Normalize AI edit proposal responses and parse patch in writer store

### DIFF
--- a/app/lib/ai/ai-adapter.ts
+++ b/app/lib/ai/ai-adapter.ts
@@ -220,7 +220,7 @@ const buildEditProposalMessages = (payload: unknown): OpenRouterMessage[] => [
   {
     role: 'system',
     content:
-      'You are an expert narrative editor. Output JSON with { "patch": string, "summary": string }. "patch" must be a JSON string encoding WriterPatchOp[]. Use ops with type values "replace_content", "splice_content", or "replace_blocks". Return ONLY JSON.',
+      'You are an expert narrative editor. Output JSON with { "patch": string, "summary": string }. "patch" must be a JSON string encoding an array of edit operations. Use ops with type values "replace_content", "splice_content", or "replace_blocks". Return ONLY JSON.',
   },
   {
     role: 'user',

--- a/app/lib/ai/ai-adapter.ts
+++ b/app/lib/ai/ai-adapter.ts
@@ -220,7 +220,7 @@ const buildEditProposalMessages = (payload: unknown): OpenRouterMessage[] => [
   {
     role: 'system',
     content:
-      'You are an expert narrative editor. Output JSON with { "ops": WriterPatchOp[], "summary": string, "rationale": string, "risk": string }. Use ops with type values "replace_content", "splice_content", or "replace_blocks". Return ONLY JSON.',
+      'You are an expert narrative editor. Output JSON with { "patch": string, "summary": string }. "patch" must be a JSON string encoding WriterPatchOp[]. Use ops with type values "replace_content", "splice_content", or "replace_blocks". Return ONLY JSON.',
   },
   {
     role: 'user',
@@ -289,7 +289,51 @@ export const createAiEditProposal = async (
     stream: false,
   });
 
-  return readOpenRouterContent<AiEditProposal>(response);
+  const rawResponse = await readOpenRouterContent<unknown>(response);
+  if (!rawResponse.ok) {
+    return rawResponse;
+  }
+
+  const proposal = rawResponse.data;
+  if (Array.isArray(proposal)) {
+    return {
+      ok: true,
+      data: {
+        patch: JSON.stringify(proposal),
+      },
+    };
+  }
+
+  if (!proposal || typeof proposal !== 'object') {
+    return errorResponse('AI response missing edit proposal.', 502);
+  }
+
+  const candidate = proposal as {
+    patch?: unknown;
+    summary?: unknown;
+    ops?: unknown;
+  };
+  const summary = typeof candidate.summary === 'string' ? candidate.summary : undefined;
+
+  if (typeof candidate.patch === 'string') {
+    return { ok: true, data: { patch: candidate.patch, summary } };
+  }
+
+  if (Array.isArray(candidate.patch)) {
+    return {
+      ok: true,
+      data: { patch: JSON.stringify(candidate.patch), summary },
+    };
+  }
+
+  if (Array.isArray(candidate.ops)) {
+    return {
+      ok: true,
+      data: { patch: JSON.stringify(candidate.ops), summary },
+    };
+  }
+
+  return errorResponse('AI response missing patch data.', 502);
 };
 
 export const createAiPlan = async (

--- a/app/lib/ai/ai-adapter.ts
+++ b/app/lib/ai/ai-adapter.ts
@@ -220,7 +220,7 @@ const buildEditProposalMessages = (payload: unknown): OpenRouterMessage[] => [
   {
     role: 'system',
     content:
-      'You are an expert narrative editor. Output JSON with { "patch": string, "summary": string }. "patch" must be a JSON string encoding an array of edit operations. Use ops with type values "replace_content", "splice_content", or "replace_blocks". Return ONLY JSON.',
+      'You are an expert editor. Use the provided context to propose edits (text, structured content, or graph data). Output JSON with { "patch": string, "summary": string }. "patch" must be a JSON string encoding an array of edit operations. Use ops with type values "replace_content", "splice_content", or "replace_blocks". Return ONLY JSON.',
   },
   {
     role: 'user',


### PR DESCRIPTION
### Motivation
- Ensure the AI edit flow uses a single, stable response shape (`AiResponse<{ patch: string; summary?: string }>`), and make the edit-proposal prompt require a `patch` JSON string for reliable parsing.  
- Update the writer workspace to consume the `AiResponse` envelope and safely deserialize the `patch` into `WriterPatchOp[]`, surfacing server-side error messages when present.

### Description
- Updated the edit-proposal system prompt in `app/lib/ai/ai-adapter.ts` to request `{ "patch": string, "summary": string }` where `patch` is a JSON string encoding `WriterPatchOp[]`.  
- Implemented normalization in `createAiEditProposal` to accept several AI output shapes (raw ops array, `ops`, `patch` array, or `patch` string) and return a canonical `AiResponse<AiEditProposal>` with `patch` as a string.  
- Modified the writer workspace store (`src/components/WriterWorkspace/store/writer-workspace-store.tsx`) to expect the `AiResponse` envelope, throw with `response.error.message` when `ok` is false, `JSON.parse` the returned `data.patch` into `WriterPatchOp[]`, and use `data.summary` for `aiPreviewMeta.summary`.  
- Added guards and error messages for missing/invalid patch data to avoid silent failures.

### Testing
- Ran `npm run build` to validate integration; build failed due to environment/package resolution (`Cannot find package '@payloadcms/next' imported from next.config.mjs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967413f67d0832dae1eff00e586af51)