### PR TITLE
Use data-attribute driven node styles and generic CSS variables

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActNode.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/shared/ui/context-menu';
 import type { ShellNodeData } from '@/forge/lib/graph-editor/hooks/useForgeFlowEditorShell';
 import { useForgeEditorActions } from '@/forge/lib/graph-editor/hooks/useForgeEditorActions';
+import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 
 export function ActNode({ data, selected, id }: NodeProps<ShellNodeData>) {
   const { node, ui = {} } = data;
@@ -19,34 +20,32 @@ export function ActNode({ data, selected, id }: NodeProps<ShellNodeData>) {
   const summary = node.content;
   
   const actions = useForgeEditorActions();
-
-  // Glow effect based on selection and path state - blue for acts
-  const glowClass = selected 
-    ? 'shadow-[0_0_20px_rgba(59,130,246,0.6)]' // blue glow
-    : isInPath 
-      ? 'shadow-[0_0_12px_rgba(59,130,246,0.4)]' 
-      : '';
+  const nodeType = node.type ?? FORGE_NODE_TYPE.ACT;
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div
           onContextMenu={(e) => e.stopPropagation()}
-          className={`min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm bg-df-node-bg transition-all duration-200 ${
-            selected ? 'border-blue-500' : 'border-df-node-border'
-          } ${isDimmed ? 'opacity-30' : ''} ${glowClass}`}
+          data-node-type={nodeType}
+          data-selected={selected ? 'true' : 'false'}
+          data-in-path={isInPath ? 'true' : 'false'}
+          data-dimmed={isDimmed ? 'true' : 'false'}
+          data-start="false"
+          data-end="false"
+          className="forge-node min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm transition-all duration-200 border-node bg-node text-node"
         >
           <Handle
             type="target"
             position={Position.Left}
-            className="!bg-df-control-bg !border-df-control-border !w-3 !h-3"
+            className="node-handle !w-3 !h-3"
           />
-          <div className="px-3 py-2 border-b border-df-node-border flex items-center gap-2 bg-blue-500/10">
-            <div className="h-8 w-8 rounded-full flex items-center justify-center text-blue-500 border border-blue-500/30 bg-df-node-bg/40">
+          <div className="px-3 py-2 border-b border-node flex items-center gap-2 bg-node-header">
+            <div className="h-8 w-8 rounded-full flex items-center justify-center border border-node bg-node">
               <Layers size={16} />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="text-xs uppercase tracking-wide text-blue-500/70">Act</div>
+              <div className="text-xs uppercase tracking-wide">Act</div>
               <div className="text-sm font-semibold text-df-text-primary truncate">{title}</div>
             </div>
           </div>
@@ -62,7 +61,7 @@ export function ActNode({ data, selected, id }: NodeProps<ShellNodeData>) {
           <Handle
             type="source"
             position={Position.Right}
-            className="!bg-df-control-bg !border-df-control-border !w-3 !h-3"
+            className="node-handle !w-3 !h-3"
           />
         </div>
       </ContextMenuTrigger>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterNode.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/shared/ui/context-menu';
 import type { ShellNodeData } from '@/forge/lib/graph-editor/hooks/useForgeFlowEditorShell';
 import { useForgeEditorActions } from '@/forge/lib/graph-editor/hooks/useForgeEditorActions';
+import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 
 export function ChapterNode({ data, selected, id }: NodeProps<ShellNodeData>) {
   const { node, ui = {} } = data;
@@ -19,34 +20,32 @@ export function ChapterNode({ data, selected, id }: NodeProps<ShellNodeData>) {
   const summary = node.content;
   
   const actions = useForgeEditorActions();
-
-  // Glow effect based on selection and path state - green for chapters
-  const glowClass = selected 
-    ? 'shadow-[0_0_20px_rgba(16,185,129,0.6)]' // emerald glow
-    : isInPath 
-      ? 'shadow-[0_0_12px_rgba(16,185,129,0.4)]' 
-      : '';
+  const nodeType = node.type ?? FORGE_NODE_TYPE.CHAPTER;
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div
           onContextMenu={(e) => e.stopPropagation()}
-          className={`min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm bg-df-node-bg transition-all duration-200 ${
-            selected ? 'border-emerald-500' : 'border-df-node-border'
-          } ${isDimmed ? 'opacity-30' : ''} ${glowClass}`}
+          data-node-type={nodeType}
+          data-selected={selected ? 'true' : 'false'}
+          data-in-path={isInPath ? 'true' : 'false'}
+          data-dimmed={isDimmed ? 'true' : 'false'}
+          data-start="false"
+          data-end="false"
+          className="forge-node min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm transition-all duration-200 border-node bg-node text-node"
         >
           <Handle
             type="target"
             position={Position.Left}
-            className="!bg-df-control-bg !border-df-control-border !w-3 !h-3"
+            className="node-handle !w-3 !h-3"
           />
-          <div className="px-3 py-2 border-b border-df-node-border flex items-center gap-2 bg-emerald-500/10">
-            <div className="h-8 w-8 rounded-full flex items-center justify-center text-emerald-500 border border-emerald-500/30 bg-df-node-bg/40">
+          <div className="px-3 py-2 border-b border-node flex items-center gap-2 bg-node-header">
+            <div className="h-8 w-8 rounded-full flex items-center justify-center border border-node bg-node">
               <BookOpen size={16} />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="text-xs uppercase tracking-wide text-emerald-500/70">Chapter</div>
+              <div className="text-xs uppercase tracking-wide">Chapter</div>
               <div className="text-sm font-semibold text-df-text-primary truncate">{title}</div>
             </div>
           </div>
@@ -62,7 +61,7 @@ export function ChapterNode({ data, selected, id }: NodeProps<ShellNodeData>) {
           <Handle
             type="source"
             position={Position.Right}
-            className="!bg-df-control-bg !border-df-control-border !w-3 !h-3"
+            className="node-handle !w-3 !h-3"
           />
         </div>
       </ContextMenuTrigger>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNode.tsx
@@ -22,7 +22,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/src/shared/ui/context-menu';
-import { ForgeNode, FORGE_CONDITIONAL_BLOCK_TYPE } from '@/forge/types/forge-graph';
+import { ForgeNode, FORGE_CONDITIONAL_BLOCK_TYPE, FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 import { ShellNodeData } from '@/forge/lib/graph-editor/hooks/useForgeFlowEditorShell';
 
 // ============================================================================
@@ -70,21 +70,7 @@ export function CharacterNode({ data, selected }: NodeProps<CharacterNodeData>) 
   const targetPosition = isHorizontal ? Position.Left : Position.Top;
   const sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
 
-  // Border color based on state
-  const borderClass = selected 
-    ? 'border-df-npc-selected shadow-lg shadow-df-glow'
-    : isStartNode 
-      ? 'border-df-start shadow-md'
-      : isEndNode 
-        ? 'border-df-end shadow-md'
-        : 'border-df-npc-border';
-
-  // Header background based on node type
-  const headerBgClass = isStartNode 
-    ? 'bg-df-start-bg' 
-    : isEndNode 
-      ? 'bg-df-end-bg' 
-      : 'bg-df-npc-header';
+  const nodeType = node.type ?? FORGE_NODE_TYPE.CHARACTER;
 
   // Content preview (truncated)
   const contentPreview = node.content?.length && node.content.length > 60 
@@ -96,20 +82,25 @@ export function CharacterNode({ data, selected }: NodeProps<CharacterNodeData>) 
       <ContextMenuTrigger asChild>
         <div 
           onContextMenu={(e) => e.stopPropagation()}
-          className={`rounded-lg border-2 transition-all duration-300 ${borderClass} ${isInPath ? 'border-df-node-selected/70' : ''} bg-df-npc-bg min-w-[320px] max-w-[450px] relative overflow-hidden`}
-          style={isDimmed ? { opacity: 0.35, filter: 'saturate(0.3)' } : undefined}
+          data-node-type={nodeType}
+          data-selected={selected ? 'true' : 'false'}
+          data-in-path={isInPath ? 'true' : 'false'}
+          data-dimmed={isDimmed ? 'true' : 'false'}
+          data-start={isStartNode ? 'true' : 'false'}
+          data-end={isEndNode ? 'true' : 'false'}
+          className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[320px] max-w-[450px] relative overflow-hidden"
         >
       {/* Input handle */}
       <Handle 
         type="target" 
         position={targetPosition} 
-        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full"
+        className="node-handle !w-4 !h-4 !rounded-full"
       />
       
       {/* Health Bar Style Header */}
-      <div className={`${headerBgClass} border-b-2 border-df-npc-border px-3 py-2.5 flex items-center gap-3 relative`}>
+      <div className="bg-node-header border-b-2 border-node px-3 py-2.5 flex items-center gap-3 relative">
         {/* Large Avatar - Left side */}
-        <div className="w-14 h-14 rounded-full bg-df-npc-bg border-[3px] border-df-npc-border flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
+        <div className="w-14 h-14 rounded-full bg-node border-[3px] border-node flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
           {avatar}
         </div>
         
@@ -181,7 +172,7 @@ export function CharacterNode({ data, selected }: NodeProps<CharacterNodeData>) 
         type="source" 
         position={sourcePosition} 
         id="next"
-        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full hover:!border-df-npc-selected hover:!bg-df-npc-selected/20"
+        className="node-handle !w-4 !h-4 !rounded-full"
       />
         </div>
       </ContextMenuTrigger>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Handle, Position, NodeProps, useUpdateNodeInternals } from 'reactflow';
 import type { ForgeCondition, ForgeConditionalBlock, ForgeNode } from '@/forge/types/forge-graph';
-import { CONDITION_VALUE_TYPE, FORGE_CONDITIONAL_BLOCK_TYPE } from '@/forge/types/forge-graph';
+import { FORGE_CONDITIONAL_BLOCK_TYPE, FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 import { GitBranch, Play, Flag, Hash, Code, Edit3, Trash2, Plus } from 'lucide-react';
 import { FlagSchema } from '@/forge/types/flags';
 import { ForgeCharacter } from '@/forge/types/characters';
@@ -79,44 +79,35 @@ export function ConditionalNode({ data, selected }: NodeProps<ConditionalNodeDat
     }
   }, [blocks.length, node.id, updateNodeInternals]);
 
-  // Border color based on state
-  const borderClass = selected
-    ? 'border-df-conditional-border shadow-lg shadow-df-glow'
-    : isStartNode
-      ? 'border-df-start shadow-md'
-      : isEndNode
-        ? 'border-df-end shadow-md'
-        : 'border-df-conditional-border';
-
-  // Header background for conditional nodes
-  const headerBgClass = isStartNode
-    ? 'bg-df-start-bg'
-    : isEndNode
-      ? 'bg-df-end-bg'
-      : 'bg-df-conditional-header';
+  const nodeType = node.type ?? FORGE_NODE_TYPE.CONDITIONAL;
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div
           onContextMenu={(e) => e.stopPropagation()}
-          className={`rounded-lg border-2 transition-all duration-300 ${borderClass} ${isInPath ? 'border-df-conditional-border/70' : ''} bg-df-conditional-bg min-w-[320px] max-w-[450px] relative overflow-hidden`}
-          style={isDimmed ? { opacity: 0.35, filter: 'saturate(0.3)' } : undefined}
+          data-node-type={nodeType}
+          data-selected={selected ? 'true' : 'false'}
+          data-in-path={isInPath ? 'true' : 'false'}
+          data-dimmed={isDimmed ? 'true' : 'false'}
+          data-start={isStartNode ? 'true' : 'false'}
+          data-end={isEndNode ? 'true' : 'false'}
+          className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[320px] max-w-[450px] relative overflow-hidden"
         >
           {/* Input handle - position based on layout direction */}
           <Handle
             type="target"
             position={targetPosition}
-            className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full"
+            className="node-handle !w-4 !h-4 !rounded-full"
           />
 
           {/* Health Bar Style Header */}
           <div
             ref={headerRef}
-            className={`${headerBgClass} border-b-2 border-df-conditional-border px-3 py-2.5 flex items-center gap-3 relative`}
+            className="bg-node-header border-b-2 border-node px-3 py-2.5 flex items-center gap-3 relative"
           >
             {/* Icon Placeholder - Left side (no avatar for conditional) */}
-            <div className="w-14 h-14 rounded-full bg-df-conditional-bg border-[3px] border-df-conditional-border flex items-center justify-center shadow-lg flex-shrink-0">
+            <div className="w-14 h-14 rounded-full bg-node border-[3px] border-node flex items-center justify-center shadow-lg flex-shrink-0">
               <Code size={20} className="text-df-conditional-selected" />
             </div>
 
@@ -206,7 +197,7 @@ export function ConditionalNode({ data, selected }: NodeProps<ConditionalNodeDat
                       top: `${handlePositions[idx] || 0}px`,
                       right: -8,
                     }}
-                    className="forge-choice-handle !bg-df-control-bg !border-df-control-border !w-3 !h-3 !rounded-full hover:!border-df-conditional-selected hover:!bg-df-conditional-selected/20"
+                    className="forge-choice-handle !w-3 !h-3 !rounded-full"
                   />
                 </div>
               );

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/DetourNode/DetourNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/DetourNode/DetourNode.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/shared/ui/context-menu';
 import { useForgeEditorActions } from '@/forge/lib/graph-editor/hooks/useForgeEditorActions';
 import type { ForgeNode } from '@/forge/types/forge-graph';
+import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 
 interface DetourNodeData {
   node: ForgeNode;
@@ -42,12 +43,7 @@ export function DetourNode({ data, selected }: NodeProps<DetourNodeData>) {
   const isHorizontal = layoutDirection === 'LR';
   const targetPosition = isHorizontal ? Position.Left : Position.Top;
   const sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
-
-  const borderClass = selected 
-    ? 'border-df-storylet-border shadow-lg shadow-df-glow'
-    : 'border-df-storylet-border';
-
-  const headerBgClass = 'bg-df-storylet-header';
+  const nodeType = node.type ?? FORGE_NODE_TYPE.DETOUR;
 
   return (
     <ContextMenu>
@@ -58,17 +54,22 @@ export function DetourNode({ data, selected }: NodeProps<DetourNodeData>) {
             e.stopPropagation();
             if (node.id) actions.openNodeEditor(node.id);
           }}
-          className={`rounded-lg border-2 transition-all duration-300 ${borderClass} ${isInPath ? 'border-df-storylet-border/70' : ''} bg-df-storylet-bg min-w-[280px] max-w-[350px] relative overflow-hidden`}
-          style={isDimmed ? { opacity: 0.35, filter: 'saturate(0.3)' } : undefined}
+          data-node-type={nodeType}
+          data-selected={selected ? 'true' : 'false'}
+          data-in-path={isInPath ? 'true' : 'false'}
+          data-dimmed={isDimmed ? 'true' : 'false'}
+          data-start={isStartNode ? 'true' : 'false'}
+          data-end={isEndNode ? 'true' : 'false'}
+          className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[280px] max-w-[350px] relative overflow-hidden"
         >
       <Handle 
         type="target" 
         position={targetPosition} 
-        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full"
+        className="node-handle !w-4 !h-4 !rounded-full"
       />
       
-      <div className={`${headerBgClass} border-b-2 border-df-storylet-border px-3 py-2.5 flex items-center gap-3 relative`}>
-        <div className="w-14 h-14 rounded-full bg-df-storylet-bg border-[3px] border-df-storylet-border flex items-center justify-center shadow-lg flex-shrink-0">
+      <div className="bg-node-header border-b-2 border-node px-3 py-2.5 flex items-center gap-3 relative">
+        <div className="w-14 h-14 rounded-full bg-node border-[3px] border-node flex items-center justify-center shadow-lg flex-shrink-0">
           <CornerDownRight size={20} className="text-df-storylet-selected" />
         </div>
         
@@ -118,7 +119,7 @@ export function DetourNode({ data, selected }: NodeProps<DetourNodeData>) {
       <Handle 
         type="source" 
         position={sourcePosition} 
-        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full"
+        className="node-handle !w-4 !h-4 !rounded-full"
       />
         </div>
       </ContextMenuTrigger>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageNode.tsx
@@ -9,6 +9,7 @@ import {
   ContextMenuTrigger,
 } from '@/shared/ui/context-menu';
 import type { ShellNodeData } from '@/forge/lib/graph-editor/hooks/useForgeFlowEditorShell';
+import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 import { useForgeEditorActions } from '@/forge/lib/graph-editor/hooks/useForgeEditorActions';
 
 export function PageNode({ data, selected, id }: NodeProps<ShellNodeData>) {
@@ -19,34 +20,32 @@ export function PageNode({ data, selected, id }: NodeProps<ShellNodeData>) {
   const summary = node.content;
   
   const actions = useForgeEditorActions();
-
-  // Glow effect based on selection and path state
-  const glowClass = selected 
-    ? 'shadow-[0_0_20px_rgba(245,158,11,0.6)]' // amber glow for pages
-    : isInPath 
-      ? 'shadow-[0_0_12px_rgba(245,158,11,0.4)]' 
-      : '';
+  const nodeType = node.type ?? FORGE_NODE_TYPE.PAGE;
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div
           onContextMenu={(e) => e.stopPropagation()}
-          className={`min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm bg-df-node-bg transition-all duration-200 ${
-            selected ? 'border-amber-500' : 'border-df-node-border'
-          } ${isDimmed ? 'opacity-30' : ''} ${glowClass}`}
+          data-node-type={nodeType}
+          data-selected={selected ? 'true' : 'false'}
+          data-in-path={isInPath ? 'true' : 'false'}
+          data-dimmed={isDimmed ? 'true' : 'false'}
+          data-start="false"
+          data-end="false"
+          className="forge-node min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm transition-all duration-200 border-node bg-node text-node"
         >
           <Handle
             type="target"
             position={Position.Left}
-            className="!bg-df-control-bg !border-df-control-border !w-3 !h-3"
+            className="node-handle !w-3 !h-3"
           />
-          <div className="px-3 py-2 border-b border-df-node-border flex items-center gap-2 bg-amber-500/10">
-            <div className="h-8 w-8 rounded-full flex items-center justify-center text-amber-500 border border-amber-500/30 bg-df-node-bg/40">
+          <div className="px-3 py-2 border-b border-node flex items-center gap-2 bg-node-header">
+            <div className="h-8 w-8 rounded-full flex items-center justify-center border border-node bg-node">
               <Files size={16} />
             </div>
             <div className="flex-1 min-w-0">
-              <div className="text-xs uppercase tracking-wide text-amber-500/70">Page</div>
+              <div className="text-xs uppercase tracking-wide">Page</div>
               <div className="text-sm font-semibold text-df-text-primary truncate">{title}</div>
             </div>
           </div>
@@ -62,7 +61,7 @@ export function PageNode({ data, selected, id }: NodeProps<ShellNodeData>) {
           <Handle
             type="source"
             position={Position.Right}
-            className="!bg-df-control-bg !border-df-control-border !w-3 !h-3"
+            className="node-handle !w-3 !h-3"
           />
         </div>
       </ContextMenuTrigger>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNode.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Handle, Position, NodeProps, useUpdateNodeInternals } from 'reactflow';
-import { ForgeChoice   } from '@/forge/types/forge-graph';
+import { ForgeChoice, ForgeNode, FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 import { ForgeCharacter } from '@/forge/types/characters';
 import { GitBranch, Play, Flag, Hash, Edit3, Plus, Trash2 } from 'lucide-react';
 import { FlagSchema } from '@/forge/types/flags';
@@ -12,7 +12,6 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/shared/ui/context-menu';
-import { ForgeNode } from '@/forge/types/forge-graph';
 import { getFlagColorClass } from '@/forge/lib/utils/flag-styles';
 import { useForgeEditorActions } from '@/forge/lib/graph-editor/hooks/useForgeEditorActions';
 
@@ -90,44 +89,35 @@ export function PlayerNode({ data, selected }: NodeProps<PlayerNodeData>) {
   // Check if this is an end node (player node with no choices that have nextNodeId)
   const hasNoOutgoingConnections = !choices.some(c => c.nextNodeId);
 
-  // Border color based on state
-  const borderClass = selected 
-    ? 'border-df-player-selected shadow-lg shadow-df-glow'
-    : isStartNode 
-      ? 'border-df-start shadow-md'
-      : isEndNode 
-        ? 'border-df-end shadow-md'
-        : 'border-df-player-border';
-
-  // Header background for player nodes
-  const headerBgClass = isStartNode 
-    ? 'bg-df-start-bg' 
-    : isEndNode 
-      ? 'bg-df-end-bg' 
-      : 'bg-df-player-header';
+  const nodeType = node.type ?? FORGE_NODE_TYPE.PLAYER;
 
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <div 
           onContextMenu={(e) => e.stopPropagation()}
-          className={`rounded-lg border-2 transition-all duration-300 ${borderClass} ${isInPath ? 'border-df-player-selected/70' : ''} bg-df-player-bg min-w-[320px] max-w-[450px] relative overflow-hidden`}
-          style={isDimmed ? { opacity: 0.35, filter: 'saturate(0.3)' } : undefined}
+          data-node-type={nodeType}
+          data-selected={selected ? 'true' : 'false'}
+          data-in-path={isInPath ? 'true' : 'false'}
+          data-dimmed={isDimmed ? 'true' : 'false'}
+          data-start={isStartNode ? 'true' : 'false'}
+          data-end={isEndNode ? 'true' : 'false'}
+          className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[320px] max-w-[450px] relative overflow-hidden"
         >
       {/* Input handle - position based on layout direction */}
       <Handle 
         type="target" 
         position={targetPosition} 
-        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full"
+        className="node-handle !w-4 !h-4 !rounded-full"
       />
       
       {/* Health Bar Style Header */}
       <div 
         ref={headerRef}
-        className={`${headerBgClass} border-b-2 border-df-player-border px-3 py-2.5 flex items-center gap-3 relative`}
+        className="bg-node-header border-b-2 border-node px-3 py-2.5 flex items-center gap-3 relative"
       >
         {/* Large Avatar - Left side */}
-        <div className="w-14 h-14 rounded-full bg-df-player-bg border-[3px] border-df-player-border flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
+        <div className="w-14 h-14 rounded-full bg-node border-[3px] border-node flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
           {avatar}
         </div>
         
@@ -177,7 +167,7 @@ export function PlayerNode({ data, selected }: NodeProps<PlayerNodeData>) {
               }}
               className="relative group"
             >
-              <div className="bg-df-elevated border border-df-control-border rounded-lg px-3 py-2 flex items-start gap-2 hover:border-df-player-selected/50 transition-colors">
+              <div className="node-choice bg-df-elevated border border-df-control-border rounded-lg px-3 py-2 flex items-start gap-2 transition-colors">
                 <div className="flex-1 min-w-0">
                   <p className="text-sm text-df-text-primary leading-relaxed">
                     &quot;{choice.text || 'Empty choice'}&quot;
@@ -212,7 +202,7 @@ export function PlayerNode({ data, selected }: NodeProps<PlayerNodeData>) {
                     transform: `translateY(-50%)`,
                     right: '-6px',
                   }}
-                  className="forge-choice-handle !bg-df-control-bg !border-2 hover:!border-df-player-selected hover:!bg-df-player-selected/20 !w-3 !h-3 !rounded-full"
+                  className="forge-choice-handle !w-3 !h-3 !rounded-full"
                 />
               </div>
             </div>
@@ -225,7 +215,7 @@ export function PlayerNode({ data, selected }: NodeProps<PlayerNodeData>) {
         type="source" 
         position={sourcePosition} 
         id="next"
-        className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full hover:!border-df-player-selected hover:!bg-df-player-selected/20"
+        className="node-handle !w-4 !h-4 !rounded-full"
       />
         </div>
       </ContextMenuTrigger>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletNode.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/shared/ui/context-menu';
 
 import type { ForgeNode } from '@/forge/types/forge-graph';
+import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 import { getFlagColorClass } from '@/forge/lib/utils/flag-styles';
 import { useForgeEditorActions } from '@/forge/lib/graph-editor/hooks/useForgeEditorActions';
 import { useForgeWorkspaceActions } from '@/forge/components/ForgeWorkspace/hooks/useForgeWorkspaceActions';
@@ -39,15 +40,7 @@ export function StoryletNode({ data, selected }: NodeProps<StoryletNodeData>) {
   const targetPosition = isHorizontal ? Position.Left : Position.Top;
   const sourcePosition = isHorizontal ? Position.Right : Position.Bottom;
 
-  const borderClass = selected
-    ? 'border-df-npc-selected shadow-lg shadow-df-glow'
-    : isStartNode
-      ? 'border-df-start shadow-md'
-      : isEndNode
-        ? 'border-df-end shadow-md'
-        : 'border-df-npc-border';
-
-  const headerBgClass = isStartNode ? 'bg-df-start-bg' : isEndNode ? 'bg-df-end-bg' : 'bg-df-npc-header';
+  const nodeType = node.type ?? FORGE_NODE_TYPE.STORYLET;
 
   const contentPreview =
     node.content?.length && node.content.length > 60 ? `${node.content.slice(0, 60)}...` : node.content || 'No description yet.';
@@ -66,19 +59,22 @@ export function StoryletNode({ data, selected }: NodeProps<StoryletNodeData>) {
             e.stopPropagation();
             if (node.id) actions.openNodeEditor(node.id);
           }}
-          className={`rounded-lg border-2 transition-all duration-300 ${borderClass} ${
-            isInPath ? 'border-df-node-selected/70' : ''
-          } bg-df-npc-bg min-w-[320px] max-w-[450px] relative overflow-hidden`}
-          style={isDimmed ? { opacity: 0.35, filter: 'saturate(0.3)' } : undefined}
+          data-node-type={nodeType}
+          data-selected={selected ? 'true' : 'false'}
+          data-in-path={isInPath ? 'true' : 'false'}
+          data-dimmed={isDimmed ? 'true' : 'false'}
+          data-start={isStartNode ? 'true' : 'false'}
+          data-end={isEndNode ? 'true' : 'false'}
+          className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[320px] max-w-[450px] relative overflow-hidden"
         >
           <Handle
             type="target"
             position={targetPosition}
-            className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full"
+            className="node-handle !w-4 !h-4 !rounded-full"
           />
 
-          <div className={`${headerBgClass} border-b-2 border-df-npc-border px-3 py-2.5 flex items-center gap-3 relative`}>
-            <div className="w-14 h-14 rounded-full bg-df-npc-bg border-[3px] border-df-npc-border flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
+          <div className="bg-node-header border-b-2 border-node px-3 py-2.5 flex items-center gap-3 relative">
+            <div className="w-14 h-14 rounded-full bg-node border-[3px] border-node flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
               <BookOpen size={20} className="text-df-npc-selected" />
             </div>
 
@@ -155,7 +151,7 @@ export function StoryletNode({ data, selected }: NodeProps<StoryletNodeData>) {
             type="source"
             position={sourcePosition}
             id="next"
-            className="!bg-df-control-bg !border-df-control-border !w-4 !h-4 !rounded-full hover:!border-df-npc-selected hover:!bg-df-npc-selected/20"
+            className="node-handle !w-4 !h-4 !rounded-full"
           />
         </div>
       </ContextMenuTrigger>

--- a/src/forge/styles/nodes.css
+++ b/src/forge/styles/nodes.css
@@ -1,0 +1,201 @@
+:root {
+  --node-default-bg: var(--color-df-node-bg);
+  --node-default-border: var(--color-df-node-border);
+  --node-default-header: var(--color-df-node-bg);
+  --node-default-text: var(--color-df-text-primary);
+  --node-default-accent: var(--color-df-node-selected);
+  --node-selected-border: var(--color-df-node-selected);
+  --node-start-border: var(--color-df-start);
+  --node-start-header: var(--color-df-start-bg);
+  --node-end-border: var(--color-df-end);
+  --node-end-header: var(--color-df-end-bg);
+
+  --node-npc-bg: var(--color-df-npc-bg);
+  --node-npc-border: var(--color-df-npc-border);
+  --node-npc-header: var(--color-df-npc-header);
+  --node-npc-text: var(--color-df-npc-text);
+  --node-npc-accent: var(--color-df-npc-selected);
+
+  --node-player-bg: var(--color-df-player-bg);
+  --node-player-border: var(--color-df-player-border);
+  --node-player-header: var(--color-df-player-header);
+  --node-player-text: var(--color-df-player-text);
+  --node-player-accent: var(--color-df-player-selected);
+
+  --node-conditional-bg: var(--color-df-conditional-bg);
+  --node-conditional-border: var(--color-df-conditional-border);
+  --node-conditional-header: var(--color-df-conditional-header);
+  --node-conditional-text: var(--color-df-conditional-text);
+  --node-conditional-accent: var(--color-df-conditional-border);
+
+  --node-storylet-bg: var(--color-df-npc-bg);
+  --node-storylet-border: var(--color-df-npc-border);
+  --node-storylet-header: var(--color-df-npc-header);
+  --node-storylet-text: var(--color-df-npc-text);
+  --node-storylet-accent: var(--color-df-npc-selected);
+
+  --node-page-bg: var(--color-df-warning-bg);
+  --node-page-border: var(--color-df-warning);
+  --node-page-header: color-mix(in oklab, var(--color-df-warning) 20%, var(--color-df-warning-bg));
+  --node-page-text: var(--color-df-text-primary);
+  --node-page-accent: var(--color-df-warning);
+
+  --node-act-bg: var(--color-df-info-bg);
+  --node-act-border: var(--color-df-info);
+  --node-act-header: color-mix(in oklab, var(--color-df-info) 20%, var(--color-df-info-bg));
+  --node-act-text: var(--color-df-text-primary);
+  --node-act-accent: var(--color-df-info);
+
+  --node-chapter-bg: var(--color-df-success-bg);
+  --node-chapter-border: var(--color-df-success);
+  --node-chapter-header: color-mix(in oklab, var(--color-df-success) 20%, var(--color-df-success-bg));
+  --node-chapter-text: var(--color-df-text-primary);
+  --node-chapter-accent: var(--color-df-success);
+
+  --node-detour-bg: var(--color-df-warning-bg);
+  --node-detour-border: var(--color-df-warning);
+  --node-detour-header: color-mix(in oklab, var(--color-df-warning) 20%, var(--color-df-warning-bg));
+  --node-detour-text: var(--color-df-text-primary);
+  --node-detour-accent: var(--color-df-warning);
+}
+
+.dialogue-graph-editor [data-node-type] {
+  --node-bg: var(--node-default-bg);
+  --node-border: var(--node-default-border);
+  --node-header-bg: var(--node-default-header);
+  --node-text: var(--node-default-text);
+  --node-accent: var(--node-default-accent);
+}
+
+.dialogue-graph-editor [data-node-type="CHARACTER"] {
+  --node-bg: var(--node-npc-bg);
+  --node-border: var(--node-npc-border);
+  --node-header-bg: var(--node-npc-header);
+  --node-text: var(--node-npc-text);
+  --node-accent: var(--node-npc-accent);
+}
+
+.dialogue-graph-editor [data-node-type="PLAYER"] {
+  --node-bg: var(--node-player-bg);
+  --node-border: var(--node-player-border);
+  --node-header-bg: var(--node-player-header);
+  --node-text: var(--node-player-text);
+  --node-accent: var(--node-player-accent);
+}
+
+.dialogue-graph-editor [data-node-type="CONDITIONAL"] {
+  --node-bg: var(--node-conditional-bg);
+  --node-border: var(--node-conditional-border);
+  --node-header-bg: var(--node-conditional-header);
+  --node-text: var(--node-conditional-text);
+  --node-accent: var(--node-conditional-accent);
+}
+
+.dialogue-graph-editor [data-node-type="STORYLET"] {
+  --node-bg: var(--node-storylet-bg);
+  --node-border: var(--node-storylet-border);
+  --node-header-bg: var(--node-storylet-header);
+  --node-text: var(--node-storylet-text);
+  --node-accent: var(--node-storylet-accent);
+}
+
+.dialogue-graph-editor [data-node-type="PAGE"] {
+  --node-bg: var(--node-page-bg);
+  --node-border: var(--node-page-border);
+  --node-header-bg: var(--node-page-header);
+  --node-text: var(--node-page-text);
+  --node-accent: var(--node-page-accent);
+}
+
+.dialogue-graph-editor [data-node-type="ACT"] {
+  --node-bg: var(--node-act-bg);
+  --node-border: var(--node-act-border);
+  --node-header-bg: var(--node-act-header);
+  --node-text: var(--node-act-text);
+  --node-accent: var(--node-act-accent);
+}
+
+.dialogue-graph-editor [data-node-type="CHAPTER"] {
+  --node-bg: var(--node-chapter-bg);
+  --node-border: var(--node-chapter-border);
+  --node-header-bg: var(--node-chapter-header);
+  --node-text: var(--node-chapter-text);
+  --node-accent: var(--node-chapter-accent);
+}
+
+.dialogue-graph-editor [data-node-type="DETOUR"] {
+  --node-bg: var(--node-detour-bg);
+  --node-border: var(--node-detour-border);
+  --node-header-bg: var(--node-detour-header);
+  --node-text: var(--node-detour-text);
+  --node-accent: var(--node-detour-accent);
+}
+
+.dialogue-graph-editor [data-start="true"] {
+  --node-border: var(--node-start-border);
+  --node-header-bg: var(--node-start-header);
+}
+
+.dialogue-graph-editor [data-end="true"] {
+  --node-border: var(--node-end-border);
+  --node-header-bg: var(--node-end-header);
+}
+
+.dialogue-graph-editor [data-in-path="true"] {
+  --node-border: color-mix(in oklab, var(--node-accent) 70%, var(--node-border));
+}
+
+.dialogue-graph-editor [data-selected="true"] {
+  --node-border: var(--node-selected-border);
+  --node-accent: var(--node-selected-border);
+}
+
+.dialogue-graph-editor .forge-node {
+  border-color: var(--node-border);
+  box-shadow: none;
+}
+
+.dialogue-graph-editor .forge-node[data-selected="true"] {
+  box-shadow: var(--shadow-df-lg), var(--shadow-df-glow);
+}
+
+.dialogue-graph-editor .forge-node[data-start="true"],
+.dialogue-graph-editor .forge-node[data-end="true"] {
+  box-shadow: var(--shadow-df-md);
+}
+
+.dialogue-graph-editor .forge-node[data-dimmed="true"] {
+  opacity: 0.35;
+  filter: saturate(0.3);
+}
+
+.dialogue-graph-editor .bg-node {
+  background-color: var(--node-bg);
+}
+
+.dialogue-graph-editor .border-node {
+  border-color: var(--node-border);
+}
+
+.dialogue-graph-editor .text-node {
+  color: var(--node-text);
+}
+
+.dialogue-graph-editor .bg-node-header {
+  background-color: var(--node-header-bg);
+}
+
+.dialogue-graph-editor .node-handle {
+  background-color: var(--color-df-control-bg);
+  border: 2px solid var(--color-df-control-border);
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.dialogue-graph-editor .node-handle:hover {
+  border-color: var(--node-accent);
+  background-color: color-mix(in oklab, var(--node-accent) 20%, var(--color-df-control-bg));
+}
+
+.dialogue-graph-editor .node-choice:hover {
+  border-color: var(--node-accent);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { CharacterSelector } from '@/forge/components/ForgeWorkspace/components/
 // Export styles
 import './styles/scrollbar.css';
 import './styles/graph.css';
+import './forge/styles/nodes.css';
 import './styles/themes.css';
 
 // Export all types

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -41,6 +41,15 @@
 
 .dialogue-graph-editor .forge-choice-handle {
   border-color: var(--edge-color);
+  border-style: solid;
+  border-width: 2px;
+  background-color: var(--color-df-control-bg);
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.dialogue-graph-editor .forge-choice-handle:hover {
+  border-color: var(--edge-color);
+  background-color: color-mix(in oklab, var(--edge-color) 20%, var(--color-df-control-bg));
 }
 
 .dialogue-graph-editor .forge-choice-input {


### PR DESCRIPTION
### Motivation
- Unify node theming so node visuals are driven by data attributes and CSS variables instead of many theme-specific classes and inline hover classes. 
- Make edge/handle colors consume centralized CSS variables (`--edge-color`, `--node-accent`) so styling is consistent and theme-able. 

### Description
- Added a new stylesheet `src/forge/styles/nodes.css` that defines node-level CSS variables and maps `data-node-type`, `data-selected`, `data-in-path`, `data-dimmed`, `data-start`, and `data-end` to those variables, and introduced generic helper classes `bg-node`, `border-node`, `text-node`, `bg-node-header`, `node-handle`, and `node-choice` used by node components.  
- Updated node components (Character, Player, Conditional, Storylet, Page, Act, Chapter, Detour) to emit the new `data-*` attributes (`data-node-type`, `data-selected`, `data-in-path`, `data-dimmed`, `data-start`, `data-end`) on their node wrapper and to use the new generic classes instead of theme-specific tailwind class branches. 
- Adjusted choice/handle styling in `src/styles/graph.css` so choice handles and node handles rely on `--edge-color` / `--node-accent` and use consistent hover/transition behavior. 
- Imported the new `nodes.css` from the library entrypoint (`src/index.ts`) so the mappings are available wherever the library is used. 

### Testing
- Ran `npm run build` to validate the package build, which failed due to a missing external dev dependency: `Cannot find package '@payloadcms/next' imported from next.config.mjs`; this is unrelated to the style/component changes and prevents a full Next.js build in this environment.  
- No other automated tests were executed in this run (unit test suite not invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969a5647d40832d909921b1d95f949d)