### PR TITLE
Replace graph editor context menus with Radix (shadcn) ContextMenu primitives

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/NarrativeGraphEditorPaneContextMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/NarrativeGraphEditorPaneContextMenu.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { ForgeNodeType, FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 import { FORGE_NODE_TYPE_LABELS } from '@/forge/types/ui-constants';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+} from '@/shared/ui/context-menu';
 
 interface NarrativeGraphEditorPaneContextMenuProps {
   x: number; // screenX
@@ -27,27 +32,31 @@ export function NarrativeGraphEditorPaneContextMenu({
   onClose,
 }: NarrativeGraphEditorPaneContextMenuProps) {
   return (
-    <div className="fixed z-50" style={{ left: x, top: y }}>
-      <div className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[150px]">
+    <ContextMenu open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <ContextMenuContent
+        className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[150px]"
+        style={{ position: 'fixed', left: x, top: y, zIndex: 50 }}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+      >
         {availableNodeTypes.map(type => (
-          <button
+          <ContextMenuItem
             key={type}
-            onClick={() => {
+            onSelect={() => {
               onAddNode(type, graphX, graphY);
               onClose();
             }}
             className="w-full text-left px-3 py-2 text-sm text-df-text-primary hover:bg-df-elevated rounded"
           >
             Add {FORGE_NODE_TYPE_LABELS[type]}
-          </button>
+          </ContextMenuItem>
         ))}
-        <button
-          onClick={onClose}
+        <ContextMenuItem
+          onSelect={onClose}
           className="w-full text-left px-3 py-2 text-sm text-df-text-secondary hover:bg-df-elevated rounded"
         >
           Cancel
-        </button>
-      </div>
-    </div>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
-}   
+}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditorPaneContextMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditorPaneContextMenu.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
-import { ForgeNodeType } from '@/src/types/forge/forge-graph';
+import { FORGE_NODE_TYPE, type ForgeNodeType } from '@/src/types/forge/forge-graph';
 import { FORGE_NODE_TYPE_LABELS } from '@/forge/types/ui-constants';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+} from '@/shared/ui/context-menu';
 
 interface ForgeStoryletGraphEditorPaneContextMenuProps {
   x: number;
@@ -12,7 +17,11 @@ interface ForgeStoryletGraphEditorPaneContextMenuProps {
 }
 
 // Available node types from pane context menu
-const availableNodeTypes: ForgeNodeType[] = ['CHARACTER', 'PLAYER', 'CONDITIONAL'];
+const availableNodeTypes: ForgeNodeType[] = [
+  FORGE_NODE_TYPE.CHARACTER,
+  FORGE_NODE_TYPE.PLAYER,
+  FORGE_NODE_TYPE.CONDITIONAL,
+];
 
 export function ForgeStoryletGraphEditorPaneContextMenu({
   x,
@@ -23,27 +32,31 @@ export function ForgeStoryletGraphEditorPaneContextMenu({
   onClose,
 }: ForgeStoryletGraphEditorPaneContextMenuProps) {
   return (
-    <div className="fixed z-50" style={{ left: x, top: y }}>
-      <div className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[150px]">
+    <ContextMenu open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <ContextMenuContent
+        className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[150px]"
+        style={{ position: 'fixed', left: x, top: y, zIndex: 50 }}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+      >
         {availableNodeTypes.map(type => (
-          <button
+          <ContextMenuItem
             key={type}
-            onClick={() => {
+            onSelect={() => {
               onAddNode(type, graphX, graphY);
               onClose();
             }}
             className="w-full text-left px-3 py-2 text-sm text-df-text-primary hover:bg-df-elevated rounded"
           >
             Add {FORGE_NODE_TYPE_LABELS[type]}
-          </button>
+          </ContextMenuItem>
         ))}
-        <button
-          onClick={onClose}
+        <ContextMenuItem
+          onSelect={onClose}
           className="w-full text-left px-3 py-2 text-sm text-df-text-secondary hover:bg-df-elevated rounded"
         >
           Cancel
-        </button>
-      </div>
-    </div>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActEdgeDropMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActEdgeDropMenu.tsx
@@ -44,7 +44,7 @@ export function ActEdgeDropMenu({
   };
 
   return (
-    <ContextMenuBase x={x} y={y} title="Create Node">
+    <ContextMenuBase x={x} y={y} title="Create Node" onClose={onClose}>
       {availableNodeTypes.map(type => (
         <ContextMenuButton
           key={type}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterEdgeDropMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterEdgeDropMenu.tsx
@@ -44,7 +44,7 @@ export function ChapterEdgeDropMenu({
   };
 
   return (
-    <ContextMenuBase x={x} y={y} title="Create Node">
+    <ContextMenuBase x={x} y={y} title="Create Node" onClose={onClose}>
       {availableNodeTypes.map(type => (
         <ContextMenuButton
           key={type}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterEdgeDropMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterEdgeDropMenu.tsx
@@ -47,7 +47,7 @@ export function CharacterEdgeDropMenu({
   };
 
   return (
-    <ContextMenuBase x={screenX} y={screenY} title="Create Node">
+    <ContextMenuBase x={screenX} y={screenY} title="Create Node" onClose={onClose}>
       {availableNodeTypes.map(type => (
         <ContextMenuButton
           key={type}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalEdgeDropMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalEdgeDropMenu.tsx
@@ -50,7 +50,7 @@ export function ConditionalEdgeDropMenu({
   };
 
   return (
-    <ContextMenuBase x={screenX} y={screenY} title="Create Node">
+    <ContextMenuBase x={screenX} y={screenY} title="Create Node" onClose={onClose}>
       {availableNodeTypes.map(type => (
         <ContextMenuButton
           key={type}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageEdgeDropMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageEdgeDropMenu.tsx
@@ -47,7 +47,7 @@ export function PageEdgeDropMenu({
   };
 
   return (
-    <ContextMenuBase x={x} y={y} title="Create Node">
+    <ContextMenuBase x={x} y={y} title="Create Node" onClose={onClose}>
       {availableNodeTypes.map(type => (
         <ContextMenuButton
           key={type}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerEdgeDropMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerEdgeDropMenu.tsx
@@ -50,7 +50,7 @@ export function PlayerEdgeDropMenu({
   };
 
   return (
-    <ContextMenuBase x={screenX} y={screenY} title="Create Node">
+    <ContextMenuBase x={screenX} y={screenY} title="Create Node" onClose={onClose}>
       {availableNodeTypes.map(type => (
         <ContextMenuButton
           key={type}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletEdgeContextMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletEdgeContextMenu.tsx
@@ -26,7 +26,7 @@ export function StoryletEdgeContextMenu({
   onClose,
 }: StoryletEdgeContextMenuProps) {
   return (
-    <ContextMenuBase x={x} y={y} title="Insert Node">
+    <ContextMenuBase x={x} y={y} title="Insert Node" onClose={onClose}>
       {availableNodeTypes.map(type => (
         <ContextMenuButton
           key={type}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletEdgeDropMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletEdgeDropMenu.tsx
@@ -47,7 +47,7 @@ export function StoryletEdgeDropMenu({
   };
 
   return (
-    <ContextMenuBase x={screenX} y={screenY} title="Create Node">
+    <ContextMenuBase x={screenX} y={screenY} title="Create Node" onClose={onClose}>
       {availableNodeTypes.map(type => (
         <ContextMenuButton
           key={type}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/shared/ContextMenuBase.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/shared/ContextMenuBase.tsx
@@ -1,4 +1,11 @@
 import React from 'react';
+import { cn } from '@/shared/lib/utils';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+} from '@/shared/ui/context-menu';
 
 interface ContextMenuBaseProps {
   x: number;
@@ -6,20 +13,35 @@ interface ContextMenuBaseProps {
   title?: string;
   children: React.ReactNode;
   className?: string;
+  onClose?: () => void;
 }
 
-export function ContextMenuBase({ x, y, title, children, className = '' }: ContextMenuBaseProps) {
+export function ContextMenuBase({
+  x,
+  y,
+  title,
+  children,
+  className = '',
+  onClose,
+}: ContextMenuBaseProps) {
   return (
-    <div className="fixed z-50" style={{ left: x, top: y }}>
-      <div className={`bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[150px] ${className}`}>
+    <ContextMenu open onOpenChange={(open) => { if (!open) onClose?.(); }}>
+      <ContextMenuContent
+        className={cn(
+          'bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[150px]',
+          className
+        )}
+        style={{ position: 'fixed', left: x, top: y, zIndex: 50 }}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+      >
         {title && (
-          <div className="px-3 py-1 text-[10px] text-df-text-secondary uppercase border-b border-df-sidebar-border">
+          <ContextMenuLabel className="px-3 py-1 text-[10px] text-df-text-secondary uppercase border-b border-df-sidebar-border">
             {title}
-          </div>
+          </ContextMenuLabel>
         )}
         {children}
-      </div>
-    </div>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
@@ -35,8 +57,8 @@ export function ContextMenuButton({ onClick, children, variant = 'primary' }: Co
     : 'w-full text-left px-3 py-2 text-sm text-df-text-secondary hover:bg-df-elevated rounded';
   
   return (
-    <button onClick={onClick} className={className}>
+    <ContextMenuItem onSelect={onClick} className={className}>
       {children}
-    </button>
+    </ContextMenuItem>
   );
 }


### PR DESCRIPTION
### Motivation

- Replace several ad-hoc/fixed-position context menu containers with the shadcn/Radix `ContextMenu` primitives so focus, keyboard navigation and portal behavior are handled by Radix.
- Keep existing menu visual spacing and behavior while wiring dismissal events into existing edge/node insertion code paths so placement coordinates are preserved when creating nodes.

### Description

- Replaced pane context menus in `ForgeStoryletGraphEditorPaneContextMenu.tsx` and `NarrativeGraphEditorPaneContextMenu.tsx` to use `ContextMenu`, `ContextMenuContent`, and `ContextMenuItem` from `src/shared/ui/context-menu` and preserved styling with class overrides and fixed positioning via inline `style`.
- Refactored the shared `ContextMenuBase` to render a Radix `ContextMenuContent` and `ContextMenuLabel`, added an optional `onClose` prop, and switched `ContextMenuButton` to use `ContextMenuItem` with `onSelect` for keyboard-friendly activation.
- Wired the new `onClose` dismissal handler into all edge/node drop and insert menus so menu close events properly notify the parent and existing `createNode` / `insertNodeOnEdge` calls receive the same `graphX`/`graphY` coordinates.
- Updated literal node type arrays to use `FORGE_NODE_TYPE.*` constants to follow codebase rules against string-literal types and keep typesafe references.

### Testing

- Ran `npm run build` which attempted a Next build and failed due to a missing package error: `Cannot find package '@payloadcms/next' imported from next.config.mjs` (build did not complete).
- Attempted `npm run dev` which failed with the same `next.config.mjs` missing package error, so the dev server did not start.
- No unit tests were executed as part of this change; local type/usage updates were compile-checked by manual inspection but full app build/dev could not be completed due to the external config dependency error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969cec6da68832d944c5471dffee191)