### PR TITLE
Add ESLint import boundary warnings for src

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,86 @@
+const baseRestrictedPatterns = [
+  "app/**",
+  "@/app/**",
+  "@magicborn/dialogue-forge/app/**",
+  "payload-types",
+  "**/payload-types",
+  "**/payload-types/**",
+];
+
+const forgeRestrictedPatterns = [
+  ...baseRestrictedPatterns,
+  "**/writer/**",
+  "@/src/writer/**",
+  "@magicborn/dialogue-forge/src/writer/**",
+  "src/writer/**",
+];
+
+const writerRestrictedPatterns = [
+  ...baseRestrictedPatterns,
+  "**/forge/**",
+  "@/src/forge/**",
+  "@magicborn/dialogue-forge/src/forge/**",
+  "src/forge/**",
+];
+
+const sharedRestrictedPatterns = [
+  ...baseRestrictedPatterns,
+  "**/forge/**",
+  "**/writer/**",
+  "@/src/forge/**",
+  "@/src/writer/**",
+  "@magicborn/dialogue-forge/src/forge/**",
+  "@magicborn/dialogue-forge/src/writer/**",
+  "src/forge/**",
+  "src/writer/**",
+];
+
+module.exports = {
+  root: true,
+  overrides: [
+    {
+      files: ["src/**/*.{js,jsx,ts,tsx}", "src/**/*.d.ts"],
+      rules: {
+        "no-restricted-imports": [
+          "warn",
+          {
+            patterns: baseRestrictedPatterns,
+          },
+        ],
+      },
+    },
+    {
+      files: ["src/forge/**/*.{js,jsx,ts,tsx}", "src/forge/**/*.d.ts"],
+      rules: {
+        "no-restricted-imports": [
+          "warn",
+          {
+            patterns: forgeRestrictedPatterns,
+          },
+        ],
+      },
+    },
+    {
+      files: ["src/writer/**/*.{js,jsx,ts,tsx}", "src/writer/**/*.d.ts"],
+      rules: {
+        "no-restricted-imports": [
+          "warn",
+          {
+            patterns: writerRestrictedPatterns,
+          },
+        ],
+      },
+    },
+    {
+      files: ["src/shared/**/*.{js,jsx,ts,tsx}", "src/shared/**/*.d.ts"],
+      rules: {
+        "no-restricted-imports": [
+          "warn",
+          {
+            patterns: sharedRestrictedPatterns,
+          },
+        ],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
### Motivation
- Enforce import boundaries between library `src/**` and host/demo `app/**` as well as internal layering to prevent accidental coupling.
- Phase 0: introduce these rules as warnings so existing code can be updated gradually.

### Description
- Add `.eslintrc.cjs` with `no-restricted-imports` overrides scoped to `src/**` and `src/*` subfolders.
- Disallow imports from `app/**` and various `payload-types` paths into `src/**` by adding base restricted patterns.
- Add stronger per-folder patterns so `src/forge/**` cannot import `src/writer/**`, `src/writer/**` cannot import `src/forge/**`, and `src/shared/**` cannot import `src/forge/**` or `src/writer/**`.
- All rules are configured at severity `"warn"` to match Phase 0 rollout.

### Testing
- Ran `npm run build` which is an automated build test and it failed with: `Cannot find package '@payloadcms/next' imported from next.config.mjs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69681f6be9ec832da87c25811124005e)