### PR TITLE
Add OpenRouter AI adapter using Vercel AI SDK

### DIFF
--- a/app/lib/ai/ai-adapter.ts
+++ b/app/lib/ai/ai-adapter.ts
@@ -1,79 +1,28 @@
-export type AiError = {
-  message: string;
-  code?: string;
-  status?: number;
-  details?: unknown;
-};
+import 'server-only';
 
-export type AiSuccessResponse<T> = {
-  ok: true;
-  data: T;
-};
+import { createOpenRouterAdapter } from '@/src/lib/aiadapter/openrouter/openrouter-adapter';
+import { getOpenRouterConfig } from '@/src/lib/aiadapter/openrouter/config';
+import type {
+  AiAdapter,
+  AiFailureResponse,
+  AiResponse,
+  AiStreamResponse,
+} from '@/src/lib/aiadapter/types';
 
-export type AiFailureResponse = {
-  ok: false;
-  error: AiError;
-};
-
-export type AiResponse<T> = AiSuccessResponse<T> | AiFailureResponse;
-
-export type AiEditProposal = {
-  patch: string;
-  summary?: string;
-};
-
-export type AiPlanStep = {
-  id: string;
-  title: string;
-  description?: string;
-};
-
-export type AiPlan = {
-  id: string;
-  title: string;
-  steps: AiPlanStep[];
-};
-
-export type AiPlanStepProposal = {
-  patch: string;
-  summary?: string;
-};
-
-export type AiPlanStepApplyResult = {
-  applied: boolean;
-  message?: string;
-  patch?: string;
-};
-
-export type AiStreamResponse = {
-  stream: ReadableStream<Uint8Array>;
-  status?: number;
-  headers?: HeadersInit;
-};
-
-export type AiPlanStepRequest = {
-  planId: string;
-  stepId: string;
-  payload: unknown;
-};
-
-export interface AiAdapter {
-  streamChat: (payload: unknown) => Promise<AiStreamResponse>;
-  proposeEdits: (payload: unknown) => Promise<AiResponse<AiEditProposal>>;
-  createPlan: (payload: unknown) => Promise<AiResponse<AiPlan>>;
-  proposePlanStep: (payload: AiPlanStepRequest) => Promise<AiResponse<AiPlanStepProposal>>;
-  applyPlanStep?: (payload: AiPlanStepRequest) => Promise<AiResponse<AiPlanStepApplyResult>>;
-}
-
-const OPENROUTER_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
-const OPENROUTER_MODEL_MODE = {
-  FAST: 'fast',
-  REASONING: 'reasoning',
-} as const;
-const OPENROUTER_MODEL_FAST =
-  process.env.OPENROUTER_MODEL_FAST ?? 'openai/gpt-4o-mini';
-const OPENROUTER_MODEL_REASONING =
-  process.env.OPENROUTER_MODEL_REASONING ?? 'openai/o1-mini';
+export type {
+  AiAdapter,
+  AiEditProposal,
+  AiError,
+  AiFailureResponse,
+  AiPlan,
+  AiPlanStep,
+  AiPlanStepApplyResult,
+  AiPlanStepProposal,
+  AiPlanStepRequest,
+  AiResponse,
+  AiStreamResponse,
+  AiSuccessResponse,
+} from '@/src/lib/aiadapter/types';
 
 const DEFAULT_STREAM_HEADERS: HeadersInit = {
   'Content-Type': 'text/event-stream',
@@ -90,26 +39,6 @@ const errorResponse = (message: string, status?: number): AiFailureResponse => (
     status,
   },
 });
-
-type OpenRouterRole = 'system' | 'user' | 'assistant';
-
-type OpenRouterMessage = {
-  role: OpenRouterRole;
-  content: string;
-};
-
-export const jsonResponse = <T>(response: AiResponse<T>, init: ResponseInit = {}) => {
-  const status = response.ok ? 200 : response.error.status ?? 500;
-  return Response.json(response, { ...init, status });
-};
-
-export const streamResponse = (response: AiStreamResponse) => {
-  const headers = {
-    ...DEFAULT_STREAM_HEADERS,
-    ...(response.headers ?? {}),
-  };
-  return new Response(response.stream, { status: response.status ?? 200, headers });
-};
 
 const encodeSse = (payload: unknown) => {
   const data = JSON.stringify(payload);
@@ -131,230 +60,17 @@ const createSseErrorStream = (message: string, status?: number): AiStreamRespons
   };
 };
 
