### PR TITLE
Add forge node and context styles to globals

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,6 +3,8 @@
 /* Import dialogue-forge theme */
 @import './themes.css';
 @import './graph.css';
+@import '../src/forge/styles/nodes.css';
+@import '../src/forge/styles/forge-context.css';
 @import './scrollbar.css';
 
 /* Source paths for Tailwind content detection */


### PR DESCRIPTION
### Motivation
- Ensure forge node and context CSS are bundled for the demo so selectors like `.forge-node`, `.bg-node`, `.border-node` and context token rules become active without relying on `src/index.ts` imports.

### Description
- Add `@import '../src/forge/styles/nodes.css';` and `@import '../src/forge/styles/forge-context.css';` to `styles/globals.css` so the forge styles are included in the demo bundle.

### Testing
- Ran `npm run build`, which failed with `Cannot find package '@payloadcms/next' imported from next.config.mjs`, so the build could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e9b7fe44832db71f3f477645b7de)