### PR TITLE
Use context-driven glow/ring for forge node shadows

### DIFF
--- a/src/forge/styles/nodes.css
+++ b/src/forge/styles/nodes.css
@@ -65,6 +65,13 @@
   --node-header-bg: var(--node-default-header);
   --node-text: var(--node-default-text);
   --node-accent: var(--node-default-accent);
+  --node-shadow: var(--shadow-df-md);
+  --node-selected-shadow: var(--shadow-df-lg), 0 0 0 2px var(--context-ring),
+    0 0 12px var(--context-glow);
+  --node-start-shadow: var(--shadow-df-md), 0 0 0 2px var(--context-ring),
+    0 0 12px var(--context-glow);
+  --node-end-shadow: var(--shadow-df-md), 0 0 0 2px var(--context-ring),
+    0 0 12px var(--context-glow);
 }
 
 .dialogue-graph-editor [data-node-type="CHARACTER"] {
@@ -152,16 +159,20 @@
 
 .dialogue-graph-editor .forge-node {
   border-color: var(--node-border);
-  box-shadow: none;
+  box-shadow: var(--node-shadow);
 }
 
 .dialogue-graph-editor .forge-node[data-selected="true"] {
-  box-shadow: var(--shadow-df-lg), var(--shadow-df-glow);
+  box-shadow: var(--node-selected-shadow);
 }
 
 .dialogue-graph-editor .forge-node[data-start="true"],
 .dialogue-graph-editor .forge-node[data-end="true"] {
-  box-shadow: var(--shadow-df-md);
+  box-shadow: var(--node-start-shadow);
+}
+
+.dialogue-graph-editor .forge-node[data-end="true"] {
+  box-shadow: var(--node-end-shadow);
 }
 
 .dialogue-graph-editor .forge-node[data-dimmed="true"] {


### PR DESCRIPTION
### Motivation
- Make node selection/hover chrome respond to workspace `data-context-*` attributes by using `--context-glow` / `--context-ring` instead of a fixed glow token. 
- Consolidate shadow behavior into node-level variables so selected/start/end states can inherit semantic/context colors. 
- Ensure color sources are semantic or context tokens rather than hard-coded shadow color values. 

### Description
- Added node-level CSS variables `--node-shadow`, `--node-selected-shadow`, `--node-start-shadow`, and `--node-end-shadow` in `src/forge/styles/nodes.css`. 
- Replaced direct uses of `--shadow-df-lg` / `--shadow-df-glow` and `box-shadow: none` with the new node shadow variables and applied them to `.forge-node`, `.forge-node[data-selected="true"]`, `.forge-node[data-start="true"]`, and `.forge-node[data-end="true"]`. 
- Composed the selected/start/end shadow values from `--context-ring` and `--context-glow` so the chrome updates with the workspace context. 
- Kept color/token sources semantic/contextual (e.g., `--context-accent`, `--context-glow`, `--node-*-accent`). 

### Testing
- Ran `npm run build`, which failed due to a missing package `@payloadcms/next` imported by `next.config.mjs`, so the build could not be validated. 
- Ran `npm run dev`, which also failed for the same missing package, so runtime verification was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969eb9de26c832d96c1c1e056a55149)