### PR TITLE
Consolidate useForgeWorkspaceStore selectors with shallow subscriptions

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
@@ -47,6 +47,7 @@ import { ForgeGraphBreadcrumbs } from '@/forge/components/ForgeWorkspace/compone
 import { ConditionalNode } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode';
 import { GraphLeftToolbar } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphLeftToolbar';
 import { GraphLayoutControls } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphLayoutControls';
+import { useShallow } from 'zustand/shallow';
 
 const nodeTypes = {
   [FORGE_NODE_TYPE.ACT]: ActNode,
@@ -75,15 +76,28 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
     className = '',
   } = props;
   
-  // Modal actions from workspace
-  const openYarnModal = useForgeWorkspaceStore((s) => s.actions.openYarnModal);
+  const {
+    openYarnModal,
+    focusedEditor,
+    setFocusedEditor,
+    pendingFocus,
+    clearFocus,
+    setContextNodeType,
+  } = useForgeWorkspaceStore(
+    useShallow((s) => ({
+      openYarnModal: s.actions.openYarnModal,
+      focusedEditor: s.focusedEditor,
+      setFocusedEditor: s.actions.setFocusedEditor,
+      pendingFocus: s.pendingFocusByScope.narrative,
+      clearFocus: s.actions.clearFocus,
+      setContextNodeType: s.actions.setContextNodeType,
+    }))
+  );
   const { draggedNodeType } = useNodeDrag();
 
   const reactFlow = useReactFlow();
 
   // Editor focus tracking - click-only, no hover preview
-  const setFocusedEditor = useForgeWorkspaceStore((s) => s.actions.setFocusedEditor);
-  const focusedEditor = useForgeWorkspaceStore((s) => s.focusedEditor);
   const isFocused = focusedEditor === 'narrative';
 
   const handleClick = React.useCallback(() => {
@@ -127,7 +141,6 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
     sessionStore,
   });
 
-  const setContextNodeType = useForgeWorkspaceStore((s) => s.actions.setContextNodeType);
   const selectedNodeType = shell.selectedNode?.type ?? null;
 
   React.useEffect(() => {
@@ -151,9 +164,6 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
   );
 
   // Consume focus requests from workspace
-  const pendingFocus = useForgeWorkspaceStore((s) => s.pendingFocusByScope.narrative);
-  const clearFocus = useForgeWorkspaceStore((s) => s.actions.clearFocus);
-  
   React.useEffect(() => {
     if (pendingFocus && graph && String(graph.id) === pendingFocus.graphId) {
       if (pendingFocus.nodeId) {

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
@@ -78,6 +78,7 @@ import {
 
 import { useForgeWorkspaceStore } from '@/forge/components/ForgeWorkspace/store/forge-workspace-store';
 import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
+import { useShallow } from 'zustand/shallow';
 
 import {
   ForgeEditorActionsProvider,
@@ -141,15 +142,29 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
   // Use gameState.flags if available, fallback to gameStateFlags for backward compatibility
   const resolvedGameStateFlags = gameState?.flags || gameStateFlags;
   
-  // Modal actions from workspace
-  const openYarnModal = useForgeWorkspaceStore((s) => s.actions.openYarnModal);
-  const openPlayModal = useForgeWorkspaceStore((s) => s.actions.openPlayModal);
+  const {
+    openYarnModal,
+    openPlayModal,
+    focusedEditor,
+    setFocusedEditor,
+    pendingFocus,
+    clearFocus,
+    setContextNodeType,
+  } = useForgeWorkspaceStore(
+    useShallow((s) => ({
+      openYarnModal: s.actions.openYarnModal,
+      openPlayModal: s.actions.openPlayModal,
+      focusedEditor: s.focusedEditor,
+      setFocusedEditor: s.actions.setFocusedEditor,
+      pendingFocus: s.pendingFocusByScope.storylet,
+      clearFocus: s.actions.clearFocus,
+      setContextNodeType: s.actions.setContextNodeType,
+    }))
+  );
 
   const reactFlow = useReactFlow();
 
   // Editor focus tracking - click-only, no hover preview
-  const setFocusedEditor = useForgeWorkspaceStore((s) => s.actions.setFocusedEditor);
-  const focusedEditor = useForgeWorkspaceStore((s) => s.focusedEditor);
   const isFocused = focusedEditor === 'storylet';
 
   const handleClick = React.useCallback(() => {
@@ -199,7 +214,6 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
     sessionStore,
   });
 
-  const setContextNodeType = useForgeWorkspaceStore((s) => s.actions.setContextNodeType);
   const selectedNodeType = shell.selectedNode?.type ?? null;
 
   React.useEffect(() => {
@@ -223,9 +237,6 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
   );
 
   // Consume focus requests from workspace
-  const pendingFocus = useForgeWorkspaceStore((s) => s.pendingFocusByScope.storylet);
-  const clearFocus = useForgeWorkspaceStore((s) => s.actions.clearFocus);
-  
   React.useEffect(() => {
     if (pendingFocus && graph && String(graph.id) === pendingFocus.graphId) {
       if (pendingFocus.nodeId) {


### PR DESCRIPTION
### Motivation

- Reduce unnecessary re-renders caused by multiple separate `useForgeWorkspaceStore` subscriptions in the graph editor components.
- Limit component updates to only the exact workspace fields each editor needs by using shallow selection.

### Description

- Import `useShallow` from `zustand/shallow` and replace multiple `useForgeWorkspaceStore` calls with a single consolidated selector in `ForgeStoryletGraphEditor` and `ForgeNarrativeGraphEditor`.
- Each selector now returns only the precise fields used by the component (`openYarnModal`, `openPlayModal` (storylet only), `focusedEditor`, `setFocusedEditor`, `pendingFocus` scoped to the editor, `clearFocus`, and `setContextNodeType`).
- Removed duplicated individual store subscriptions and adjusted usages to consume the consolidated values.
- Modified files: `src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx` and `src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx`.

### Testing

- Ran the automated build via `npm run build`, which failed due to an unrelated environment/package issue: `Cannot find package '@payloadcms/next' imported from next.config.mjs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969db31bc98832d89426daae3017846)