### PR TITLE
Add TypeScript path aliases for shared modules and host

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,21 @@
     "isolatedModules": true,
     "allowJs": true,
     "paths": {
+      "@/shared/*": [
+        "./src/shared/*"
+      ],
+      "@/ai/*": [
+        "./src/ai/*"
+      ],
+      "@/forge/*": [
+        "./src/forge/*"
+      ],
+      "@/writer/*": [
+        "./src/writer/*"
+      ],
+      "@/host/*": [
+        "./app/lib/*"
+      ],
       "@/*": [
         "./*"
       ],

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -13,10 +13,16 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "types": ["node"]
+    "types": ["node"],
+    "paths": {
+      "@/shared/*": ["./src/shared/*"],
+      "@/ai/*": ["./src/ai/*"],
+      "@/forge/*": ["./src/forge/*"],
+      "@/writer/*": ["./src/writer/*"],
+      "@/host/*": ["./app/lib/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "app", "components", "styles", ".next"]
 }
-
 

--- a/tsconfig.next.json
+++ b/tsconfig.next.json
@@ -23,6 +23,11 @@
       }
     ],
     "paths": {
+      "@/shared/*": ["./src/shared/*"],
+      "@/ai/*": ["./src/ai/*"],
+      "@/forge/*": ["./src/forge/*"],
+      "@/writer/*": ["./src/writer/*"],
+      "@/host/*": ["./app/lib/*"],
       "@/*": ["./*"],
       "@magicborn/dialogue-forge/*": ["./src/*"]
     }
@@ -40,4 +45,3 @@
     "src"
   ]
 }
-


### PR DESCRIPTION
### Motivation

- Provide stable, readable import aliases for internal packages (`shared`, `ai`, `forge`, `writer`) and an optional host-only mapping for host app code.
- Ensure each build tool that uses its own TS config (Next.js, library build) sees the same path mappings so imports resolve consistently across dev and build.

### Description

- Added aliases `@/shared/*`, `@/ai/*`, `@/forge/*`, `@/writer/*` and the optional host-only `@/host/* -> app/lib/*` to the main TypeScript config in `tsconfig.json`.
- Mirrored the same path mappings into the Next.js config `tsconfig.next.json` so the Next build resolves the aliases.
- Added the same mappings into the library TS config `tsconfig.lib.json` so the library build and type generation respect the aliases.
- Inserted the mappings under the existing `compilerOptions.paths` structure to match the repo's TS config layout.

### Testing

- Ran `npm run build` (Next.js build); the build failed due to a missing dependency `@payloadcms/next` referenced by `next.config.mjs`, so alias changes themselves did not cause build errors but the repo build is blocked by the missing package.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69681f33928c832dbe1786f7ca262db7)