### PR TITLE
Swap Forge workspace chrome to semantic tokens

### DIFF
--- a/src/forge/components/ForgeWorkspace/ForgeWorkspace.tsx
+++ b/src/forge/components/ForgeWorkspace/ForgeWorkspace.tsx
@@ -229,8 +229,20 @@ function ForgeWorkspaceContent({
     [setActiveGameState]
   );
 
+  const editorTokens = {
+    '--editor-border-hover': 'var(--color-df-border-hover)',
+    '--editor-border-active': 'var(--color-df-border-active)',
+    '--editor-info': 'var(--color-df-info)',
+    '--editor-edge-choice': 'var(--color-df-edge-choice-1)',
+    '--editor-warning': 'var(--color-df-warning)',
+    '--editor-npc-border': 'var(--color-df-npc-border)',
+    '--editor-player-border': 'var(--color-df-player-border)',
+    '--editor-conditional-border': 'var(--color-df-conditional-border)',
+    '--editor-muted-foreground': 'var(--color-df-text-tertiary)',
+  } as React.CSSProperties;
+
   return (
-    <div className={`flex h-full w-full flex-col ${className}`}>
+    <div className={`flex h-full w-full flex-col ${className}`} style={editorTokens}>
       <ForgeWorkspaceMenuBar
         counts={{ actCount: 0, chapterCount: 0, pageCount: 0, characterCount: Object.keys(characters ?? {}).length }}
         onGuideClick={openGuide}

--- a/src/forge/components/ForgeWorkspace/components/ForgeSideBar/ForgeNarrativeList.tsx
+++ b/src/forge/components/ForgeWorkspace/components/ForgeSideBar/ForgeNarrativeList.tsx
@@ -78,10 +78,10 @@ export function ForgeNarrativeList({ className }: ForgeNarrativeListProps) {
   return (
     <div className={`flex h-full w-full flex-col ${className ?? ''}`}>
       {/* Compact header */}
-      <div className="flex items-center justify-between px-2 py-1.5 border-b border-df-sidebar-border">
+      <div className="flex items-center justify-between px-2 py-1.5 border-b border-border">
         <div className="flex items-center gap-1.5">
-          <BookOpen size={14} className="text-df-text-tertiary" />
-          <span className="text-xs font-medium text-df-text-secondary">Narratives</span>
+          <BookOpen size={14} className="text-muted-foreground" />
+          <span className="text-xs font-medium text-muted-foreground">Narratives</span>
           {filteredGraphs.length > 0 && (
             <Badge variant="secondary" className="h-4 px-1.5 text-[10px]">
               {filteredGraphs.length}
@@ -108,7 +108,7 @@ export function ForgeNarrativeList({ className }: ForgeNarrativeListProps) {
       </div>
 
       {/* Search */}
-      <div className="px-2 py-1.5 border-b border-df-sidebar-border">
+      <div className="px-2 py-1.5 border-b border-border">
         <SearchInput
           value={searchQuery}
           onChange={setSearchQuery}
@@ -119,7 +119,7 @@ export function ForgeNarrativeList({ className }: ForgeNarrativeListProps) {
       {/* List */}
       <div className="flex-1 overflow-y-auto">
         {filteredGraphs.length === 0 ? (
-          <div className="px-3 py-6 text-center text-xs text-df-text-tertiary">
+          <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             {searchQuery ? 'No narratives found' : 'No narratives'}
           </div>
         ) : (
@@ -134,12 +134,12 @@ export function ForgeNarrativeList({ className }: ForgeNarrativeListProps) {
                       onClick={() => workspaceActions.openNarrativeGraph(String(graph.id))}
                       className={`w-full px-2 py-1.5 text-left text-xs transition-colors duration-200 ${
                         isSelected
-                          ? 'bg-df-control-hover text-df-text-primary border-l-2 border-[var(--color-df-border-active)]'
-                          : 'text-df-text-secondary hover:bg-df-control-hover hover:text-df-text-primary hover:border-l-2 hover:border-[var(--color-df-border-hover)]'
+                          ? 'bg-muted text-foreground border-l-2 border-[var(--editor-border-active)]'
+                          : 'text-muted-foreground hover:bg-muted hover:text-foreground hover:border-l-2 hover:border-[var(--editor-border-hover)]'
                       }`}
                     >
                       <div className="flex items-center gap-1.5 truncate">
-                        <BookOpen size={12} className="shrink-0 text-df-text-tertiary" />
+                        <BookOpen size={12} className="shrink-0 text-muted-foreground" />
                         <span className="truncate font-medium">{graph.title ?? String(graph.id)}</span>
                       </div>
                     </button>

--- a/src/forge/components/ForgeWorkspace/components/ForgeSideBar/ForgeSidebar.tsx
+++ b/src/forge/components/ForgeWorkspace/components/ForgeSideBar/ForgeSidebar.tsx
@@ -26,16 +26,16 @@ export function ForgeSidebar({ className }: ForgeSidebarProps) {
           if (value) setActiveTab(value as 'narratives' | 'storylets' | 'nodes');
         }}
         variant="outline"
-        className="w-full flex rounded-none bg-transparent h-8 px-0 gap-0 m-0 min-w-0 overflow-hidden border-b border-df-sidebar-border relative group"
+        className="w-full flex rounded-none bg-transparent h-8 px-0 gap-0 m-0 min-w-0 overflow-hidden border-b border-border relative group"
       >
-        <div className="absolute inset-x-0 bottom-0 h-[1px] bg-[var(--color-df-border-hover)] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
+        <div className="absolute inset-x-0 bottom-0 h-[1px] bg-[var(--editor-border-hover)] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
         <ToggleGroupItem
           value="narratives"
           aria-label="Narratives"
           className={cn(
             "min-w-0 flex-1 text-xs rounded-none px-1 py-0.5 truncate leading-tight",
-            "text-df-text-secondary hover:text-df-text-primary",
-            "data-[state=on]:bg-df-control-hover data-[state=on]:text-df-text-primary data-[state=on]:border-b-2 data-[state=on]:border-[var(--color-df-border-active)]"
+            "text-muted-foreground hover:text-foreground",
+            "data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:border-b-2 data-[state=on]:border-[var(--editor-border-active)]"
           )}
         >
           <BookOpen
@@ -43,7 +43,7 @@ export function ForgeSidebar({ className }: ForgeSidebarProps) {
             className={cn(
               "mr-0.5 shrink-0 transition-colors",
               activeTab === 'narratives'
-                ? "text-[var(--color-df-info)]"
+                ? "text-[var(--editor-info)]"
                 : "text-[var(--color-df-info-muted,theme(colors.blue.300))]"
             )}
           />
@@ -54,8 +54,8 @@ export function ForgeSidebar({ className }: ForgeSidebarProps) {
           aria-label="Storylets"
           className={cn(
             "min-w-0 flex-1 text-xs rounded-none px-1 py-0.5 truncate leading-tight",
-            "text-df-text-secondary hover:text-df-text-primary",
-            "data-[state=on]:bg-df-control-hover data-[state=on]:text-df-text-primary data-[state=on]:border-b-2 data-[state=on]:border-[var(--color-df-border-active)]"
+            "text-muted-foreground hover:text-foreground",
+            "data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:border-b-2 data-[state=on]:border-[var(--editor-border-active)]"
           )}
         >
           <Layers
@@ -63,7 +63,7 @@ export function ForgeSidebar({ className }: ForgeSidebarProps) {
             className={cn(
               "mr-0.5 shrink-0 transition-colors",
               activeTab === 'storylets'
-                ? "text-[var(--color-df-edge-choice-1)]"
+                ? "text-[var(--editor-edge-choice)]"
                 : "text-[var(--color-df-edge-choice-1-muted,theme(colors.green.400))]"
             )}
           />
@@ -74,8 +74,8 @@ export function ForgeSidebar({ className }: ForgeSidebarProps) {
           aria-label="Nodes"
           className={cn(
             "min-w-0 flex-1 text-xs rounded-none px-1 py-0.5 truncate leading-tight",
-            "text-df-text-secondary hover:text-df-text-primary",
-            "data-[state=on]:bg-df-control-hover data-[state=on]:text-df-text-primary data-[state=on]:border-b-2 data-[state=on]:border-[var(--color-df-border-active)]"
+            "text-muted-foreground hover:text-foreground",
+            "data-[state=on]:bg-muted data-[state=on]:text-foreground data-[state=on]:border-b-2 data-[state=on]:border-[var(--editor-border-active)]"
           )}
         >
           <Boxes
@@ -83,7 +83,7 @@ export function ForgeSidebar({ className }: ForgeSidebarProps) {
             className={cn(
               "mr-0.5 shrink-0 transition-colors",
               activeTab === 'nodes'
-                ? "text-[var(--color-df-warning)]"
+                ? "text-[var(--editor-warning)]"
                 : "text-[var(--color-df-warning-muted,theme(colors.amber.400))]"
             )}
           />
@@ -91,8 +91,8 @@ export function ForgeSidebar({ className }: ForgeSidebarProps) {
           {focusedEditor && (
             <span className={cn(
               "ml-0.5 text-[9px] px-1 py-0.5 rounded shrink-0",
-              focusedEditor === 'narrative' && "bg-[var(--color-df-info)]/20 text-[var(--color-df-info)]",
-              focusedEditor === 'storylet' && "bg-[var(--color-df-edge-choice-1)]/20 text-[var(--color-df-edge-choice-1)]"
+              focusedEditor === 'narrative' && "bg-[var(--editor-info)]/20 text-[var(--editor-info)]",
+              focusedEditor === 'storylet' && "bg-[var(--editor-edge-choice)]/20 text-[var(--editor-edge-choice)]"
             )}>
               {focusedEditor === 'narrative' ? 'N' : 'S'}
             </span>

--- a/src/forge/components/ForgeWorkspace/components/ForgeSideBar/NodePalette.tsx
+++ b/src/forge/components/ForgeWorkspace/components/ForgeSideBar/NodePalette.tsx
@@ -27,18 +27,18 @@ import { FORGE_NODE_TYPE_LABELS } from '@/forge/types/ui-constants';
  */
 function getNodeIconColor(nodeType: ForgeNodeType): string {
   const colorMap: Record<ForgeNodeType, string> = {
-    [FORGE_NODE_TYPE.CHARACTER]: 'var(--color-df-npc-border)',
-    [FORGE_NODE_TYPE.PLAYER]: 'var(--color-df-player-border)',
-    [FORGE_NODE_TYPE.CONDITIONAL]: 'var(--color-df-conditional-border)',
+    [FORGE_NODE_TYPE.CHARACTER]: 'var(--editor-npc-border)',
+    [FORGE_NODE_TYPE.PLAYER]: 'var(--editor-player-border)',
+    [FORGE_NODE_TYPE.CONDITIONAL]: 'var(--editor-conditional-border)',
     [FORGE_NODE_TYPE.ACT]: '#8b5cf6', // Purple
     [FORGE_NODE_TYPE.CHAPTER]: '#06b6d4', // Cyan
     [FORGE_NODE_TYPE.PAGE]: '#22c55e', // Green
     [FORGE_NODE_TYPE.DETOUR]: '#a78bfa', // Light purple
-    [FORGE_NODE_TYPE.STORYLET]: 'var(--color-df-npc-border)', // Use NPC color
+    [FORGE_NODE_TYPE.STORYLET]: 'var(--editor-npc-border)', // Use NPC color
     [FORGE_NODE_TYPE.JUMP]: '#f472b6', // Pink
     [FORGE_NODE_TYPE.END]: '#9ca3af', // Gray
   };
-  return colorMap[nodeType] || 'var(--color-df-text-tertiary)';
+  return colorMap[nodeType] || 'var(--editor-muted-foreground)';
 }
 
 /**
@@ -221,7 +221,7 @@ export function NodePalette({ className }: NodePaletteProps) {
 
     return (
       <div key={category} className="mb-3">
-        <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-df-text-tertiary">
+        <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
           {categoryLabels[category]}
         </div>
         <div className="space-y-0.5">
@@ -235,10 +235,10 @@ export function NodePalette({ className }: NodePaletteProps) {
                     onDragEnd={handleDragEnd}
                     className={cn(
                       'flex items-center gap-2 px-2 py-1.5 text-xs cursor-grab active:cursor-grabbing',
-                      'text-df-text-secondary hover:bg-df-control-hover hover:text-df-text-primary',
+                      'text-muted-foreground hover:bg-muted hover:text-foreground',
                       'transition-colors rounded',
-                      focusedEditor === 'narrative' && 'border-l-1 border-l-[var(--color-df-info)]',
-                      focusedEditor === 'storylet' && 'border-l-1 border-l-[var(--color-df-edge-choice-1)]'
+                      focusedEditor === 'narrative' && 'border-l-1 border-l-[var(--editor-info)]',
+                      focusedEditor === 'storylet' && 'border-l-1 border-l-[var(--editor-edge-choice)]'
                     )}
                   >
                     <ColoredNodeIcon nodeType={nodeInfo.type} icon={nodeInfo.icon} />
@@ -258,25 +258,25 @@ export function NodePalette({ className }: NodePaletteProps) {
 
   // Determine colors based on focused editor
   const headerBgColor = focusedEditor === 'narrative' 
-    ? 'bg-[var(--color-df-info)]/10' 
+    ? 'bg-[var(--editor-info)]/10' 
     : focusedEditor === 'storylet'
-    ? 'bg-[var(--color-df-edge-choice-1)]/10'
+    ? 'bg-[var(--editor-edge-choice)]/10'
     : 'bg-transparent';
   const headerBorderColor = focusedEditor === 'narrative'
-    ? 'border-b-[var(--color-df-info)]'
+    ? 'border-b-[var(--editor-info)]'
     : focusedEditor === 'storylet'
-    ? 'border-b-[var(--color-df-edge-choice-1)]'
-    : 'border-b-df-sidebar-border';
+    ? 'border-b-[var(--editor-edge-choice)]'
+    : 'border-b-border';
   const headerTextColor = focusedEditor === 'narrative'
-    ? 'text-[var(--color-df-info)]'
+    ? 'text-[var(--editor-info)]'
     : focusedEditor === 'storylet'
-    ? 'text-[var(--color-df-edge-choice-1)]'
-    : 'text-df-text-secondary';
+    ? 'text-[var(--editor-edge-choice)]'
+    : 'text-muted-foreground';
   const headerIconColor = focusedEditor === 'narrative'
-    ? 'var(--color-df-info)'
+    ? 'var(--editor-info)'
     : focusedEditor === 'storylet'
-    ? 'var(--color-df-edge-choice-1)'
-    : 'var(--color-df-text-tertiary)';
+    ? 'var(--editor-edge-choice)'
+    : 'var(--editor-muted-foreground)';
 
   return (
     <div className={cn('flex h-full w-full flex-col', className)}>
@@ -296,8 +296,8 @@ export function NodePalette({ className }: NodePaletteProps) {
                 variant="secondary" 
                 className={cn(
                   "h-4 px-1.5 text-[10px]",
-                  focusedEditor === 'narrative' && "bg-[var(--color-df-info)]/20 text-[var(--color-df-info)] border-[var(--color-df-info)]/30",
-                  focusedEditor === 'storylet' && "bg-[var(--color-df-edge-choice-1)]/20 text-[var(--color-df-edge-choice-1)] border-[var(--color-df-edge-choice-1)]/30"
+                  focusedEditor === 'narrative' && "bg-[var(--editor-info)]/20 text-[var(--editor-info)] border-[var(--editor-info)]/30",
+                  focusedEditor === 'storylet' && "bg-[var(--editor-edge-choice)]/20 text-[var(--editor-edge-choice)] border-[var(--editor-edge-choice)]/30"
                 )}
               >
                 {focusedEditor === 'narrative' ? 'Narrative' : 'Storylet'}
@@ -322,7 +322,7 @@ export function NodePalette({ className }: NodePaletteProps) {
           renderCategory(category, nodes)
         )}
         {Object.values(filteredNodes).every((nodes) => nodes.length === 0) && (
-          <div className="px-3 py-6 text-center text-xs text-df-text-tertiary">
+          <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             {searchQuery ? 'No nodes found' : 'No nodes available'}
           </div>
         )}

--- a/src/forge/components/ForgeWorkspace/components/ForgeSideBar/StoryletList.tsx
+++ b/src/forge/components/ForgeWorkspace/components/ForgeSideBar/StoryletList.tsx
@@ -77,10 +77,10 @@ export function StoryletList({ className }: StoryletsListProps) {
   return (
     <div className={`flex h-full w-full flex-col ${className ?? ''}`}>
       {/* Compact header */}
-      <div className="flex items-center justify-between px-2 py-1.5 border-b border-df-sidebar-border">
+      <div className="flex items-center justify-between px-2 py-1.5 border-b border-border">
         <div className="flex items-center gap-1.5">
-          <Layers size={14} className="text-df-text-tertiary" />
-          <span className="text-xs font-medium text-df-text-secondary">Storylets</span>
+          <Layers size={14} className="text-muted-foreground" />
+          <span className="text-xs font-medium text-muted-foreground">Storylets</span>
           {filteredGraphs.length > 0 && (
             <Badge variant="secondary" className="h-4 px-1.5 text-[10px]">
               {filteredGraphs.length}
@@ -107,7 +107,7 @@ export function StoryletList({ className }: StoryletsListProps) {
       </div>
 
       {/* Search */}
-      <div className="px-2 py-1.5 border-b border-df-sidebar-border">
+      <div className="px-2 py-1.5 border-b border-border">
         <SearchInput
           value={searchQuery}
           onChange={setSearchQuery}
@@ -118,7 +118,7 @@ export function StoryletList({ className }: StoryletsListProps) {
       {/* List */}
       <div className="flex-1 overflow-y-auto">
         {filteredGraphs.length === 0 ? (
-          <div className="px-3 py-6 text-center text-xs text-df-text-tertiary">
+          <div className="px-3 py-6 text-center text-xs text-muted-foreground">
             {searchQuery ? 'No storylets found' : 'No storylets'}
           </div>
         ) : (
@@ -133,12 +133,12 @@ export function StoryletList({ className }: StoryletsListProps) {
                       onClick={() => workspaceActions.openStoryletGraph(String(graph.id))}
                       className={`w-full px-2 py-1.5 text-left text-xs transition-colors duration-200 ${
                         isSelected
-                          ? 'bg-df-control-hover text-df-text-primary border-l-2 border-[var(--color-df-border-active)]'
-                          : 'text-df-text-secondary hover:bg-df-control-hover hover:text-df-text-primary hover:border-l-2 hover:border-[var(--color-df-border-hover)]'
+                          ? 'bg-muted text-foreground border-l-2 border-[var(--editor-border-active)]'
+                          : 'text-muted-foreground hover:bg-muted hover:text-foreground hover:border-l-2 hover:border-[var(--editor-border-hover)]'
                       }`}
                     >
                       <div className="flex items-center gap-1.5 truncate">
-                        <Layers size={12} className="shrink-0 text-df-text-tertiary" />
+                        <Layers size={12} className="shrink-0 text-muted-foreground" />
                         <span className="truncate font-medium">{graph.title ?? String(graph.id)}</span>
                       </div>
                     </button>

--- a/src/forge/components/ForgeWorkspace/components/ForgeWorkspaceLayout.tsx
+++ b/src/forge/components/ForgeWorkspace/components/ForgeWorkspaceLayout.tsx
@@ -46,15 +46,15 @@ export function ForgeWorkspaceLayout({
       data-focused={isFocused ? 'true' : 'false'}
     >
       {panelVisibility.sidebar && (
-        <div className="w-[280px] border-r border-df-sidebar-border flex-shrink-0 relative group">
-          <div className="absolute inset-y-0 right-0 w-[1px] bg-[var(--color-df-border-hover)] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
+        <div className="w-[280px] border-r border-border flex-shrink-0 relative group">
+          <div className="absolute inset-y-0 right-0 w-[1px] bg-[var(--editor-border-hover)] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
           <SidebarPanel />
         </div>
       )}
       <div className="flex-1 flex flex-col min-w-0">
         {panelVisibility['narrative-editor'] && (
-          <div className="flex-1 border-b border-df-sidebar-border min-h-0 relative group">
-            <div className="absolute inset-x-0 top-0 h-[1px] bg-[var(--color-df-border-hover)] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
+          <div className="flex-1 border-b border-border min-h-0 relative group">
+            <div className="absolute inset-x-0 top-0 h-[1px] bg-[var(--editor-border-hover)] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none" />
             <NarrativeEditorPanel 
               graph={narrativeGraph}
               onChange={onNarrativeGraphChange}

--- a/src/forge/components/ForgeWorkspace/components/ForgeWorkspaceMenuBar.tsx
+++ b/src/forge/components/ForgeWorkspace/components/ForgeWorkspaceMenuBar.tsx
@@ -58,14 +58,14 @@ export function ForgeWorkspaceMenuBar({
   headerLinks,
 }: ForgeWorkspaceMenuBarProps) {
   return (
-    <div className="flex items-center justify-between border-b border-df-sidebar-border bg-df-base/80 px-2 py-1 hover:border-[var(--color-df-border-hover)] transition-colors duration-200">
+    <div className="flex items-center justify-between border-b border-border bg-background/80 px-2 py-1 hover:border-[var(--editor-border-hover)] transition-colors duration-200">
       {/* Left Section: Project Switcher + Menus */}
       <div className="flex items-center gap-2">
         <ForgeProjectSwitcher />
         <Menubar className="border-0 bg-transparent p-0">
           {/* File Menu */}
           <MenubarMenu>
-            <MenubarTrigger className="px-3 py-1.5 text-sm font-medium border border-transparent hover:border-df-control-border hover:bg-df-control-hover rounded-sm transition-colors data-[state=open]:bg-df-control-hover data-[state=open]:border-df-control-border">
+            <MenubarTrigger className="px-3 py-1.5 text-sm font-medium border border-transparent hover:border-border hover:bg-muted rounded-sm transition-colors data-[state=open]:bg-muted data-[state=open]:border-border">
               File
             </MenubarTrigger>
             <MenubarContent>
@@ -88,7 +88,7 @@ export function ForgeWorkspaceMenuBar({
 
           {/* View Menu */}
           <MenubarMenu>
-            <MenubarTrigger className="px-3 py-1.5 text-sm font-medium border border-transparent hover:border-df-control-border hover:bg-df-control-hover rounded-sm transition-colors data-[state=open]:bg-df-control-hover data-[state=open]:border-df-control-border">
+            <MenubarTrigger className="px-3 py-1.5 text-sm font-medium border border-transparent hover:border-border hover:bg-muted rounded-sm transition-colors data-[state=open]:bg-muted data-[state=open]:border-border">
               View
             </MenubarTrigger>
             <MenubarContent>
@@ -123,7 +123,7 @@ export function ForgeWorkspaceMenuBar({
       </div>
 
       {/* Center Section: Status Bar */}
-      <div className="text-[11px] text-df-text-tertiary">
+      <div className="text-[11px] text-muted-foreground">
         {counts.actCount} acts · {counts.chapterCount} chapters · {counts.pageCount} pages · {counts.characterCount} characters
       </div>
 
@@ -146,7 +146,7 @@ export function ForgeWorkspaceMenuBar({
                 </Button>
               ))}
             </div>
-            <div className="h-4 w-px bg-df-control-border" />
+            <div className="h-4 w-px bg-border" />
           </>
         )}
         <ThemeSwitcher />

--- a/src/forge/components/ForgeWorkspace/components/ForgeWorkspaceToolbar.tsx
+++ b/src/forge/components/ForgeWorkspace/components/ForgeWorkspaceToolbar.tsx
@@ -27,7 +27,7 @@ export function ForgeWorkspaceToolbar({
   const togglePanel = useForgeWorkspaceStore((s) => s.actions.togglePanel);
 
   return (
-    <div className="flex items-center justify-between border-b border-df-sidebar-border bg-df-base/80 px-3 py-2">
+    <div className="flex items-center justify-between border-b border-border bg-background/80 px-3 py-2">
       <div className="flex items-center gap-2">
         <Button type="button" variant="outline" size="icon" onClick={onPlayClick} title="Play selected page">
           <Play size={16} />
@@ -38,7 +38,7 @@ export function ForgeWorkspaceToolbar({
         <Button type="button" variant="outline" size="icon" onClick={onGuideClick} title="Open guide">
           <HelpCircle size={16} />
         </Button>
-        <div className="h-4 w-px bg-df-control-border mx-1" />
+        <div className="h-4 w-px bg-border mx-1" />
         <Button
           type="button"
           variant="outline"
@@ -67,7 +67,7 @@ export function ForgeWorkspaceToolbar({
           {panelLayout.storyletEditor.visible ? <Eye size={16} /> : <EyeOff size={16} />}
         </Button>
       </div>
-      <div className="text-[11px] text-df-text-tertiary">
+      <div className="text-[11px] text-muted-foreground">
         {counts.actCount} acts · {counts.chapterCount} chapters · {counts.pageCount} pages · {counts.characterCount} characters
       </div>
       <div className="flex items-center gap-2">{toolbarActions}</div>


### PR DESCRIPTION
### Motivation
- Move Forge workspace chrome and sidebar styles from DF-specific utility classes to semantic UI tokens to decouple styling from implementation details and improve themeability.
- Preserve existing visual accents that are domain-specific by introducing alias editor tokens so components keep a semantic API while still supporting DF color values.

### Description
- Replaced `bg-df-*`, `border-df-*`, and `text-df-*` utilities with semantic classes such as `bg-background`, `border-border`, `text-foreground`, and `text-muted-foreground` across the workspace chrome and sidebar components (`ForgeWorkspaceToolbar`, `ForgeWorkspaceMenuBar`, `ForgeWorkspaceLayout`, `ForgeSidebar`, `ForgeNarrativeList`, `StoryletList`, `NodePalette`).
- Added editor alias CSS variables in the root `ForgeWorkspace` component via an `editorTokens` object (e.g. `--editor-border-hover`, `--editor-border-active`, `--editor-info`, `--editor-edge-choice`, `--editor-warning`, `--editor-npc-border`, `--editor-player-border`, `--editor-conditional-border`, `--editor-muted-foreground`) and applied them where DF-specific `--color-df-*` values were previously used.
- Updated `NodePalette` to reference the editor alias tokens for icon colors and focused-state accents and replaced direct `var(--color-df-*)` fallbacks with `var(--editor-*)` aliases.
- Kept layout, spacing and interactive behavior unchanged; this is a token/API swap only.

### Testing
- Ran `npm run build` which failed due to a missing dependency error: "Cannot find package '@payloadcms/next' imported from next.config.mjs" (build did not complete).
- Ran `npm run dev -- --hostname 0.0.0.0 --port 3000` which failed with the same missing package error and the dev server did not start.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d27e8f24832d93ebab0765d7e2dc)