### PR TITLE
Update architecture docs: introduce domain/shared/ai layout and placement rules

### DIFF
--- a/docs/architecture/FILE-PLACEMENT.md
+++ b/docs/architecture/FILE-PLACEMENT.md
@@ -27,6 +27,14 @@ Use this decision tree to place new files consistently with the reorg plan and t
 - Shared types, UI primitives, utilities → **Shared**.
 - Forge graph editor or Writer workspace UI → **Domain**.
 
+## How to Place New Files (Checklist)
+
+- [ ] Needs Next.js, PayloadCMS, or host wiring? → **Host (app/)**.
+- [ ] Reused across Forge + Writer? → **Shared (src/shared/)**.
+- [ ] Forge- or Writer-specific? → **Domain (src/forge/, src/writer/)**.
+- [ ] AI infrastructure or AI contracts? → **AI (src/ai/)**.
+- [ ] Confirm import direction rules (`src/**` never imports `app/**` or `app/payload-types.ts`).
+
 ## Non-Negotiable Boundary Rule
 
 - **`src/**` must not import `app/**` or `app/payload-types.ts`.**


### PR DESCRIPTION
### Motivation
- Align the agent guide with the new repo layout and ownership model by surfacing `forge`/`writer` domain roots plus `shared` and `ai` layers.
- Make the placement decision explicit and enforce the boundary that `src/**` must never import `app/**` or `app/payload-types.ts`.
- Provide a short, actionable checklist to help contributors place new files consistently and preserve existing guidance about constants and type independence.

### Description
- Updated `agents.md` to add the North Star Placement Rule, the non‑negotiable import direction rule, and examples describing `src/forge`, `src/writer`, `src/shared`, and `src/ai` usage; updated path references to point to `src/shared/types/constants.ts` and domain/shared locations where appropriate.
- Reconciled and preserved existing rules about using exported constants and keeping library types independent of host app types while migrating guidance to the new domain/shared layout (examples and patterns updated to reference domain/shared folders).
- Added a short "How to Place New Files (Checklist)" to `docs/architecture/FILE-PLACEMENT.md` that mirrors the new rules and explicitly reminds contributors to confirm import direction constraints.

### Testing
- No automated tests were run because this is a documentation-only change (no code modified).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69681f71aa24832d86b97d849c26a006)