### PR TITLE
Add architecture boundaries and file placement docs

### DIFF
--- a/docs/architecture/BOUNDARIES.md
+++ b/docs/architecture/BOUNDARIES.md
@@ -1,0 +1,50 @@
+# Architecture Boundaries
+
+## Layer Model (Host → Shared → Domain → AI)
+
+**Host (app/)**
+- Next.js + PayloadCMS application code.
+- Owns runtime integration, API routes, and generated types.
+- **Host may import from src/** (shared/domain/ai).
+
+**Shared (src/shared/)**
+- Cross-domain types, utilities, and UI primitives.
+- Lowest common layer used by domain packages.
+- No dependencies on host or domain-specific packages.
+
+**Domains (src/forge/, src/writer/)**
+- Domain-specific types, stores, components, and libraries.
+- May depend on shared and AI layers.
+- **Forge ↔ Writer cross-imports are prohibited.**
+
+**AI (src/ai/)**
+- Shared AI infrastructure and domain AI adapters.
+- Can depend on shared types/utilities.
+- Domain layers can depend on AI, never the reverse.
+
+## North Star Placement Rule
+
+> **Place code in the lowest layer that can own it without depending on higher layers.**
+
+Practical guidance:
+- If it must reference PayloadCMS, Next.js, or runtime app wiring → **Host**.
+- If it is domain-specific and could ship in the package → **Domain**.
+- If it is reusable across domains → **Shared**.
+- If it is AI infrastructure or contracts → **AI**.
+
+## Import Direction Rules
+
+1. **Host may import from src/** (shared, domain, ai).
+2. **src/** may not import from **app/** or `app/payload-types.ts`.
+3. **Domains may import from shared and ai only.**
+4. **Domains may not import each other** (Forge ↔ Writer).
+5. **AI may not import from domains or host.**
+
+## Placement Checklist (for new files)
+
+- [ ] Does it reference PayloadCMS, Next.js routing, or app runtime wiring? → **Host**.
+- [ ] Is it reusable across Forge and Writer? → **Shared**.
+- [ ] Is it specific to Forge or Writer workflows? → **Domain**.
+- [ ] Is it AI infrastructure or AI contracts? → **AI**.
+- [ ] Does it violate import direction rules? → **Move it down** to the lowest valid layer.
+- [ ] **Verify `src/**` does not import `app/**` or `app/payload-types.ts`.**

--- a/docs/architecture/FILE-PLACEMENT.md
+++ b/docs/architecture/FILE-PLACEMENT.md
@@ -1,0 +1,36 @@
+# File Placement Decision Tree
+
+Use this decision tree to place new files consistently with the reorg plan and the boundary model.
+
+## Decision Tree
+
+1. **Does the file need Next.js, PayloadCMS, or runtime host wiring?**
+   - **Yes** → Place in **Host (app/)**.
+   - **No** → Continue.
+
+2. **Is it AI infrastructure, contracts, or domain AI adapters?**
+   - **Yes** → Place in **AI (src/ai/)**.
+   - **No** → Continue.
+
+3. **Is it reusable across Forge and Writer?**
+   - **Yes** → Place in **Shared (src/shared/)**.
+   - **No** → Continue.
+
+4. **Is it Forge- or Writer-specific?**
+   - **Forge** → Place in **Domain (src/forge/)**.
+   - **Writer** → Place in **Domain (src/writer/)**.
+
+## Quick Examples
+
+- PayloadCMS collections, API routes, or server wiring → **Host**.
+- AI adapters, model routing, streaming helpers → **AI**.
+- Shared types, UI primitives, utilities → **Shared**.
+- Forge graph editor or Writer workspace UI → **Domain**.
+
+## Non-Negotiable Boundary Rule
+
+- **`src/**` must not import `app/**` or `app/payload-types.ts`.**
+
+## Tie-Breaker: North Star Placement Rule
+
+When uncertain, place code in the **lowest layer that can own it without depending on higher layers**. If later reused across domains, **promote it upward** from domain → shared.


### PR DESCRIPTION
### Motivation

- Clarify the intended layer model and placement rules to guide the repository reorganization and prevent boundary violations. 
- Explicitly prohibit library code from depending on host types by enforcing that `src/**` must not import `app/**` or `app/payload-types.ts`. 
- Align wording and placement guidance with the existing `docs/reorg-discovery/*` artifacts and the north‑star placement rule.

### Description

- Add `docs/architecture/BOUNDARIES.md` describing the Host / Shared / Domain / AI layers, the “North Star Placement Rule”, import direction rules, and a placement checklist that includes the `src/**` → `app/**` prohibition. 
- Add `docs/architecture/FILE-PLACEMENT.md` containing a file placement decision tree (Host / AI / Shared / Domain), quick examples, the non‑negotiable import rule, and the tie‑breaker rule to promote items upward when needed. 
- Keep language consistent with the reorg discovery materials and the plan, and place both documents under `docs/architecture/`.

### Testing

- Ran `npm run build`, which failed due to a missing dependency (`Error: Cannot find package '@payloadcms/next'` referenced by `next.config.mjs`). 
- No other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69681e70c744832d857ded87d354d5f3)