### PR TITLE
Add workspace context data attributes and CSS mapping

### DIFF
--- a/src/ai/components/AiWorkspace/AiWorkspace.tsx
+++ b/src/ai/components/AiWorkspace/AiWorkspace.tsx
@@ -4,6 +4,7 @@ import type { AiDataAdapter } from '@/ai/adapters/types/ai-data-adapter';
 import {
   AiWorkspaceStoreProvider,
   createAiWorkspaceStore,
+  useAiWorkspaceStore,
 } from './store/ai-workspace-store';
 import { AiWorkspaceConfig } from './components/AiWorkspaceConfig';
 import { AiWorkspaceRequest } from './components/AiWorkspaceRequest';
@@ -24,22 +25,41 @@ export function AiWorkspace({ dataAdapter, className = '' }: AiWorkspaceProps) {
 
   return (
     <AiWorkspaceStoreProvider store={storeRef.current}>
-      <div className={`flex h-full w-full flex-col gap-4 p-4 ${className}`}>
-        <div className="flex items-center justify-between">
-          <h1 className="text-lg font-semibold text-df-text-primary">AI Workspace</h1>
-        </div>
+      <AiWorkspaceContent className={className} />
+    </AiWorkspaceStoreProvider>
+  );
+}
 
-        <div className="grid gap-4 md:grid-cols-2">
-          <div className="space-y-4">
-            <AiWorkspaceConfig />
-            <AiWorkspaceRequest />
-          </div>
-          <div className="space-y-4">
-            <AiWorkspaceResponse />
-            <AiWorkspaceHistory />
-          </div>
+function AiWorkspaceContent({ className = '' }: { className?: string }) {
+  const currentRequest = useAiWorkspaceStore((state) => state.currentRequest);
+  const currentResponse = useAiWorkspaceStore((state) => state.currentResponse);
+  const isStreaming = useAiWorkspaceStore((state) => state.isStreaming);
+
+  const isFocused = Boolean(currentRequest) || isStreaming;
+  const contextNodeType = currentResponse ? 'response' : currentRequest ? 'request' : undefined;
+
+  return (
+    <div
+      className={`flex h-full w-full flex-col gap-4 p-4 ${className}`}
+      data-domain="ai"
+      data-editor-scope="ai"
+      data-context-node-type={contextNodeType}
+      data-focused={isFocused ? 'true' : 'false'}
+    >
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-df-text-primary">AI Workspace</h1>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-4">
+          <AiWorkspaceConfig />
+          <AiWorkspaceRequest />
+        </div>
+        <div className="space-y-4">
+          <AiWorkspaceResponse />
+          <AiWorkspaceHistory />
         </div>
       </div>
-    </AiWorkspaceStoreProvider>
+    </div>
   );
 }

--- a/src/forge/components/ForgeWorkspace/components/ForgeWorkspaceLayout.tsx
+++ b/src/forge/components/ForgeWorkspace/components/ForgeWorkspaceLayout.tsx
@@ -4,6 +4,7 @@ import type { ForgeGameState } from '@/forge/types/forge-game-state';
 import type { ForgeCharacter } from '@/forge/types/characters';
 import type { FlagSchema } from '@/forge/types/flags';
 import { SidebarPanel, NarrativeEditorPanel, StoryletEditorPanel } from './ForgeWorkspacePanels';
+import { useForgeWorkspaceStore } from '@/forge/components/ForgeWorkspace/store/forge-workspace-store';
 
 type PanelId = 'sidebar' | 'narrative-editor' | 'storylet-editor';
 
