### PR TITLE
Refine narrative graph metadata lookups

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
@@ -192,6 +192,11 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
     [layoutDirection, onChange, reactFlow, shell.effectiveGraph, setLayoutDirection]
   );
 
+  const flowById = React.useMemo(
+    () => new Map<string, ForgeReactFlowNode>(shell.effectiveGraph.flow.nodes.map((node) => [node.id, node])),
+    [shell.effectiveGraph.flow.nodes]
+  );
+
   // Decorate nodes with UI metadata
   const nodesWithMeta = React.useMemo(() => {
     const hasSelection = shell.selectedNodeId !== null && showPathHighlight;
@@ -218,14 +223,21 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
         } as ShellNodeData,
       };
     });
-  }, [shell.effectiveGraph, shell.selectedNodeId, showPathHighlight, nodeDepths, layoutDirection]);
+  }, [
+    layoutDirection,
+    nodeDepths,
+    showPathHighlight,
+    shell.effectiveGraph.endNodeIds,
+    shell.effectiveGraph.flow.nodes,
+    shell.effectiveGraph.startNodeId,
+    shell.selectedNodeId,
+  ]);
 
   // Decorate edges with UI metadata
   const edgesWithMeta = React.useMemo(() => {
     return shell.effectiveGraph.flow.edges.map((edge) => {
       const isInPath = showPathHighlight && edgesToSelectedNode.has(edge.id);
-      const sourceNode = shell.effectiveGraph.flow.nodes.find((n) => n.id === edge.source);
-      const sourceFlowNode = sourceNode as ForgeReactFlowNode | undefined;
+      const sourceFlowNode = flowById.get(edge.source);
 
       return {
         ...edge,
@@ -236,7 +248,7 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
         },
       };
     });
-  }, [shell.effectiveGraph, showPathHighlight, edgesToSelectedNode]);
+  }, [edgesToSelectedNode, flowById, showPathHighlight, shell.effectiveGraph.flow.edges]);
 
   return (
     <ForgeEditorActionsProvider actions={actions}>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
@@ -254,6 +254,11 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
   }, [pendingFocus, graph, reactFlow, clearFocus, shell.effectiveGraph]);
 
 
+  const flowById = React.useMemo(
+    () => new Map<string, ForgeReactFlowNode>(shell.effectiveGraph.flow.nodes.map((n: ForgeReactFlowNode) => [n.id, n])),
+    [shell.effectiveGraph.flow.nodes]
+  );
+
   // Decorate nodes with UI metadata + read-only context (NO callbacks)
   const nodesWithMeta = React.useMemo(() => {
     const hasSelection = shell.selectedNodeId !== null && showPathHighlight;
@@ -264,7 +269,7 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
       const isSelected = n.id === shell.selectedNodeId;
       const isDimmed = hasSelection && !inPath && !isSelected;
 
-      const flowNode = shell.effectiveGraph.flow.nodes.find((node: ForgeReactFlowNode) => node.id === n.id);
+      const flowNode = flowById.get(n.id);
       const nodeType = (flowNode?.type as ForgeNodeType | undefined) ?? (flowNode?.data as any)?.type;
 
       const isStartNode = n.id === startId;
@@ -303,17 +308,17 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
     layoutDirection,
     nodeDepths,
     showPathHighlight,
-    shell,
+    shell.effectiveGraph.startNodeId,
+    shell.endNodeIds,
+    shell.nodes,
+    shell.selectedNodeId,
+    flowById,
   ]);
 
   // Create lookup maps for nodes and flow nodes (moved outside to avoid hook-in-hook)
   const nodeById = React.useMemo(
     () => new Map<string, typeof shell.nodes[number]>(shell.nodes.map((n) => [n.id, n])),
     [shell.nodes]
-  );
-  const flowById = React.useMemo(
-    () => new Map<string, ForgeReactFlowNode>(shell.effectiveGraph.flow.nodes.map((n: ForgeReactFlowNode) => [n.id, n])),
-    [shell.effectiveGraph.flow.nodes]
   );
 
   // Decorate edges with UI metadata (NO callbacks)


### PR DESCRIPTION
### Motivation
- Avoid repeated linear searches of flow nodes when decorating graph nodes and edges by introducing a stable lookup map. 
- Apply the same optimization to the narrative graph editor to match the storylet editor changes. 
- Stabilize `useMemo` dependency arrays so memoized decorations only recompute on meaningful changes.

### Description
- Add a memoized `flowById` lookup (`new Map(...)`) in `ForgeNarrativeGraphEditor` and reuse it when decorating edges to replace `find(...)` calls. 
- Tighten the `nodesWithMeta` and `edgesWithMeta` `useMemo` dependency arrays to reference stable inputs (e.g. `shell.effectiveGraph.flow.nodes`, `shell.effectiveGraph.startNodeId`, `shell.effectiveGraph.endNodeIds`, `flowById`, etc.).
- Keep/ensure existing `flowById` and `nodeById` maps in the storylet editor are used consistently for node/edge decoration to avoid repeated scans. 
- Files updated: `src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx` and `src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx`.

### Testing
- Ran `npm run build`, which failed due to a missing external package: `Cannot find package '@payloadcms/next' imported from next.config.mjs` (build did not complete).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e2e4f73c832da5475e1548adf2b0)