### PR TITLE
Switch choice edges to CSS-driven theming

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
@@ -332,7 +332,7 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
         ...e,
         style: {
           ...(e.style ?? {}),
-          stroke,
+          ...(stroke ? { stroke } : {}),
           strokeWidth: isInPath ? 4 : 3,
           opacity: isDimmed ? 0.4 : isInPath ? 1 : 0.9,
           strokeDasharray: isBackEdge ? '8 4' : undefined,

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode.tsx
@@ -32,9 +32,6 @@ interface ConditionalNodeData {
   layoutDirection?: LayoutDirection;
 }
 
-// Color scheme for conditional block edges
-const CONDITIONAL_COLORS = ['#3b82f6', '#8b5cf6', '#06b6d4', '#22c55e', '#f59e0b'];
-
 export function ConditionalNode({ data, selected }: NodeProps<ConditionalNodeData>) {
   const { node, flagSchema, characters = {}, ui = {}, layoutDirection = 'TB' } = data;
   const { isDimmed, isInPath, isStartNode, isEndNode } = ui;
@@ -161,7 +158,6 @@ export function ConditionalNode({ data, selected }: NodeProps<ConditionalNodeDat
           {/* Conditional Blocks */}
           <div className="px-4 py-3">
             {blocks.map((block, idx) => {
-              const color = CONDITIONAL_COLORS[idx % CONDITIONAL_COLORS.length];
               const blockType = block.type === FORGE_CONDITIONAL_BLOCK_TYPE.IF ? 'IF' : block.type === FORGE_CONDITIONAL_BLOCK_TYPE.ELSE_IF ? 'ELSE IF' : 'ELSE';
 
               // Get character if characterId is set
@@ -205,11 +201,12 @@ export function ConditionalNode({ data, selected }: NodeProps<ConditionalNodeDat
                     type="source"
                     position={Position.Right}
                     id={`block-${idx}`}
+                    data-choice-index={idx % 5}
                     style={{
                       top: `${handlePositions[idx] || 0}px`,
                       right: -8,
                     }}
-                    className="!bg-df-control-bg !border-df-control-border !w-3 !h-3 !rounded-full hover:!border-df-conditional-selected hover:!bg-df-conditional-selected/20"
+                    className="forge-choice-handle !bg-df-control-bg !border-df-control-border !w-3 !h-3 !rounded-full hover:!border-df-conditional-selected hover:!bg-df-conditional-selected/20"
                   />
                 </div>
               );
@@ -271,4 +268,3 @@ export function ConditionalNode({ data, selected }: NodeProps<ConditionalNodeDat
     </ContextMenu>
   );
 }
-

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNode.tsx
@@ -29,9 +29,6 @@ interface PlayerNodeData {
   layoutDirection?: LayoutDirection;
 }
 
-// Color scheme for choice edges (same as current implementation)
-const CHOICE_COLORS = ['#e94560', '#8b5cf6', '#06b6d4', '#22c55e', '#f59e0b'];
-
 export function PlayerNode({ data, selected }: NodeProps<PlayerNodeData>) {
   const { node, flagSchema, characters = {}, ui = {}, layoutDirection = 'TB' } = data;
   const { isDimmed, isInPath, isStartNode, isEndNode } = ui;
@@ -172,9 +169,6 @@ export function PlayerNode({ data, selected }: NodeProps<PlayerNodeData>) {
       {/* Choices */}
       <div className="px-4 py-3 space-y-2">
         {choices.map((choice, idx) => {
-          // Use calculated position or fallback
-          const choiceColor = CHOICE_COLORS[idx % CHOICE_COLORS.length];
-          
           return (
             <div 
               key={choice.id} 
@@ -212,13 +206,13 @@ export function PlayerNode({ data, selected }: NodeProps<PlayerNodeData>) {
                   type="source"
                   position={Position.Right}
                   id={`choice-${idx}`}
+                  data-choice-index={idx % 5}
                   style={{ 
                     top: `50%`,
                     transform: `translateY(-50%)`,
                     right: '-6px',
-                    borderColor: choiceColor,
                   }}
-                  className="!bg-df-control-bg !border-2 hover:!border-df-player-selected hover:!bg-df-player-selected/20 !w-3 !h-3 !rounded-full"
+                  className="forge-choice-handle !bg-df-control-bg !border-2 hover:!border-df-player-selected hover:!bg-df-player-selected/20 !w-3 !h-3 !rounded-full"
                 />
               </div>
             </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNodeFields.tsx
@@ -8,7 +8,6 @@ import { FlagSelector } from '@/forge/components/ForgeWorkspace/components/Graph
 import { EdgeIcon } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/shared/EdgeIcon';
 import { User, GitBranch } from 'lucide-react';
 import { validateCondition, parseCondition } from '@/forge/lib/yarn-converter/utils/condition-utils';
-import { CHOICE_COLORS } from '@/forge/lib/utils/forge-flow-helpers';
 import { useForgeEditorActions } from '@/forge/lib/graph-editor/hooks/useForgeEditorActions';
 
 interface PlayerNodeFieldsProps {
@@ -26,17 +25,6 @@ interface PlayerNodeFieldsProps {
   onFocusNode?: (nodeId: string) => void;
   setConditionInputs: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   setChoiceInputs: React.Dispatch<React.SetStateAction<Record<string, Partial<ForgeChoice>>>>;
-}
-
-function darkenColor(color: string): string {
-  const hex = color.replace('#', '');
-  const r = parseInt(hex.substr(0, 2), 16);
-  const g = parseInt(hex.substr(2, 2), 16);
-  const b = parseInt(hex.substr(4, 2), 16);
-  const darkR = Math.floor(r * 0.6);
-  const darkG = Math.floor(g * 0.6);
-  const darkB = Math.floor(b * 0.6);
-  return `rgb(${darkR}, ${darkG}, ${darkB})`;
 }
 
 export function PlayerNodeFields({
@@ -139,26 +127,22 @@ export function PlayerNodeFields({
           const displayText = localInput?.text !== undefined ? localInput.text : (debouncedInput?.text ?? choice.text ?? '');
           const displayNextNodeId = localInput?.nextNodeId !== undefined ? localInput.nextNodeId : (debouncedInput?.nextNodeId ?? choice.nextNodeId);
           
-          const choiceColor = CHOICE_COLORS[idx % CHOICE_COLORS.length];
-          const darkChoiceColor = darkenColor(choiceColor);
-          
+          const choiceIndex = idx % 5;
+
           return (
             <div 
               key={choice.id} 
+              data-choice-index={choiceIndex}
               className={`rounded p-2 space-y-2 ${
                 hasCondition 
                   ? 'bg-blue-500/10 border-2 border-blue-500/50' 
-                  : 'bg-[#12121a] border border-[#2a2a3e]'
+                  : 'bg-[#12121a] border border-[#2a2a3e] forge-choice-border-top'
               }`}
-              style={{
-                borderTopColor: hasCondition ? undefined : choiceColor
-              }}
             >
               <div 
-                className="flex items-center gap-2 pb-2 border-b"
-                style={{
-                  borderBottomColor: hasCondition ? '#2a2a3e' : choiceColor
-                }}
+                className={`flex items-center gap-2 pb-2 border-b ${
+                  hasCondition ? 'border-[#2a2a3e]' : 'forge-choice-border-bottom'
+                }`}
               >
                 <label className="flex items-center cursor-pointer">
                   <div className="relative">
@@ -202,14 +186,10 @@ export function PlayerNodeFields({
                         onFocusNode(displayNextNodeId);
                       }
                     }}
-                    className="transition-colors cursor-pointer flex-shrink-0"
+                    className="forge-choice-color transition-colors cursor-pointer flex-shrink-0"
                     title={`Focus on node: ${displayNextNodeId}`}
                   >
-                    <EdgeIcon 
-                      size={16} 
-                      color={CHOICE_COLORS[idx % CHOICE_COLORS.length]} 
-                      className="transition-colors"
-                    />
+                    <EdgeIcon size={16} className="transition-colors" />
                   </button>
                 )}
                 <div className="relative flex-1">
@@ -223,24 +203,9 @@ export function PlayerNodeFields({
                       }));
                       handleUpdateChoice(idx, { nextNodeId: newNextNodeId });
                     }}
-                    className="w-full bg-[#0d0d14] border rounded px-2 py-1 pr-8 text-xs text-gray-300 outline-none"
-                    style={{
-                      borderColor: displayNextNodeId ? darkChoiceColor : '#2a2a3e',
-                    }}
-                    onFocus={(event) => {
-                      if (displayNextNodeId) {
-                        event.target.style.borderColor = darkChoiceColor;
-                      } else {
-                        event.target.style.borderColor = '#e94560';
-                      }
-                    }}
-                    onBlur={(event) => {
-                      if (displayNextNodeId) {
-                        event.target.style.borderColor = darkChoiceColor;
-                      } else {
-                        event.target.style.borderColor = '#2a2a3e';
-                      }
-                    }}
+                    data-choice-index={choiceIndex}
+                    data-has-next={displayNextNodeId ? 'true' : 'false'}
+                    className="forge-choice-input w-full bg-[#0d0d14] border rounded px-2 py-1 pr-8 text-xs text-gray-300 outline-none"
                   >
                     <option value="">— Select target —</option>
                     {graph.flow?.nodes?.map((n) => (
@@ -249,9 +214,8 @@ export function PlayerNodeFields({
                   </select>
                   {displayNextNodeId && (
                     <div 
-                      className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none"
+                      className="forge-choice-color absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none"
                       title={`Connects to node: ${displayNextNodeId}`}
-                      style={{ color: CHOICE_COLORS[idx % CHOICE_COLORS.length] }}
                     >
                       <GitBranch size={14} />
                     </div>
@@ -282,12 +246,11 @@ export function PlayerNodeFields({
                     // Also update immediately for better UX
                     handleUpdateChoice(idx, { text: newText });
                   }}
-                  className={`w-full bg-[#0d0d14] border rounded px-3 py-2 text-sm outline-none transition-colors ${
+                  data-choice-index={choiceIndex}
+                  data-has-text={displayText ? 'true' : 'false'}
+                  className={`forge-choice-input w-full bg-[#0d0d14] border rounded px-3 py-2 text-sm outline-none transition-colors ${
                     hasCondition ? 'text-gray-100' : 'text-gray-200'
                   }`}
-                  style={{
-                    borderColor: displayText ? darkChoiceColor : '#2a2a3e'
-                  }}
                   placeholder="Dialogue text..."
                 />
               </div>

--- a/src/forge/lib/utils/forge-edge-styles.ts
+++ b/src/forge/lib/utils/forge-edge-styles.ts
@@ -1,8 +1,6 @@
 // src/utils/forge-edge-style.ts
 import type { ForgeReactFlowEdge, ForgeReactFlowNode, ForgeNodeType } from '@/src/types/forge/forge-graph';
 
-export const CHOICE_COLORS = ['#e94560', '#8b5cf6', '#06b6d4', '#22c55e', '#f59e0b'];
-
 export const TYPE_COLORS: Record<ForgeNodeType, string> = {
   ACT: '#8b5cf6',
   CHAPTER: '#06b6d4',
@@ -20,15 +18,6 @@ export function edgeColorFor(
   edge: ForgeReactFlowEdge,
   sourceNode?: ForgeReactFlowNode
 ): string {
-  const handle = edge.sourceHandle ?? '';
-  if (handle.startsWith('choice-')) {
-    const idx = parseInt(handle.replace('choice-', ''), 10);
-    return CHOICE_COLORS[(Number.isFinite(idx) ? idx : 0) % CHOICE_COLORS.length];
-  }
-  if (handle.startsWith('block-')) {
-    const idx = parseInt(handle.replace('block-', ''), 10);
-    return CHOICE_COLORS[(Number.isFinite(idx) ? idx : 0) % CHOICE_COLORS.length];
-  }
   // Check source node type from data if available
   if (sourceNode?.data?.type) {
     return TYPE_COLORS[sourceNode.data.type as ForgeNodeType] ?? '#9ca3af';

--- a/src/forge/lib/utils/forge-flow-helpers.ts
+++ b/src/forge/lib/utils/forge-flow-helpers.ts
@@ -19,12 +19,6 @@ import {
   FORGE_GRAPH_KIND,
 } from '@/forge/types/forge-graph';
 
-/**
- * Choice palette (used for Player/Conditional multi-branches)
- * Keep this consistent with your existing ChoiceEdge visuals.
- */
-export const CHOICE_COLORS = ['#e94560', '#8b5cf6', '#06b6d4', '#22c55e', '#f59e0b'];
-
 export type LayoutDirection = 'TB' | 'LR';
 
 export enum Prefixes {
@@ -376,18 +370,16 @@ export function insertNodeBetweenEdge(
 
 /**
  * Utility to compute visual stroke color for a given edge.
- * - choice-/block- handles use CHOICE_COLORS[idx]
+ * - choice-/block- handles should use CSS choice variables instead of inline colors
  * - otherwise use the source node type palette (matches your NPCEdgeV2 intent)
  */
-export function edgeStrokeColor(edge: ForgeReactFlowEdge, sourceType?: string): string {
+export function edgeStrokeColor(edge: ForgeReactFlowEdge, sourceType?: string): string | undefined {
   const handle = edge.sourceHandle ?? '';
   if (handle.startsWith(Prefixes.CHOICE)) {
-    const idx = parseInt(handle.replace(Prefixes.CHOICE, ''), 10);
-    return CHOICE_COLORS[(Number.isFinite(idx) ? idx : 0) % CHOICE_COLORS.length];
+    return undefined;
   }
   if (handle.startsWith(Prefixes.BLOCK)) {
-    const idx = parseInt(handle.replace(Prefixes.BLOCK, ''), 10);
-    return CHOICE_COLORS[(Number.isFinite(idx) ? idx : 0) % CHOICE_COLORS.length];
+    return undefined;
   }
 
   // Type palette aligned with edgeColorFor in forge-edge-styles.ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { CharacterSelector } from '@/forge/components/ForgeWorkspace/components/
 
 // Export styles
 import './styles/scrollbar.css';
+import './styles/graph.css';
 import './styles/themes.css';
 
 // Export all types

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -1,0 +1,82 @@
+.dialogue-graph-editor [data-choice-index] {
+  --edge-color: var(--edge-choice-1);
+  --edge-color-muted: color-mix(in oklab, var(--edge-color) 60%, black);
+}
+
+.dialogue-graph-editor [data-choice-index="0"] {
+  --edge-color: var(--edge-choice-1);
+}
+
+.dialogue-graph-editor [data-choice-index="1"] {
+  --edge-color: var(--edge-choice-2);
+}
+
+.dialogue-graph-editor [data-choice-index="2"] {
+  --edge-color: var(--edge-choice-3);
+}
+
+.dialogue-graph-editor [data-choice-index="3"] {
+  --edge-color: var(--edge-choice-4);
+}
+
+.dialogue-graph-editor [data-choice-index="4"] {
+  --edge-color: var(--edge-choice-5);
+}
+
+.dialogue-graph-editor .forge-choice-color {
+  color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-border {
+  border-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-border-top {
+  border-top-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-border-bottom {
+  border-bottom-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-handle {
+  border-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-input {
+  border-color: #2a2a3e;
+}
+
+.dialogue-graph-editor .forge-choice-input[data-has-next="true"] {
+  border-color: var(--edge-color-muted);
+}
+
+.dialogue-graph-editor .forge-choice-input[data-has-text="true"] {
+  border-color: var(--edge-color-muted);
+}
+
+.dialogue-graph-editor .forge-choice-input:focus {
+  border-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-edge .forge-edge-path {
+  stroke: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-edge.is-loop:not(.is-dimmed) .forge-edge-path {
+  stroke: var(--color-df-edge-loop);
+}
+
+.dialogue-graph-editor .forge-choice-edge.is-dimmed .forge-edge-path {
+  stroke: var(--color-df-edge-dimmed);
+}
+
+.dialogue-graph-editor .forge-choice-edge .forge-choice-arrow {
+  stroke: var(--edge-color);
+  fill: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-edge.is-loop:not(.is-dimmed) .forge-choice-arrow {
+  stroke: var(--color-df-edge-loop);
+  fill: var(--color-df-edge-loop);
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -77,6 +77,11 @@
   --color-df-edge-choice-5: oklch(0.55 0.10 45);
   --color-df-edge-loop: oklch(0.60 0.12 60);
   --color-df-edge-dimmed: oklch(0.32 0 0);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   --color-df-error: oklch(0.65 0.20 25);
   --color-df-error-bg: oklch(0.28 0.08 25);
@@ -174,6 +179,11 @@ html[data-theme='dark-fantasy'] {
   --color-df-edge-choice-5: oklch(0.55 0.10 45);
   --color-df-edge-loop: oklch(0.60 0.12 60);
   --color-df-edge-dimmed: oklch(0.32 0 0);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status Colors */
   --color-df-error: oklch(0.65 0.20 25);
@@ -278,6 +288,11 @@ html[data-theme='light'] {
   --color-df-edge-choice-5: oklch(0.50 0.15 45);
   --color-df-edge-loop: oklch(0.45 0.15 60);
   --color-df-edge-dimmed: oklch(0.75 0.02 250);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.45 0.22 25);
@@ -382,6 +397,11 @@ html[data-theme='cyberpunk'] {
   --color-df-edge-choice-5: oklch(0.60 0.25 60);
   --color-df-edge-loop: oklch(0.65 0.25 30);
   --color-df-edge-dimmed: oklch(0.25 0.05 280);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.60 0.25 25);
@@ -486,6 +506,11 @@ html[data-theme='darcula'] {
   --color-df-edge-choice-5: oklch(0.50 0.12 300);
   --color-df-edge-loop: oklch(0.50 0.12 30);
   --color-df-edge-dimmed: oklch(0.25 0.01 250);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.55 0.18 25);
@@ -590,6 +615,11 @@ html[data-theme='high-contrast'] {
   --color-df-edge-choice-5: oklch(0.70 0.25 300);
   --color-df-edge-loop: oklch(0.70 0.25 30);
   --color-df-edge-dimmed: oklch(0.40 0.02 250);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.70 0.25 25);
@@ -694,6 +724,11 @@ html[data-theme='girly'] {
   --color-df-edge-choice-5: oklch(0.60 0.18 20);
   --color-df-edge-loop: oklch(0.60 0.18 30);
   --color-df-edge-dimmed: oklch(0.30 0.02 330);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.60 0.20 20);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,6 +2,7 @@
 
 /* Import dialogue-forge theme */
 @import './themes.css';
+@import './graph.css';
 @import './scrollbar.css';
 
 /* Source paths for Tailwind content detection */

--- a/styles/graph.css
+++ b/styles/graph.css
@@ -1,0 +1,82 @@
+.dialogue-graph-editor [data-choice-index] {
+  --edge-color: var(--edge-choice-1);
+  --edge-color-muted: color-mix(in oklab, var(--edge-color) 60%, black);
+}
+
+.dialogue-graph-editor [data-choice-index="0"] {
+  --edge-color: var(--edge-choice-1);
+}
+
+.dialogue-graph-editor [data-choice-index="1"] {
+  --edge-color: var(--edge-choice-2);
+}
+
+.dialogue-graph-editor [data-choice-index="2"] {
+  --edge-color: var(--edge-choice-3);
+}
+
+.dialogue-graph-editor [data-choice-index="3"] {
+  --edge-color: var(--edge-choice-4);
+}
+
+.dialogue-graph-editor [data-choice-index="4"] {
+  --edge-color: var(--edge-choice-5);
+}
+
+.dialogue-graph-editor .forge-choice-color {
+  color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-border {
+  border-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-border-top {
+  border-top-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-border-bottom {
+  border-bottom-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-handle {
+  border-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-input {
+  border-color: #2a2a3e;
+}
+
+.dialogue-graph-editor .forge-choice-input[data-has-next="true"] {
+  border-color: var(--edge-color-muted);
+}
+
+.dialogue-graph-editor .forge-choice-input[data-has-text="true"] {
+  border-color: var(--edge-color-muted);
+}
+
+.dialogue-graph-editor .forge-choice-input:focus {
+  border-color: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-edge .forge-edge-path {
+  stroke: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-edge.is-loop:not(.is-dimmed) .forge-edge-path {
+  stroke: var(--color-df-edge-loop);
+}
+
+.dialogue-graph-editor .forge-choice-edge.is-dimmed .forge-edge-path {
+  stroke: var(--color-df-edge-dimmed);
+}
+
+.dialogue-graph-editor .forge-choice-edge .forge-choice-arrow {
+  stroke: var(--edge-color);
+  fill: var(--edge-color);
+}
+
+.dialogue-graph-editor .forge-choice-edge.is-loop:not(.is-dimmed) .forge-choice-arrow {
+  stroke: var(--color-df-edge-loop);
+  fill: var(--color-df-edge-loop);
+}

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -77,6 +77,11 @@
   --color-df-edge-choice-5: oklch(0.55 0.10 45);
   --color-df-edge-loop: oklch(0.60 0.12 60);
   --color-df-edge-dimmed: oklch(0.32 0 0);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   --color-df-error: oklch(0.65 0.20 25);
   --color-df-error-bg: oklch(0.28 0.08 25);
@@ -174,6 +179,11 @@ html[data-theme='dark-fantasy'] {
   --color-df-edge-choice-5: oklch(0.55 0.10 45);
   --color-df-edge-loop: oklch(0.60 0.12 60);
   --color-df-edge-dimmed: oklch(0.32 0 0);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status Colors */
   --color-df-error: oklch(0.65 0.20 25);
@@ -278,6 +288,11 @@ html[data-theme='light'] {
   --color-df-edge-choice-5: oklch(0.50 0.15 45);
   --color-df-edge-loop: oklch(0.45 0.15 60);
   --color-df-edge-dimmed: oklch(0.75 0.02 250);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.45 0.22 25);
@@ -382,6 +397,11 @@ html[data-theme='cyberpunk'] {
   --color-df-edge-choice-5: oklch(0.60 0.25 60);
   --color-df-edge-loop: oklch(0.65 0.25 30);
   --color-df-edge-dimmed: oklch(0.25 0.05 280);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.60 0.25 25);
@@ -486,6 +506,11 @@ html[data-theme='darcula'] {
   --color-df-edge-choice-5: oklch(0.50 0.12 300);
   --color-df-edge-loop: oklch(0.50 0.12 30);
   --color-df-edge-dimmed: oklch(0.25 0.01 250);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.55 0.18 25);
@@ -590,6 +615,11 @@ html[data-theme='high-contrast'] {
   --color-df-edge-choice-5: oklch(0.70 0.25 300);
   --color-df-edge-loop: oklch(0.70 0.25 30);
   --color-df-edge-dimmed: oklch(0.40 0.02 250);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.70 0.25 25);
@@ -694,6 +724,11 @@ html[data-theme='girly'] {
   --color-df-edge-choice-5: oklch(0.60 0.18 20);
   --color-df-edge-loop: oklch(0.60 0.18 30);
   --color-df-edge-dimmed: oklch(0.30 0.02 330);
+  --edge-choice-1: var(--color-df-edge-choice-1);
+  --edge-choice-2: var(--color-df-edge-choice-2);
+  --edge-choice-3: var(--color-df-edge-choice-3);
+  --edge-choice-4: var(--color-df-edge-choice-4);
+  --edge-choice-5: var(--color-df-edge-choice-5);
 
   /* Status */
   --color-df-error: oklch(0.60 0.20 20);


### PR DESCRIPTION
### Motivation
- Move choice/conditional edge coloring from hard-coded arrays into theme-level CSS variables so colors can be mapped per theme and updated without touching JS/TS.
- Replace inline color usage with semantic `data-choice-index` attributes so node UI and SVG edges derive color from CSS, making theming consistent and simpler.

### Description
- Remove inline `CHOICE_COLORS` usage and palette constants from `src/forge/lib/utils/forge-flow-helpers.ts` and `src/forge/lib/utils/forge-edge-styles.ts`, and stop returning inline choice colors for choice/block handles in `edgeStrokeColor`/`edgeColorFor` helpers.
- Add CSS mapping files `src/styles/graph.css` and `styles/graph.css` that map `[data-choice-index=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69697afd57ac832d83dd308010441d08)