@@ -28,8 +29,22 @@ export function ForgeWorkspaceLayout({
   onNarrativeGraphChange,
   onStoryletGraphChange,
 }: ForgeWorkspaceLayoutProps) {
+  const focusedEditor = useForgeWorkspaceStore((s) => s.focusedEditor);
+  const graphScope = useForgeWorkspaceStore((s) => s.graphScope);
+  const contextNodeTypeByScope = useForgeWorkspaceStore((s) => s.contextNodeTypeByScope);
+
+  const resolvedScope = focusedEditor ?? graphScope;
+  const contextNodeType = contextNodeTypeByScope[resolvedScope];
+  const isFocused = Boolean(focusedEditor);
+
   return (
-    <div className="flex h-full w-full">
+    <div
+      className="flex h-full w-full"
+      data-domain="forge"
+      data-editor-scope={resolvedScope}
+      data-context-node-type={contextNodeType ?? undefined}
+      data-focused={isFocused ? 'true' : 'false'}
+    >
       {panelVisibility.sidebar && (
         <div className="w-[280px] border-r border-df-sidebar-border flex-shrink-0 relative group">
           <div className="absolute inset-y-0 right-0 w-[1px] bg-[var(--color-df-border-hover)] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
@@ -127,6 +127,17 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
     sessionStore,
   });
 
+  const setContextNodeType = useForgeWorkspaceStore((s) => s.actions.setContextNodeType);
+  const selectedNodeType = shell.selectedNode?.type ?? null;
+
+  React.useEffect(() => {
+    setContextNodeType('narrative', selectedNodeType);
+  }, [selectedNodeType, setContextNodeType]);
+
+  React.useEffect(() => {
+    return () => setContextNodeType('narrative', null);
+  }, [setContextNodeType]);
+
   // Create actions from dispatch and provide to children
   const actions = React.useMemo(() => makeForgeEditorActions(shell.dispatch), [shell.dispatch]);
 

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
@@ -199,6 +199,17 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
     sessionStore,
   });
 
+  const setContextNodeType = useForgeWorkspaceStore((s) => s.actions.setContextNodeType);
+  const selectedNodeType = shell.selectedNode?.type ?? null;
+
+  React.useEffect(() => {
+    setContextNodeType('storylet', selectedNodeType);
+  }, [selectedNodeType, setContextNodeType]);
+
+  React.useEffect(() => {
+    return () => setContextNodeType('storylet', null);
+  }, [setContextNodeType]);
+
   // Actions from dispatch (node/edge components consume this)
   const actions = React.useMemo(() => makeForgeEditorActions(shell.dispatch), [shell.dispatch]);
 