-const getOpenRouterKey = () => process.env.OPENROUTER_API_KEY?.trim();
-
-const getOpenRouterHeaders = (apiKey: string) => ({
-  Authorization: `Bearer ${apiKey}`,
-  'Content-Type': 'application/json',
-});
-
-const resolveModelFromPayload = (payload: unknown) => {
-  if (payload && typeof payload === 'object') {
-    const candidate = payload as {
-      mode?: string;
-      preference?: string;
-      reasoning?: boolean;
-    };
-    if (candidate.reasoning === true) {
-      return OPENROUTER_MODEL_REASONING;
-    }
-    if (candidate.mode === OPENROUTER_MODEL_MODE.REASONING) {
-      return OPENROUTER_MODEL_REASONING;
-    }
-    if (candidate.preference === OPENROUTER_MODEL_MODE.REASONING) {
-      return OPENROUTER_MODEL_REASONING;
-    }
-  }
-  return OPENROUTER_MODEL_FAST;
+export const jsonResponse = <T>(response: AiResponse<T>, init: ResponseInit = {}) => {
+  const status = response.ok ? 200 : response.error.status ?? 500;
+  return Response.json(response, { ...init, status });
 };
 
-const buildChatMessages = (payload: unknown): OpenRouterMessage[] => {
-  if (payload && typeof payload === 'object') {
-    const candidate = payload as { messages?: OpenRouterMessage[] };
-    if (Array.isArray(candidate.messages) && candidate.messages.length > 0) {
-      return candidate.messages;
-    }
-  }
-  return [
-    {
-      role: 'user',
-      content: JSON.stringify(payload ?? {}),
-    },
-  ];
-};
-
-const parseContentJson = <T>(content: string): AiResponse<T> => {
-  try {
-    const parsed = JSON.parse(content) as T;
-    return { ok: true, data: parsed };
-  } catch (error) {
-    return errorResponse(
-      error instanceof Error
-        ? error.message
-        : 'Unable to parse AI response.',
-      502
-    );
-  }
-};
-
-const readOpenRouterContent = async <T>(
-  response: Response
-): Promise<AiResponse<T>> => {
-  if (!response.ok) {
-    const errorText = await response.text();
-    return errorResponse(errorText || 'OpenRouter request failed.', response.status);
-  }
-
-  const data = (await response.json()) as {
-    choices?: Array<{ message?: { content?: string } }>;
+export const streamResponse = (response: AiStreamResponse) => {
+  const headers = {
+    ...DEFAULT_STREAM_HEADERS,
+    ...(response.headers ?? {}),
   };
-  const content = data.choices?.[0]?.message?.content;
-  if (!content) {
-    return errorResponse('OpenRouter response missing content.', 502);
-  }
-  return parseContentJson<T>(content);
-};
-
-const requestOpenRouter = async (
-  apiKey: string,
-  body: Record<string, unknown>
-) => {
-  return fetch(OPENROUTER_ENDPOINT, {
-    method: 'POST',
-    headers: getOpenRouterHeaders(apiKey),
-    body: JSON.stringify(body),
-  });
-};
-
-const buildEditProposalMessages = (payload: unknown): OpenRouterMessage[] => [
-  {
-    role: 'system',
-    content:
-      'You are an expert editor. Use the provided context to propose edits (text, structured content, or graph data). Output JSON with { "patch": string, "summary": string }. "patch" must be a JSON string encoding an array of edit operations. Use ops with type values "replace_content", "splice_content", or "replace_blocks". Return ONLY JSON.',
-  },
-  {
-    role: 'user',
-    content: JSON.stringify(payload ?? {}),
-  },
-];
-
-const buildPlanMessages = (payload: unknown): OpenRouterMessage[] => [
-  {
-    role: 'system',
-    content:
-      'You are a planning assistant. Output JSON with { "id": string, "title": string, "steps": [{ "id": string, "title": string, "description": string }] }. Return ONLY JSON.',
-  },
-  {
-    role: 'user',
-    content: JSON.stringify(payload ?? {}),
-  },
-];
-
-export const createAiChat = async (payload: unknown): Promise<AiStreamResponse> => {
-  const apiKey = getOpenRouterKey();
-  if (!apiKey) {
-    return createSseErrorStream(NOT_CONFIGURED_MESSAGE, 501);
-  }
-
-  const model = resolveModelFromPayload(payload);
-  const messages = buildChatMessages(payload);
-  const response = await requestOpenRouter(apiKey, {
-    model,
-    messages,
-    stream: true,
-  });
-
-  if (!response.ok || !response.body) {
-    const errorText = await response.text();
-    return createSseErrorStream(
-      errorText || 'OpenRouter streaming request failed.',
-      response.status
-    );
-  }
-
-  const contentType = response.headers.get('Content-Type');
-
-  return {
-    stream: response.body,
-    status: response.status,
-    headers: contentType ? { 'Content-Type': contentType } : undefined,
-  };
-};
-
-export const createAiEditProposal = async (
-  payload: unknown
-): Promise<AiResponse<AiEditProposal>> => {
-  const apiKey = getOpenRouterKey();
-  if (!apiKey) {
-    return errorResponse(NOT_CONFIGURED_MESSAGE, 501);
-  }
-
-  const model = resolveModelFromPayload({
-    ...(payload && typeof payload === 'object' ? payload : {}),
-    reasoning: true,
-  });
-  const response = await requestOpenRouter(apiKey, {
-    model,
-    messages: buildEditProposalMessages(payload),
-    stream: false,
-  });
-
-  const rawResponse = await readOpenRouterContent<unknown>(response);
-  if (!rawResponse.ok) {
-    return rawResponse;
-  }
-
-  const proposal = rawResponse.data;
-  if (Array.isArray(proposal)) {
-    return {
-      ok: true,
-      data: {
-        patch: JSON.stringify(proposal),
-      },
-    };
-  }
-
-  if (!proposal || typeof proposal !== 'object') {
-    return errorResponse('AI response missing edit proposal.', 502);
-  }
-
-  const candidate = proposal as {
-    patch?: unknown;
-    summary?: unknown;
-    ops?: unknown;
-  };
-  const summary = typeof candidate.summary === 'string' ? candidate.summary : undefined;
-
-  if (typeof candidate.patch === 'string') {
-    return { ok: true, data: { patch: candidate.patch, summary } };
-  }
-
-  if (Array.isArray(candidate.patch)) {
-    return {
-      ok: true,
-      data: { patch: JSON.stringify(candidate.patch), summary },
-    };
-  }
-
-  if (Array.isArray(candidate.ops)) {
-    return {
-      ok: true,
-      data: { patch: JSON.stringify(candidate.ops), summary },
-    };
-  }
-
-  return errorResponse('AI response missing patch data.', 502);
-};
-
-export const createAiPlan = async (
-  payload: unknown
-): Promise<AiResponse<AiPlan>> => {
-  const apiKey = getOpenRouterKey();
-  if (!apiKey) {
-    return errorResponse(NOT_CONFIGURED_MESSAGE, 501);
-  }
-
-  const model = resolveModelFromPayload({
-    ...(payload && typeof payload === 'object' ? payload : {}),
-    reasoning: true,
-  });
-  const response = await requestOpenRouter(apiKey, {
-    model,
-    messages: buildPlanMessages(payload),
-    stream: false,
-  });
-
-  return readOpenRouterContent<AiPlan>(response);
+  return new Response(response.stream, { status: response.status ?? 200, headers });
 };
 
 const defaultAdapter: AiAdapter = {
@@ -365,18 +81,13 @@ const defaultAdapter: AiAdapter = {
   applyPlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
 };
 
-const openRouterAdapter: AiAdapter = {
-  streamChat: (payload) => createAiChat(payload),
-  proposeEdits: (payload) => createAiEditProposal(payload),
-  createPlan: (payload) => createAiPlan(payload),
-  proposePlanStep: async () =>
-    errorResponse('Plan step proposals are not configured.', 501),
-  applyPlanStep: async () =>
-    errorResponse('Plan step apply is not configured.', 501),
-};
-
 export const isServerSideApplyEnabled = () =>
   process.env.AI_SERVER_APPLY_ENABLED === 'true';
 
-export const getAiAdapter = (): AiAdapter =>
-  getOpenRouterKey() ? openRouterAdapter : defaultAdapter;
+export const getAiAdapter = (): AiAdapter => {
+  const config = getOpenRouterConfig();
+  if (config.apiKey) {
+    return createOpenRouterAdapter(config);
+  }
+  return defaultAdapter;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@ai-sdk/openai": "^3.0.10",
         "@dagrejs/dagre": "^1.1.8",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -37,6 +38,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.90.16",
         "@types/d3-hierarchy": "^3.1.7",
+        "ai": "^6.0.34",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "d3-hierarchy": "^3.1.2",
@@ -76,6 +78,68 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.14.tgz",
+      "integrity": "sha512-udVpkDaQ00jMcBvtGGvmkEBU31XidsHB4E8HIF9l7/H7lyjOS/EtXzN2adoupDg5j1/VjjSI3Ny5P1zHUvLyMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider-utils": "4.0.6",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.10.tgz",
+      "integrity": "sha512-G6HJORN0rKuCFrqIUiYchjl2b4UjzKvv3VcNuW7xwQIdI8EcdB9Pr8ZaR9nEImK9E639nM8gCfvFEUM1xwGaCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider-utils": "4.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.3.tgz",
+      "integrity": "sha512-qGPYdoAuECaUXPrrz0BPX1SacZQuJ6zky0aakxpW89QW1hrY0eF4gcFm/3L9Pk8C5Fwe+RvBf2z7ZjDhaPjnlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.6.tgz",
+      "integrity": "sha512-o/SP1GQOrpXAzHjMosPHI0Pu+YkwxIMndSjSLrEXtcVixdrjqrGaA9I7xJcWf+XpRFJ9byPHrKYnprwS+36gMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.3",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2515,6 +2579,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@payloadcms/db-sqlite": {
       "version": "3.70.0",
       "resolved": "https://registry.npmjs.org/@payloadcms/db-sqlite/-/db-sqlite-3.70.0.tgz",
@@ -4360,6 +4433,12 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -5151,6 +5230,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.1.9",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
@@ -5303,6 +5391,24 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.34",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.34.tgz",
+      "integrity": "sha512-Q8vGOaSg+Hsak8/m5pKXj6YOW+9ioF7BVUUfzuYEADq2uFyrJQBFoaDG4gc59/DWo/ko99vf0AjCF+sIdNTCmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.14",
+        "@ai-sdk/provider": "3.0.3",
+        "@ai-sdk/provider-utils": "4.0.6",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -6881,6 +6987,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -7667,6 +7782,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-to-typescript": {
       "version": "15.0.3",
@@ -12076,6 +12197,16 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "undici": "^6.19.8"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.10",
     "@dagrejs/dagre": "^1.1.8",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
@@ -89,6 +90,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.90.16",
     "@types/d3-hierarchy": "^3.1.7",
+    "ai": "^6.0.34",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3-hierarchy": "^3.1.2",

--- a/src/lib/aiadapter/openrouter/config.ts
+++ b/src/lib/aiadapter/openrouter/config.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+const DEFAULT_MODEL_FAST = 'openai/gpt-4o-mini';
+const DEFAULT_MODEL_REASONING = 'openai/o1-mini';
+const DEFAULT_TIMEOUT_MS = 60000;
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
+const parseTimeout = (value?: string) => {
+  if (!value) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  return parsed;
+};
+
+export type OpenRouterConfig = {
+  apiKey?: string;
+  baseUrl: string;
+  timeoutMs: number;
+  models: {
+    fast: string;
+    reasoning: string;
+  };
+};
+
+export const getOpenRouterConfig = (): OpenRouterConfig => ({
+  apiKey: process.env.OPENROUTER_API_KEY?.trim(),
+  baseUrl: process.env.OPENROUTER_BASE_URL?.trim() || OPENROUTER_BASE_URL,
+  timeoutMs: parseTimeout(process.env.OPENROUTER_TIMEOUT_MS),
+  models: {
+    fast: process.env.OPENROUTER_MODEL_FAST ?? DEFAULT_MODEL_FAST,
+    reasoning: process.env.OPENROUTER_MODEL_REASONING ?? DEFAULT_MODEL_REASONING,
+  },
+});

--- a/src/lib/aiadapter/openrouter/openrouter-adapter.ts
+++ b/src/lib/aiadapter/openrouter/openrouter-adapter.ts
@@ -1,0 +1,273 @@
+import 'server-only';
+
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText, streamText } from 'ai';
+
+import type {
+  AiAdapter,
+  AiEditProposal,
+  AiPlan,
+  AiPlanStepApplyResult,
+  AiPlanStepProposal,
+  AiResponse,
+  AiStreamResponse,
+} from '@/src/lib/aiadapter/types';
+import { getOpenRouterConfig, type OpenRouterConfig } from './config';
+
+const OPENROUTER_MODEL_MODE = {
+  FAST: 'fast',
+  REASONING: 'reasoning',
+} as const;
+
+const NOT_CONFIGURED_MESSAGE = 'AI adapter is not configured.';
+
+type OpenRouterRole = 'system' | 'user' | 'assistant';
+
+type OpenRouterMessage = {
+  role: OpenRouterRole;
+  content: string;
+};
+
+const errorResponse = (message: string, status?: number): AiResponse<never> => ({
+  ok: false,
+  error: {
+    message,
+    status,
+  },
+});
+
+const encodeSse = (payload: unknown) => {
+  const data = JSON.stringify(payload);
+  return `data: ${data}\n\n`;
+};
+
+const createSseErrorStream = (message: string, status?: number): AiStreamResponse => {
+  const encoder = new TextEncoder();
+  const payload = errorResponse(message, status);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(encodeSse(payload)));
+      controller.close();
+    },
+  });
+  return {
+    stream,
+    status: status ?? 500,
+  };
+};
+
+const toHeadersInit = (headers: Headers) => Object.fromEntries(headers.entries());
+
+const resolveModelFromPayload = (payload: unknown, config: OpenRouterConfig) => {
+  if (payload && typeof payload === 'object') {
+    const candidate = payload as {
+      mode?: string;
+      preference?: string;
+      reasoning?: boolean;
+    };
+    if (candidate.reasoning === true) {
+      return config.models.reasoning;
+    }
+    if (candidate.mode === OPENROUTER_MODEL_MODE.REASONING) {
+      return config.models.reasoning;
+    }
+    if (candidate.preference === OPENROUTER_MODEL_MODE.REASONING) {
+      return config.models.reasoning;
+    }
+  }
+  return config.models.fast;
+};
+
+const buildChatMessages = (payload: unknown): OpenRouterMessage[] => {
+  if (payload && typeof payload === 'object') {
+    const candidate = payload as { messages?: OpenRouterMessage[] };
+    if (Array.isArray(candidate.messages) && candidate.messages.length > 0) {
+      return candidate.messages;
+    }
+  }
+  return [
+    {
+      role: 'user',
+      content: JSON.stringify(payload ?? {}),
+    },
+  ];
+};
+
+const parseContentJson = <T>(content: string): AiResponse<T> => {
+  try {
+    const parsed = JSON.parse(content) as T;
+    return { ok: true, data: parsed };
+  } catch (error) {
+    return errorResponse(
+      error instanceof Error ? error.message : 'Unable to parse AI response.',
+      502
+    );
+  }
+};
+
+const buildEditProposalMessages = (payload: unknown): OpenRouterMessage[] => [
+  {
+    role: 'system',
+    content:
+      'You are an expert editor. Use the provided context to propose edits (text, structured content, or graph data). Output JSON with { "patch": string, "summary": string }. "patch" must be a JSON string encoding an array of edit operations. Use ops with type values "replace_content", "splice_content", or "replace_blocks". Return ONLY JSON.',
+  },
+  {
+    role: 'user',
+    content: JSON.stringify(payload ?? {}),
+  },
+];
+
+const buildPlanMessages = (payload: unknown): OpenRouterMessage[] => [
+  {
+    role: 'system',
+    content:
+      'You are a planning assistant. Output JSON with { "id": string, "title": string, "steps": [{ "id": string, "title": string, "description": string }] }. Return ONLY JSON.',
+  },
+  {
+    role: 'user',
+    content: JSON.stringify(payload ?? {}),
+  },
+];
+
+const normalizeEditProposal = (
+  content: string
+): AiResponse<AiEditProposal> => {
+  const parsed = parseContentJson<unknown>(content);
+  if (!parsed.ok) {
+    return parsed;
+  }
+
+  const proposal = parsed.data;
+  if (Array.isArray(proposal)) {
+    return {
+      ok: true,
+      data: {
+        patch: JSON.stringify(proposal),
+      },
+    };
+  }
+
+  if (!proposal || typeof proposal !== 'object') {
+    return errorResponse('AI response missing edit proposal.', 502);
+  }
+
+  const candidate = proposal as {
+    patch?: unknown;
+    summary?: unknown;
+    ops?: unknown;
+  };
+  const summary = typeof candidate.summary === 'string' ? candidate.summary : undefined;
+
+  if (typeof candidate.patch === 'string') {
+    return { ok: true, data: { patch: candidate.patch, summary } };
+  }
+
+  if (Array.isArray(candidate.patch)) {
+    return {
+      ok: true,
+      data: { patch: JSON.stringify(candidate.patch), summary },
+    };
+  }
+
+  if (Array.isArray(candidate.ops)) {
+    return {
+      ok: true,
+      data: { patch: JSON.stringify(candidate.ops), summary },
+    };
+  }
+
+  return errorResponse('AI response missing patch data.', 502);
+};
+
+const createTimeoutSignal = (timeoutMs: number) =>
+  timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+
+export const createOpenRouterAdapter = (
+  config: OpenRouterConfig = getOpenRouterConfig()
+): AiAdapter => {
+  if (!config.apiKey) {
+    return {
+      streamChat: async () => createSseErrorStream(NOT_CONFIGURED_MESSAGE, 501),
+      proposeEdits: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+      createPlan: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+      proposePlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+      applyPlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+    };
+  }
+
+  const client = createOpenAI({
+    apiKey: config.apiKey,
+    baseURL: config.baseUrl,
+  });
+
+  return {
+    streamChat: async (payload: unknown): Promise<AiStreamResponse> => {
+      try {
+        const model = resolveModelFromPayload(payload, config);
+        const messages = buildChatMessages(payload);
+        const result = streamText({
+          model: client(model),
+          messages,
+          abortSignal: createTimeoutSignal(config.timeoutMs),
+        });
+        const response = result.toDataStreamResponse();
+        return {
+          stream: response.body ?? new ReadableStream<Uint8Array>(),
+          status: response.status,
+          headers: toHeadersInit(response.headers),
+        };
+      } catch (error) {
+        return createSseErrorStream(
+          error instanceof Error
+            ? error.message
+            : 'OpenRouter streaming request failed.',
+          502
+        );
+      }
+    },
+    proposeEdits: async (payload: unknown): Promise<AiResponse<AiEditProposal>> => {
+      try {
+        const result = await generateText({
+          model: client(resolveModelFromPayload({
+            ...(payload && typeof payload === 'object' ? payload : {}),
+            reasoning: true,
+          }, config)),
+          messages: buildEditProposalMessages(payload),
+          abortSignal: createTimeoutSignal(config.timeoutMs),
+        });
+
+        return normalizeEditProposal(result.text);
+      } catch (error) {
+        return errorResponse(
+          error instanceof Error
+            ? error.message
+            : 'OpenRouter edit proposal request failed.',
+          502
+        );
+      }
+    },
+    createPlan: async (payload: unknown): Promise<AiResponse<AiPlan>> => {
+      try {
+        const result = await generateText({
+          model: client(resolveModelFromPayload({
+            ...(payload && typeof payload === 'object' ? payload : {}),
+            reasoning: true,
+          }, config)),
+          messages: buildPlanMessages(payload),
+          abortSignal: createTimeoutSignal(config.timeoutMs),
+        });
+
+        return parseContentJson<AiPlan>(result.text);
+      } catch (error) {
+        return errorResponse(
+          error instanceof Error ? error.message : 'OpenRouter plan request failed.',
+          502
+        );
+      }
+    },
+    proposePlanStep: async (): Promise<AiResponse<AiPlanStepProposal>> =>
+      errorResponse('Plan step proposals are not configured.', 501),
+    applyPlanStep: async (): Promise<AiResponse<AiPlanStepApplyResult>> =>
+      errorResponse('Plan step apply is not configured.', 501),
+  };
+};

