### PR TITLE
Replace hardcoded CSS colors with semantic tokens

### DIFF
--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -53,7 +53,7 @@
 }
 
 .dialogue-graph-editor .forge-choice-input {
-  border-color: #2a2a3e;
+  border-color: var(--border);
 }
 
 .dialogue-graph-editor .forge-choice-input[data-has-next="true"] {

--- a/src/styles/scrollbar.css
+++ b/src/styles/scrollbar.css
@@ -4,7 +4,7 @@
 * {
   /* Firefox */
   scrollbar-width: thin;
-  scrollbar-color: var(--color-df-control-border) transparent;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 /* Webkit browsers (Chrome, Safari, Edge) - Global */
@@ -14,18 +14,18 @@
 }
 
 *::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--scrollbar-track);
 }
 
 *::-webkit-scrollbar-thumb {
-  background: var(--color-df-control-border);
+  background: var(--scrollbar-thumb);
   border-radius: 4px;
-  border: 2px solid transparent;
+  border: 2px solid var(--scrollbar-track);
   background-clip: padding-box;
 }
 
 *::-webkit-scrollbar-thumb:hover {
-  background: var(--color-df-border-hover);
+  background: var(--scrollbar-thumb-hover);
   background-clip: padding-box;
 }
 
@@ -35,7 +35,7 @@
 }
 
 *::-webkit-scrollbar-corner {
-  background: transparent;
+  background: var(--scrollbar-track);
 }
 
 /* Thin variant for smaller containers */
@@ -45,24 +45,24 @@
 }
 
 .dialogue-forge-scrollbar-thin::-webkit-scrollbar-track {
-  background: transparent;
+  background: var(--scrollbar-track);
 }
 
 .dialogue-forge-scrollbar-thin::-webkit-scrollbar-thumb {
-  background: var(--color-df-control-border);
+  background: var(--scrollbar-thumb);
   border-radius: 2px;
-  border: 1px solid transparent;
+  border: 1px solid var(--scrollbar-track);
   background-clip: padding-box;
 }
 
 .dialogue-forge-scrollbar-thin::-webkit-scrollbar-thumb:hover {
-  background: var(--color-df-border-hover);
+  background: var(--scrollbar-thumb-hover);
   background-clip: padding-box;
 }
 
 .dialogue-forge-scrollbar-thin {
   scrollbar-width: thin;
-  scrollbar-color: var(--color-df-control-border) transparent;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 /* Hide scrollbar but keep functionality */
@@ -77,8 +77,8 @@
 
 /* React Flow Controls Styling */
 .react-flow__controls {
-  background: #0d0d14 !important;
-  border: 1px solid #2a2a3e !important;
+  background: var(--color-df-editor-bg) !important;
+  border: 1px solid var(--border) !important;
   border-radius: 8px !important;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3) !important;
   padding: 4px !important;
@@ -88,8 +88,8 @@
 }
 
 .react-flow__controls-button {
-  background: #12121a !important;
-  border: 1px solid #2a2a3e !important;
+  background: var(--color-df-control-bg) !important;
+  border: 1px solid var(--border) !important;
   border-radius: 4px !important;
   width: 24px !important;
   height: 24px !important;
@@ -101,18 +101,17 @@
 }
 
 .react-flow__controls-button:hover {
-  background: #1a1a2e !important;
-  border-color: #3a3a4e !important;
+  background: var(--color-df-control-hover) !important;
+  border-color: var(--color-df-border-hover) !important;
 }
 
 .react-flow__controls-button svg {
-  fill: #6b7280 !important;
+  fill: var(--muted-foreground) !important;
   max-width: 14px !important;
   max-height: 14px !important;
 }
 
 .react-flow__controls-button:hover svg {
-  fill: #e5e7eb !important;
+  fill: var(--foreground) !important;
 }
-
 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -28,6 +28,10 @@
   --input: var(--color-df-control-border);
   --ring: var(--color-df-node-selected);
 
+  --scrollbar-track: transparent;
+  --scrollbar-thumb: var(--color-df-control-border);
+  --scrollbar-thumb-hover: var(--color-df-border-hover);
+
   --radius: 0.6rem;
 
   /* Shadows */


### PR DESCRIPTION
### Motivation
- Remove remaining hardcoded hex colors in graph and scrollbar styles and consolidate appearance around semantic theme tokens for easier theming and consistency.
- Introduce explicit scrollbar tokens so scrollbar styling can be overridden per theme without scattering hex literals.

### Description
- Added root-level scrollbar variables `--scrollbar-track`, `--scrollbar-thumb`, and `--scrollbar-thumb-hover` to `:root` in `src/styles/themes.css` and left them to be overridden in `html[data-theme="..."]` only when needed.
- Replaced the remaining hardcoded border in `src/styles/graph.css` (`#2a2a3e`) with `var(--border)`.
- Replaced hardcoded colors in `src/styles/scrollbar.css` (track, thumb, hover, control backgrounds, borders, and icon fills) with the new scrollbar tokens and existing semantic tokens such as `--color-df-editor-bg`, `--border`, `--color-df-control-bg`, `--color-df-control-hover`, `--color-df-border-hover`, `--muted-foreground`, and `--foreground`.
- Updated Firefox scrollbar color usage to use `--scrollbar-thumb` and `--scrollbar-track` and adjusted WebKit thumb border to use `--scrollbar-track` so transparency is preserved via the token.

### Testing
- Searched the modified files with a regex for hex color literals and verified no remaining hex color literals in the changed files (success).
- Ran `npm run build`, which failed due to an unrelated missing package error: `Cannot find package '@payloadcms/next' imported from /workspace/dialogue-forge/next.config.mjs` (failure not caused by these CSS changes).
- Ran `npm run dev` to attempt local verification, which failed with the same missing package error (failure not caused by these CSS changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969c261586c832da643f68ed8fd3f38)