--- a/src/forge/components/ForgeWorkspace/store/forge-workspace-store.tsx
+++ b/src/forge/components/ForgeWorkspace/store/forge-workspace-store.tsx
@@ -42,6 +42,7 @@ export interface ForgeWorkspaceState {
   graphScope: ReturnType<typeof createViewStateSlice>["graphScope"]
   storyletFocusId: ReturnType<typeof createViewStateSlice>["storyletFocusId"]
   pendingFocusByScope: ReturnType<typeof createViewStateSlice>["pendingFocusByScope"]
+  contextNodeTypeByScope: ReturnType<typeof createViewStateSlice>["contextNodeTypeByScope"]
   panelLayout: ReturnType<typeof createViewStateSlice>["panelLayout"]
   focusedEditor: ReturnType<typeof createViewStateSlice>["focusedEditor"]
   modalState: ReturnType<typeof createViewStateSlice>["modalState"]
@@ -81,6 +82,7 @@ export interface ForgeWorkspaceState {
     setStoryletFocusId: ReturnType<typeof createViewStateSlice>["setStoryletFocusId"]
     requestFocus: ReturnType<typeof createViewStateSlice>["requestFocus"]
     clearFocus: ReturnType<typeof createViewStateSlice>["clearFocus"]
+    setContextNodeType: ReturnType<typeof createViewStateSlice>["setContextNodeType"]
     togglePanel: ReturnType<typeof createViewStateSlice>["togglePanel"]
     dockPanel: ReturnType<typeof createViewStateSlice>["dockPanel"]
     undockPanel: ReturnType<typeof createViewStateSlice>["undockPanel"]
@@ -255,6 +257,7 @@ export function createForgeWorkspaceStore(
             setStoryletFocusId: viewStateSlice.setStoryletFocusId,
             requestFocus: viewStateSlice.requestFocus,
             clearFocus: viewStateSlice.clearFocus,
+            setContextNodeType: viewStateSlice.setContextNodeType,
             togglePanel: viewStateSlice.togglePanel,
             dockPanel: viewStateSlice.dockPanel,
             undockPanel: viewStateSlice.undockPanel,

--- a/src/forge/components/ForgeWorkspace/store/slices/viewState.slice.ts
+++ b/src/forge/components/ForgeWorkspace/store/slices/viewState.slice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand"
 import type { ForgeWorkspaceState } from "../forge-workspace-store"
+import type { ForgeNodeType } from "@/forge/types/forge-graph"
 
 export interface PanelLayoutState {
   sidebar: {
@@ -43,6 +44,10 @@ export interface ViewStateSlice {
     narrative?: { graphId: string; nodeId?: string }
     storylet?: { graphId: string; nodeId?: string }
   }
+  contextNodeTypeByScope: {
+    narrative: ForgeNodeType | null
+    storylet: ForgeNodeType | null
+  }
   panelLayout: PanelLayoutState
   focusedEditor: "narrative" | "storylet" | null
   modalState: ModalState
@@ -53,6 +58,7 @@ export interface ViewStateActions {
   setStoryletFocusId: (id: string | null) => void
   requestFocus: (scope: "narrative" | "storylet", graphId: string, nodeId?: string) => void
   clearFocus: (scope: "narrative" | "storylet") => void
+  setContextNodeType: (scope: "narrative" | "storylet", nodeType: ForgeNodeType | null) => void
   togglePanel: (panel: 'sidebar' | 'narrativeEditor' | 'storyletEditor') => void
   dockPanel: (panel: 'sidebar' | 'narrativeEditor' | 'storyletEditor') => void
   undockPanel: (panel: 'sidebar' | 'narrativeEditor' | 'storyletEditor') => void
@@ -75,6 +81,10 @@ export function createViewStateSlice(
     graphScope: "narrative",
     storyletFocusId: null,
     pendingFocusByScope: {},
+    contextNodeTypeByScope: {
+      narrative: null,
+      storylet: null,
+    },
     panelLayout: defaultPanelLayout,
     focusedEditor: null,
     modalState: defaultModalState,
@@ -94,6 +104,14 @@ export function createViewStateSlice(
         delete next[scope]
         return { pendingFocusByScope: next }
       })
+    },
+    setContextNodeType: (scope, nodeType) => {
+      set((state) => ({
+        contextNodeTypeByScope: {
+          ...state.contextNodeTypeByScope,
+          [scope]: nodeType,
+        },
+      }))
     },
     togglePanel: (panel) => {
       set((state) => ({

--- a/src/forge/styles/forge-context.css
+++ b/src/forge/styles/forge-context.css
@@ -1,0 +1,82 @@
+:root {
+  --context-accent: var(--color-df-border-hover);
+  --context-glow: color-mix(in oklab, var(--context-accent) 35%, transparent);
+  --context-ring: color-mix(in oklab, var(--context-accent) 60%, transparent);
+}
+
+[data-domain] {
+  --context-glow: color-mix(in oklab, var(--context-accent) 35%, transparent);
+  --context-ring: color-mix(in oklab, var(--context-accent) 60%, transparent);
+}
+
+[data-domain][data-focused="false"] {
+  --context-accent: var(--color-df-border-hover);
+}
+
+[data-domain="forge"] {
+  --context-accent: var(--color-df-info);
+}
+
+[data-domain="forge"][data-editor-scope="storylet"] {
+  --context-accent: var(--color-df-edge-choice-1);
+}
+
+[data-domain="forge"][data-context-node-type="ACT"] {
+  --context-accent: var(--node-act-accent);
+}
+
+[data-domain="forge"][data-context-node-type="CHAPTER"] {
+  --context-accent: var(--node-chapter-accent);
+}
+
+[data-domain="forge"][data-context-node-type="PAGE"] {
+  --context-accent: var(--node-page-accent);
+}
+
+[data-domain="forge"][data-context-node-type="CHARACTER"] {
+  --context-accent: var(--node-npc-accent);
+}
+
+[data-domain="forge"][data-context-node-type="PLAYER"] {
+  --context-accent: var(--node-player-accent);
+}
+
+[data-domain="forge"][data-context-node-type="CONDITIONAL"] {
+  --context-accent: var(--node-conditional-accent);
+}
+
+[data-domain="forge"][data-context-node-type="STORYLET"] {
+  --context-accent: var(--node-storylet-accent);
+}
+
+[data-domain="forge"][data-context-node-type="DETOUR"] {
+  --context-accent: var(--node-detour-accent);
+}
+
+[data-domain="forge"][data-context-node-type="JUMP"] {
+  --context-accent: var(--color-df-warning);
+}
+
+[data-domain="forge"][data-context-node-type="END"] {
+  --context-accent: var(--color-df-text-tertiary);
+}
+
+[data-domain="writer"] {
+  --context-accent: var(--color-df-warning);
+}
+
+[data-domain="writer"][data-context-node-type="PAGE"] {
+  --context-accent: var(--node-page-accent);
+}
+
+[data-domain="ai"] {
+  --context-accent: var(--color-df-info);
+}
+
+[data-domain="ai"][data-context-node-type="request"] {
+  --context-accent: var(--color-df-info);
+}
+
+[data-domain="ai"][data-context-node-type="response"] {
+  --context-accent: var(--color-df-success);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { CharacterSelector } from '@/forge/components/ForgeWorkspace/components/
 import './styles/scrollbar.css';
 import './styles/graph.css';
 import './forge/styles/nodes.css';
+import './forge/styles/forge-context.css';
 import './styles/themes.css';
 
 // Export all types

--- a/src/writer/components/WriterWorkspace/layout/WriterLayout.tsx
+++ b/src/writer/components/WriterWorkspace/layout/WriterLayout.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from 'react';
+import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
+import { useWriterWorkspaceStore } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
 
 interface WriterLayoutProps {
   sidebar: ReactNode;
@@ -7,8 +9,18 @@ interface WriterLayoutProps {
 }
 
 export function WriterLayout({ sidebar, editor, className }: WriterLayoutProps) {
+  const activePageId = useWriterWorkspaceStore((state) => state.activePageId);
+  const hasActivePage = activePageId !== null;
+  const contextNodeType = hasActivePage ? FORGE_NODE_TYPE.PAGE : null;
+
   return (
-    <div className={`flex min-h-0 flex-1 gap-2 p-2 ${className ?? ''}`}>
+    <div
+      className={`flex min-h-0 flex-1 gap-2 p-2 ${className ?? ''}`}
+      data-domain="writer"
+      data-editor-scope="writer"
+      data-context-node-type={contextNodeType ?? undefined}
+      data-focused={hasActivePage ? 'true' : 'false'}
+    >
       <aside className="flex min-h-0 w-[320px] min-w-[260px] flex-col">
         {sidebar}
       </aside>


### PR DESCRIPTION
### Motivation
- Surface workspace and editor context (domain, focused scope, focused node type) as DOM attributes so host apps and styles can respond to editor state.
- Avoid string literals for node types by using exported constants and central store values to keep type-safety and consistency.
- Provide visual theming hooks by mapping context attributes to CSS variables for accent/glow/ring tokens.

### Description
- Added `contextNodeTypeByScope` and `setContextNodeType` to the Forge workspace `viewState` slice and exposed the action via the workspace store to track selected node types per scope (`narrative` / `storylet`).
- Updated narrative and storylet editors to source the selected node type from their editor session (`shell.selectedNode?.type`) and push it into the workspace store with `setContextNodeType`, and clear it on unmount.
- Added DOM data attributes on workspace roots: Forge (`data-domain="forge"`, `data-editor-scope`, `data-context-node-type`, `data-focused`), Writer (`data-domain="writer"`, etc.), and AI (`data-domain="ai"`, etc.), sourcing values from stores/session state and `FORGE_NODE_TYPE` when appropriate.
- Added a small CSS mapping file `src/forge/styles/forge-context.css` and imported it from `src/index.ts` to convert the attributes into `--context-accent`, `--context-glow`, and `--context-ring` tokens used by the UI.

### Testing
- Ran the package build with `npm run build`, which failed due to an unrelated environment dependency error: "Cannot find package '@payloadcms/next' imported from next.config.mjs"; no further automated tests completed.
- No unit tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969c6cceca4832dbf5d9c98bdb38982)