--- a/src/lib/aiadapter/types.ts
+++ b/src/lib/aiadapter/types.ts
@@ -1,0 +1,66 @@
+export type AiError = {
+  message: string;
+  code?: string;
+  status?: number;
+  details?: unknown;
+};
+
+export type AiSuccessResponse<T> = {
+  ok: true;
+  data: T;
+};
+
+export type AiFailureResponse = {
+  ok: false;
+  error: AiError;
+};
+
+export type AiResponse<T> = AiSuccessResponse<T> | AiFailureResponse;
+
+export type AiEditProposal = {
+  patch: string;
+  summary?: string;
+};
+
+export type AiPlanStep = {
+  id: string;
+  title: string;
+  description?: string;
+};
+
+export type AiPlan = {
+  id: string;
+  title: string;
+  steps: AiPlanStep[];
+};
+
+export type AiPlanStepProposal = {
+  patch: string;
+  summary?: string;
+};
+
+export type AiPlanStepApplyResult = {
+  applied: boolean;
+  message?: string;
+  patch?: string;
+};
+
+export type AiStreamResponse = {
+  stream: ReadableStream<Uint8Array>;
+  status?: number;
+  headers?: HeadersInit;
+};
+
+export type AiPlanStepRequest = {
+  planId: string;
+  stepId: string;
+  payload: unknown;
+};
+
+export interface AiAdapter {
+  streamChat: (payload: unknown) => Promise<AiStreamResponse>;
+  proposeEdits: (payload: unknown) => Promise<AiResponse<AiEditProposal>>;
+  createPlan: (payload: unknown) => Promise<AiResponse<AiPlan>>;
+  proposePlanStep: (payload: AiPlanStepRequest) => Promise<AiResponse<AiPlanStepProposal>>;
+  applyPlanStep?: (payload: AiPlanStepRequest) => Promise<AiResponse<AiPlanStepApplyResult>>;
+}


