### PR TITLE
Add Markdown paste plugin for Lexical writer editor

### DIFF
--- a/src/components/WriterWorkspace/editor/lexical/plugins/MarkdownPastePlugin.tsx
+++ b/src/components/WriterWorkspace/editor/lexical/plugins/MarkdownPastePlugin.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { $convertFromMarkdownString, TRANSFORMERS } from '@lexical/markdown';
+import {
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  PASTE_COMMAND,
+  RootNode,
+} from 'lexical';
+
+const MARKDOWN_HINTS = [
+  /^\s{0,3}#{1,6}\s/m,
+  /^\s{0,3}(?:\*|-|\+|\d+\.)\s+/m,
+  /^\s{0,3}>\s+/m,
+  /```[\s\S]*?```/m,
+  /`[^`]+`/,
+  /\[(.+?)\]\((.+?)\)/,
+  /(?:\*\*|__)(?=\S)([\s\S]*?)(?<=\S)(?:\*\*|__)/,
+  /(?:\*|_)(?=\S)([\s\S]*?)(?<=\S)(?:\*|_)/,
+];
+
+function isMarkdownLike(text: string) {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return MARKDOWN_HINTS.some((regex) => regex.test(trimmed));
+}
+
+export function MarkdownPastePlugin() {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerCommand<ClipboardEvent>(
+      PASTE_COMMAND,
+      (event) => {
+        const text = event?.clipboardData?.getData('text/plain') ?? '';
+        if (!text || !isMarkdownLike(text)) {
+          return false;
+        }
+
+        event?.preventDefault();
+
+        editor.update(() => {
+          const container = new RootNode();
+          $convertFromMarkdownString(text, TRANSFORMERS, container);
+          const nodes = container.getChildren();
+          if (!nodes.length) {
+            return;
+          }
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            selection.insertNodes(nodes);
+            return;
+          }
+          $getRoot().append(...nodes);
+        });
+
+        return true;
+      },
+      COMMAND_PRIORITY_LOW
+    );
+  }, [editor]);
+
+  return null;
+}

--- a/src/components/WriterWorkspace/editor/lexical/plugins/WriterPlugins.tsx
+++ b/src/components/WriterWorkspace/editor/lexical/plugins/WriterPlugins.tsx
@@ -4,6 +4,7 @@ import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
 import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import { TRANSFORMERS } from '@lexical/markdown';
+import { MarkdownPastePlugin } from './MarkdownPastePlugin';
 
 export function WriterPlugins() {
   return (
@@ -12,6 +13,7 @@ export function WriterPlugins() {
       <ListPlugin />
       <LinkPlugin />
       <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
+      <MarkdownPastePlugin />
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve the writer editor paste experience by detecting markdown-like clipboard content and importing it as rich nodes. 
- Reuse Lexical's existing markdown transformers so pasted markdown maps to the same node types produced by the editor shortcuts.

### Description
- Add `src/components/WriterWorkspace/editor/lexical/plugins/MarkdownPastePlugin.tsx` which registers a `PASTE_COMMAND` handler that inspects `text/plain` clipboard content, heuristically detects markdown via regex hints, and converts to Lexical nodes using `$convertFromMarkdownString` with `TRANSFORMERS` into a temporary `RootNode` before inserting into the editor. 
- Ensure the handler returns `false` for non-markdown clipboard content so the default paste behavior is preserved. 
- Register the plugin by importing and adding `<MarkdownPastePlugin />` to `src/components/WriterWorkspace/editor/lexical/plugins/WriterPlugins.tsx` alongside existing plugins.

### Testing
- Ran the build with `npm run build`, which failed due to an unrelated environment/missing dependency error: `Cannot find package '@payloadcms/next' imported from next.config.mjs`, so no full build/test result was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968057e2778832d88f1685945ff1164)