### PR DESCRIPTION
### Motivation
- Introduce an OpenRouter-backed AI adapter to enable streaming chat, edit proposals, and plan creation via the Vercel AI SDK and OpenRouter/OpenAI-compatible models.
- Centralize OpenRouter environment parsing (API key, model defaults, timeouts) and keep the server-only restriction to avoid bundling into client code.

### Description
- Add shared AI adapter types in `src/lib/aiadapter/types.ts` and OpenRouter config parsing in `src/lib/aiadapter/openrouter/config.ts` (env keys, model defaults, timeout parsing).
- Implement `createOpenRouterAdapter` in `src/lib/aiadapter/openrouter/openrouter-adapter.ts` using `@ai-sdk/openai` + `ai` (`generateText`/`streamText`) for streaming and JSON response normalization (chat, edit proposals, plans) with SSE error streams.
- Update server entry `app/lib/ai/ai-adapter.ts` to import the new adapter, return the OpenRouter adapter when `OPENROUTER_API_KEY` is set, and retain `jsonResponse`/`streamResponse` helpers and server-only imports; re-export the shared types.
- Add runtime dependencies (`ai`, `@ai-sdk/openai`) to `package.json` and update lockfile to support the new adapter.

### Testing
- Ran `npm install ai @ai-sdk/openai` (initial attempt encountered postinstall script issues; re-run with scripts ignored succeeded), which updated `package.json`/`package-lock.json` and installed new packages.
- Ran `npm run build` to compile the Next app; the build failed with a TypeScript resolution error: `Cannot find module '@/app/payload-types'` in `app/lib/forge/data-adapter/payload-forge-adapter.ts`, preventing a full successful build (this is unrelated to the new adapter changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d8f4c838832db796ef3927e176f6)