### PR TITLE
Replace node color classes with semantic tokens

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphMiniMap.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphMiniMap.tsx
@@ -26,15 +26,15 @@ export function GraphMiniMap({ showMiniMap }: GraphMiniMapProps) {
           style={{
             width: 180,
             height: 120,
-            backgroundColor: '#0d0d14',
+            backgroundColor: 'var(--minimap-bg)',
           }}
-          maskColor="rgba(0, 0, 0, 0.7)"
+          maskColor="var(--minimap-mask)"
           nodeColor={node => {
             if (node.type === FORGE_NODE_TYPE.CHARACTER || node.type === FORGE_NODE_TYPE.STORYLET)
-              return '#e94560';
-            if (node.type === FORGE_NODE_TYPE.PLAYER) return '#8b5cf6';
-            if (node.type === FORGE_NODE_TYPE.CONDITIONAL) return '#3b82f6';
-            return '#4a4a6a';
+              return 'var(--minimap-node-character)';
+            if (node.type === FORGE_NODE_TYPE.PLAYER) return 'var(--minimap-node-player)';
+            if (node.type === FORGE_NODE_TYPE.CONDITIONAL) return 'var(--minimap-node-conditional)';
+            return 'var(--minimap-node-default)';
           }}
           nodeStrokeWidth={2}
           pannable

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActNode.tsx
@@ -55,16 +55,16 @@ export const ActNode = React.memo(function ActNode({ data, selected, id }: NodeP
             </div>
             <div className="flex-1 min-w-0">
               <div className="text-xs uppercase tracking-wide">Act</div>
-              <div className="text-sm font-semibold text-df-text-primary truncate">{title}</div>
+              <div className="text-sm font-semibold text-foreground truncate">{title}</div>
             </div>
           </div>
           <div className="px-3 py-2 space-y-2">
-            <div className="text-[10px] uppercase tracking-wide text-df-text-tertiary">ID</div>
-            <div className="text-xs font-mono text-df-text-secondary bg-df-base/40 border border-df-node-border rounded px-2 py-1">
+            <div className="text-[10px] uppercase tracking-wide text-[var(--color-df-text-tertiary)]">ID</div>
+            <div className="text-xs font-mono text-[var(--color-df-text-secondary)] bg-[color-mix(in_oklab,var(--color-df-base)_40%,transparent)] border border-border rounded px-2 py-1">
               {id}
             </div>
             {summary && (
-              <div className="text-xs text-df-text-secondary leading-relaxed">{summary}</div>
+              <div className="text-xs text-[var(--color-df-text-secondary)] leading-relaxed">{summary}</div>
             )}
           </div>
           <Handle
@@ -77,10 +77,10 @@ export const ActNode = React.memo(function ActNode({ data, selected, id }: NodeP
 
       <ContextMenuContent className="w-48">
         <ContextMenuItem onSelect={handleEdit}>
-          <Edit3 size={14} className="mr-2 text-df-npc-selected" /> Edit Act
+          <Edit3 size={14} className="mr-2 text-[var(--node-accent)]" /> Edit Act
         </ContextMenuItem>
         <ContextMenuItem onSelect={handleAddChapter}>
-          <Plus size={14} className="mr-2 text-df-player-selected" /> Add Chapter
+          <Plus size={14} className="mr-2 text-[var(--node-chapter-accent)]" /> Add Chapter
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem 

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActNodeFields.tsx
@@ -15,7 +15,7 @@ export function ActNodeFields({ act, onUpdate }: ActNodeFieldsProps) {
           type="text"
           value={act.title || ''}
           onChange={(event) => onUpdate({ title: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-act-accent)] outline-none"
           placeholder="Act title"
         />
       </div>
@@ -24,7 +24,7 @@ export function ActNodeFields({ act, onUpdate }: ActNodeFieldsProps) {
         <textarea
           value={act.summary || ''}
           onChange={(event) => onUpdate({ summary: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none min-h-[100px] resize-y"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-act-accent)] outline-none min-h-[100px] resize-y"
           placeholder="Act summary"
         />
       </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterNode.tsx
@@ -55,16 +55,16 @@ export const ChapterNode = React.memo(function ChapterNode({ data, selected, id 
             </div>
             <div className="flex-1 min-w-0">
               <div className="text-xs uppercase tracking-wide">Chapter</div>
-              <div className="text-sm font-semibold text-df-text-primary truncate">{title}</div>
+              <div className="text-sm font-semibold text-foreground truncate">{title}</div>
             </div>
           </div>
           <div className="px-3 py-2 space-y-2">
-            <div className="text-[10px] uppercase tracking-wide text-df-text-tertiary">ID</div>
-            <div className="text-xs font-mono text-df-text-secondary bg-df-base/40 border border-df-node-border rounded px-2 py-1">
+            <div className="text-[10px] uppercase tracking-wide text-[var(--color-df-text-tertiary)]">ID</div>
+            <div className="text-xs font-mono text-[var(--color-df-text-secondary)] bg-[color-mix(in_oklab,var(--color-df-base)_40%,transparent)] border border-border rounded px-2 py-1">
               {id}
             </div>
             {summary && (
-              <div className="text-xs text-df-text-secondary leading-relaxed">{summary}</div>
+              <div className="text-xs text-[var(--color-df-text-secondary)] leading-relaxed">{summary}</div>
             )}
           </div>
           <Handle
@@ -77,10 +77,10 @@ export const ChapterNode = React.memo(function ChapterNode({ data, selected, id 
 
       <ContextMenuContent className="w-48">
         <ContextMenuItem onSelect={handleEdit}>
-          <Edit3 size={14} className="mr-2 text-df-npc-selected" /> Edit Chapter
+          <Edit3 size={14} className="mr-2 text-[var(--node-accent)]" /> Edit Chapter
         </ContextMenuItem>
         <ContextMenuItem onSelect={handleAddPage}>
-          <Plus size={14} className="mr-2 text-df-player-selected" /> Add Page
+          <Plus size={14} className="mr-2 text-[var(--node-page-accent)]" /> Add Page
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem 

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterNodeFields.tsx
@@ -15,7 +15,7 @@ export function ChapterNodeFields({ chapter, onUpdate }: ChapterNodeFieldsProps)
           type="text"
           value={chapter.title || ''}
           onChange={(event) => onUpdate({ title: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-chapter-accent)] outline-none"
           placeholder="Chapter title"
         />
       </div>
@@ -24,7 +24,7 @@ export function ChapterNodeFields({ chapter, onUpdate }: ChapterNodeFieldsProps)
         <textarea
           value={chapter.summary || ''}
           onChange={(event) => onUpdate({ summary: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none min-h-[100px] resize-y"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-chapter-accent)] outline-none min-h-[100px] resize-y"
           placeholder="Chapter summary"
         />
       </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterEdgeContextMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterEdgeContextMenu.tsx
@@ -26,8 +26,8 @@ export function CharacterEdgeContextMenu({
 }: CharacterEdgeContextMenuProps) {
   return (
     <div className="fixed z-50" style={{ left: x, top: y }}>
-      <div className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[180px]">
-        <div className="px-3 py-1 text-[10px] text-df-text-secondary uppercase border-b border-df-sidebar-border">
+      <div className="bg-popover border border-border rounded-lg shadow-lg p-1 min-w-[180px]">
+        <div className="px-3 py-1 text-[10px] text-muted-foreground uppercase border-b border-border">
           Insert Node
         </div>
         {availableNodeTypes.map(type => (
@@ -37,14 +37,14 @@ export function CharacterEdgeContextMenu({
               onInsertNode(type, edgeId, graphX, graphY);
               onClose();
             }}
-            className="w-full text-left px-3 py-2 text-sm text-df-text-primary hover:bg-df-elevated rounded"
+            className="w-full text-left px-3 py-2 text-sm text-foreground hover:bg-accent rounded"
           >
             Insert {FORGE_NODE_TYPE_LABELS[type]}
           </button>
         ))}
         <button
           onClick={onClose}
-          className="w-full text-left px-3 py-2 text-sm text-df-text-secondary hover:bg-df-elevated rounded"
+          className="w-full text-left px-3 py-2 text-sm text-muted-foreground hover:bg-accent rounded"
         >
           Cancel
         </button>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNode.tsx
@@ -131,7 +131,7 @@ export const CharacterNode = React.memo(function CharacterNode({ data, selected 
         
         {/* Character Name - Center/Left */}
         <div className="flex-1 min-w-0">
-          <h3 className="text-base font-bold text-df-text-primary truncate leading-tight">
+          <h3 className="text-base font-bold text-foreground truncate leading-tight">
             {displayName}
           </h3>
         </div>
@@ -139,26 +139,32 @@ export const CharacterNode = React.memo(function CharacterNode({ data, selected 
         {/* Metadata Icons - Right side */}
         <div className="flex items-center gap-2 flex-shrink-0">
           {/* Node ID Icon */}
-          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-base/50 border border-df-control-border" title={`Node ID: ${node.id}`}>
-            <Hash size={12} className="text-df-text-secondary" />
-            <span className="text-[10px] font-mono text-df-text-secondary">{node.id}</span>
+          <div
+            className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--color-df-base)_50%,transparent)] border border-border"
+            title={`Node ID: ${node.id}`}
+          >
+            <Hash size={12} className="text-[var(--color-df-text-secondary)]" />
+            <span className="text-[10px] font-mono text-[var(--color-df-text-secondary)]">{node.id}</span>
           </div>
           
           {/* Type Icon */}
-          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-npc-selected/20 border border-df-npc-selected/50" title="NPC Node">
-            <MessageSquare size={14} className="text-df-npc-selected" />
-            <span className="text-[10px] font-semibold text-df-npc-selected">NPC</span>
+          <div
+            className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--node-accent)_20%,transparent)] border border-[color-mix(in_oklab,var(--node-accent)_50%,transparent)]"
+            title="NPC Node"
+          >
+            <MessageSquare size={14} className="text-[var(--node-accent)]" />
+            <span className="text-[10px] font-semibold text-[var(--node-accent)]">NPC</span>
           </div>
         </div>
         
         {/* Start/End badge - Overlay on header */}
         {isStartNode && (
-          <div className="absolute top-1 right-1 bg-df-start text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+          <div className="absolute top-1 right-1 bg-[var(--node-start-border)] text-foreground text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
             <Play size={8} fill="currentColor" /> START
           </div>
         )}
         {isEndNode && (
-          <div className="absolute top-1 right-1 bg-df-end text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+          <div className="absolute top-1 right-1 bg-[var(--node-end-border)] text-foreground text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
             <Flag size={8} /> END
           </div>
         )}
@@ -166,8 +172,8 @@ export const CharacterNode = React.memo(function CharacterNode({ data, selected 
       
       {/* Dialogue Content */}
       <div className="px-4 py-3">
-        <div className="bg-df-elevated border border-df-control-border rounded-lg px-4 py-3 mb-2">
-          <p className="text-sm text-df-text-primary leading-relaxed">
+        <div className="bg-card border border-border rounded-lg px-4 py-3 mb-2">
+          <p className="text-sm text-foreground leading-relaxed">
             &quot;{contentPreview}&quot;
           </p>
         </div>
@@ -204,11 +210,11 @@ export const CharacterNode = React.memo(function CharacterNode({ data, selected 
 
       <ContextMenuContent className="w-48">
         <ContextMenuItem onSelect={handleEdit}>
-          <Edit3 size={14} className="mr-2 text-df-npc-selected" /> Edit Node
+          <Edit3 size={14} className="mr-2 text-[var(--node-accent)]" /> Edit Node
         </ContextMenuItem>
         {node.id && (
           <ContextMenuItem onSelect={handleAddConditionals}>
-            <Plus size={14} className="mr-2 text-df-conditional-border" /> Add Conditionals
+            <Plus size={14} className="mr-2 text-[var(--node-conditional-accent)]" /> Add Conditionals
           </ContextMenuItem>
         )}
         {!isStartNode && node.id && (

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNodeFields.tsx
@@ -18,7 +18,7 @@ export function CharacterNodeFields({ node, graph, characters, onUpdate, onFocus
   return (
     <>
       <div>
-        <label className="text-[10px] text-df-text-secondary uppercase">Character</label>
+        <label className="text-[10px] text-[var(--color-df-text-secondary)] uppercase">Character</label>
         <CharacterSelector
           characters={characters}
           selectedCharacterId={node.characterId}
@@ -32,21 +32,21 @@ export function CharacterNodeFields({ node, graph, characters, onUpdate, onFocus
           placeholder="Select character..."
           className="mb-2"
         />
-        <div className="text-[9px] text-df-text-tertiary mt-1">
+        <div className="text-[9px] text-[var(--color-df-text-tertiary)] mt-1">
           Or enter custom speaker name below
         </div>
       </div>
       <div>
-        <label className="text-[10px] text-df-text-secondary uppercase">Speaker (Custom)</label>
+        <label className="text-[10px] text-[var(--color-df-text-secondary)] uppercase">Speaker (Custom)</label>
         <div className="flex items-center gap-2">
-          <div className="w-8 h-8 rounded-full bg-df-control-bg border border-df-control-border flex items-center justify-center flex-shrink-0">
-            <User size={16} className="text-df-text-secondary" />
+          <div className="w-8 h-8 rounded-full bg-[var(--color-df-control-bg)] border border-border flex items-center justify-center flex-shrink-0">
+            <User size={16} className="text-[var(--color-df-text-secondary)]" />
           </div>
           <input
             type="text"
             value={node.speaker || ''}
             onChange={(event) => onUpdate({ speaker: event.target.value })}
-            className="flex-1 bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+            className="flex-1 bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-npc-accent)] outline-none"
             placeholder="Custom speaker name (optional)"
           />
         </div>
@@ -56,7 +56,7 @@ export function CharacterNodeFields({ node, graph, characters, onUpdate, onFocus
         <textarea
           value={node.content}
           onChange={(event) => onUpdate({ content: event.target.value })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none min-h-[100px] resize-y"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-npc-accent)] outline-none min-h-[100px] resize-y"
           placeholder="What the character says..."
         />
       </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalEdgeContextMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalEdgeContextMenu.tsx
@@ -26,8 +26,8 @@ export function ConditionalEdgeContextMenu({
 }: ConditionalEdgeContextMenuProps) {
   return (
     <div className="fixed z-50" style={{ left: x, top: y }}>
-      <div className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[180px]">
-        <div className="px-3 py-1 text-[10px] text-df-text-secondary uppercase border-b border-df-sidebar-border">
+      <div className="bg-popover border border-border rounded-lg shadow-lg p-1 min-w-[180px]">
+        <div className="px-3 py-1 text-[10px] text-muted-foreground uppercase border-b border-border">
           Insert Node
         </div>
         {availableNodeTypes.map(type => (
@@ -37,14 +37,14 @@ export function ConditionalEdgeContextMenu({
               onInsertNode(type, edgeId, graphX, graphY);
               onClose();
             }}
-            className="w-full text-left px-3 py-2 text-sm text-df-text-primary hover:bg-df-elevated rounded"
+            className="w-full text-left px-3 py-2 text-sm text-foreground hover:bg-accent rounded"
           >
             Insert {FORGE_NODE_TYPE_LABELS[type]}
           </button>
         ))}
         <button
           onClick={onClose}
-          className="w-full text-left px-3 py-2 text-sm text-df-text-secondary hover:bg-df-elevated rounded"
+          className="w-full text-left px-3 py-2 text-sm text-muted-foreground hover:bg-accent rounded"
         >
           Cancel
         </button>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode.tsx
@@ -130,12 +130,12 @@ export const ConditionalNode = React.memo(function ConditionalNode({ data, selec
           >
             {/* Icon Placeholder - Left side (no avatar for conditional) */}
             <div className="w-14 h-14 rounded-full bg-node border-[3px] border-node flex items-center justify-center shadow-lg flex-shrink-0">
-              <Code size={20} className="text-df-conditional-selected" />
+              <Code size={20} className="text-[var(--node-accent)]" />
             </div>
 
             {/* Node Type Name - Center/Left */}
             <div className="flex-1 min-w-0">
-              <h3 className="text-base font-bold text-df-text-primary truncate leading-tight">
+              <h3 className="text-base font-bold text-foreground truncate leading-tight">
                 Conditional Logic
               </h3>
             </div>
@@ -143,26 +143,32 @@ export const ConditionalNode = React.memo(function ConditionalNode({ data, selec
             {/* Metadata Icons - Right side */}
             <div className="flex items-center gap-2 flex-shrink-0">
               {/* Node ID Icon */}
-              <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-base/50 border border-df-control-border" title={`Node ID: ${node.id}`}>
-                <Hash size={12} className="text-df-text-secondary" />
-                <span className="text-[10px] font-mono text-df-text-secondary">{node.id}</span>
+              <div
+                className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--color-df-base)_50%,transparent)] border border-border"
+                title={`Node ID: ${node.id}`}
+              >
+                <Hash size={12} className="text-[var(--color-df-text-secondary)]" />
+                <span className="text-[10px] font-mono text-[var(--color-df-text-secondary)]">{node.id}</span>
               </div>
 
               {/* Type Icon */}
-              <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-conditional-selected/20 border border-df-conditional-selected/50" title="Conditional Node">
-                <GitBranch size={14} className="text-df-conditional-selected" />
-                <span className="text-[10px] font-semibold text-df-conditional-selected">IF/ELSE</span>
+              <div
+                className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--node-accent)_20%,transparent)] border border-[color-mix(in_oklab,var(--node-accent)_50%,transparent)]"
+                title="Conditional Node"
+              >
+                <GitBranch size={14} className="text-[var(--node-accent)]" />
+                <span className="text-[10px] font-semibold text-[var(--node-accent)]">IF/ELSE</span>
               </div>
             </div>
 
             {/* Start/End badge - Overlay on header */}
             {isStartNode && (
-              <div className="absolute top-1 right-1 bg-df-start text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+              <div className="absolute top-1 right-1 bg-[var(--node-start-border)] text-foreground text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
                 <Play size={8} fill="currentColor" /> START
               </div>
             )}
             {isEndNode && (
-              <div className="absolute top-1 right-1 bg-df-end text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+              <div className="absolute top-1 right-1 bg-[var(--node-end-border)] text-foreground text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
                 <Flag size={8} /> END
               </div>
             )}
@@ -182,14 +188,14 @@ export const ConditionalNode = React.memo(function ConditionalNode({ data, selec
                 <div
                   key={block.id}
                   ref={el => { blockRefs.current[idx] = el; }}
-                  className="px-3 py-2 border-b border-df-control-border last:border-b-0"
+                  className="px-3 py-2 border-b border-border last:border-b-0"
                 >
                   <div className="flex items-center gap-2 mb-1.5">
-                    <span className="text-[9px] px-1.5 py-0.5 rounded bg-df-base text-df-text-primary font-semibold">
+                    <span className="text-[9px] px-1.5 py-0.5 rounded bg-[var(--color-df-base)] text-foreground font-semibold">
                       {blockType}
                     </span>
                     {block.condition && block.condition.length > 0 && (
-                      <span className="text-[9px] text-df-text-secondary font-mono truncate flex-1">
+                      <span className="text-[9px] text-[var(--color-df-text-secondary)] font-mono truncate flex-1">
                         {block.condition.map((condition: ForgeCondition) => {
                           return formatCondition(condition);
                         }).filter(c => c).join(' and ').slice(0, 30)}
@@ -201,11 +207,11 @@ export const ConditionalNode = React.memo(function ConditionalNode({ data, selec
                   {displayName && (
                     <div className="flex items-center gap-1.5 mb-1.5">
                       <span className="text-sm flex-shrink-0">{avatar}</span>
-                      <span className="text-[10px] text-df-conditional-selected font-medium">{displayName}</span>
+                      <span className="text-[10px] text-[var(--node-accent)] font-medium">{displayName}</span>
                     </div>
                   )}
 
-                  <div className="text-xs text-df-text-primary line-clamp-2 bg-df-elevated border border-df-control-border rounded px-3 py-1.5">
+                  <div className="text-xs text-foreground line-clamp-2 bg-card border border-border rounded px-3 py-1.5">
                     &quot;{block.content?.slice(0, 60) + (block.content?.length && block.content.length > 60 ? '...' : '')}&quot;
                   </div>
 
@@ -228,7 +234,7 @@ export const ConditionalNode = React.memo(function ConditionalNode({ data, selec
 
           {/* Flag indicators */}
           {setFlags.length > 0 && (
-            <div className="px-4 py-2 border-t border-df-control-border flex flex-wrap gap-1">
+            <div className="px-4 py-2 border-t border-border flex flex-wrap gap-1">
               {setFlags.map(flagId => {
                 const flag = flagSchema?.flags.find(f => f.id === flagId);
                 const flagType = flag?.type || 'dialogue';
@@ -246,7 +252,7 @@ export const ConditionalNode = React.memo(function ConditionalNode({ data, selec
 
       <ContextMenuContent className="w-48">
         <ContextMenuItem onSelect={handleEdit}>
-          <Edit3 size={14} className="mr-2 text-df-npc-selected" /> Edit Node
+          <Edit3 size={14} className="mr-2 text-[var(--node-accent)]" /> Edit Node
         </ContextMenuItem>
         {!isStartNode && node.id && (
           <>
@@ -261,7 +267,7 @@ export const ConditionalNode = React.memo(function ConditionalNode({ data, selec
         )}
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={handleAddBlock}>
-          <Plus size={14} className="mr-2 text-df-npc-selected" /> Add Conditional Block
+          <Plus size={14} className="mr-2 text-[var(--node-accent)]" /> Add Conditional Block
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNodeFields.tsx
@@ -142,8 +142,8 @@ export function ConditionalNodeFields({
                   </div>
                   
                   <div className="flex items-center gap-2">
-                    <div className="w-7 h-7 rounded-full bg-df-control-bg border border-df-control-border flex items-center justify-center flex-shrink-0">
-                      <User size={14} className="text-df-text-secondary" />
+                    <div className="w-7 h-7 rounded-full bg-[var(--color-df-control-bg)] border border-border flex items-center justify-center flex-shrink-0">
+                      <User size={14} className="text-[var(--color-df-text-secondary)]" />
                     </div>
                     <input
                       type="text"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/DetourNode/DetourNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/DetourNode/DetourNode.tsx
@@ -77,46 +77,52 @@ export const DetourNode = React.memo(function DetourNode({ data, selected }: Nod
       
       <div className="bg-node-header border-b-2 border-node px-3 py-2.5 flex items-center gap-3 relative">
         <div className="w-14 h-14 rounded-full bg-node border-[3px] border-node flex items-center justify-center shadow-lg flex-shrink-0">
-          <CornerDownRight size={20} className="text-df-storylet-selected" />
+          <CornerDownRight size={20} className="text-[var(--node-accent)]" />
         </div>
         
         <div className="flex-1 min-w-0">
-          <h3 className="text-base font-bold text-df-text-primary truncate leading-tight">
+          <h3 className="text-base font-bold text-foreground truncate leading-tight">
             {title || 'Detour'}
           </h3>
           {summary && (
-            <p className="text-xs text-df-text-secondary truncate mt-0.5">
+            <p className="text-xs text-[var(--color-df-text-secondary)] truncate mt-0.5">
               {summary}
             </p>
           )}
         </div>
         
         <div className="flex items-center gap-2 flex-shrink-0">
-          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-base/50 border border-df-control-border" title={`Node ID: ${id}`}>
-            <Hash size={12} className="text-df-text-secondary" />
-            <span className="text-[10px] font-mono text-df-text-secondary">{id}</span>
+          <div
+            className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--color-df-base)_50%,transparent)] border border-border"
+            title={`Node ID: ${id}`}
+          >
+            <Hash size={12} className="text-[var(--color-df-text-secondary)]" />
+            <span className="text-[10px] font-mono text-[var(--color-df-text-secondary)]">{id}</span>
           </div>
           
-          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-storylet-selected/20 border border-df-storylet-selected/50" title="Detour Node">
-            <CornerDownRight size={14} className="text-df-storylet-selected" />
-            <span className="text-[10px] font-semibold text-df-storylet-selected">DETOUR</span>
+          <div
+            className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--node-accent)_20%,transparent)] border border-[color-mix(in_oklab,var(--node-accent)_50%,transparent)]"
+            title="Detour Node"
+          >
+            <CornerDownRight size={14} className="text-[var(--node-accent)]" />
+            <span className="text-[10px] font-semibold text-[var(--node-accent)]">DETOUR</span>
           </div>
         </div>
       </div>
       
       <div className="px-4 py-3 space-y-2">
         <div className="flex items-center gap-2 text-sm">
-          <span className="text-df-text-secondary">Storylet:</span>
-          <span className="text-df-storylet-selected font-mono text-xs bg-df-base px-2 py-0.5 rounded border border-df-control-border">
+          <span className="text-[var(--color-df-text-secondary)]">Storylet:</span>
+          <span className="text-[var(--node-accent)] font-mono text-xs bg-[var(--color-df-base)] px-2 py-0.5 rounded border border-border">
             {storyletId ? String(storyletId) : 'Not set'}
           </span>
         </div>
         
         {returnNodeId && (
           <div className="flex items-center gap-2 text-sm">
-            <ArrowLeftCircle size={14} className="text-df-text-secondary" />
-            <span className="text-df-text-secondary">Returns to:</span>
-            <span className="text-df-text-primary font-mono text-xs bg-df-base px-2 py-0.5 rounded border border-df-control-border">
+            <ArrowLeftCircle size={14} className="text-[var(--color-df-text-secondary)]" />
+            <span className="text-[var(--color-df-text-secondary)]">Returns to:</span>
+            <span className="text-foreground font-mono text-xs bg-[var(--color-df-base)] px-2 py-0.5 rounded border border-border">
               {returnNodeId}
             </span>
           </div>
@@ -133,7 +139,7 @@ export const DetourNode = React.memo(function DetourNode({ data, selected }: Nod
 
       <ContextMenuContent className="w-48">
         <ContextMenuItem onSelect={handleEdit}>
-          <Edit3 size={14} className="mr-2 text-df-npc-selected" /> Edit Node
+          <Edit3 size={14} className="mr-2 text-[var(--node-accent)]" /> Edit Node
         </ContextMenuItem>
         {!isStartNode && node.id && (
           <>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/DetourNode/DetourNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/DetourNode/DetourNodeFields.tsx
@@ -39,7 +39,7 @@ export function DetourNodeFields({
           type="text"
           value={node.label || ''}
           onChange={(event) => onUpdate({ label: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-storylet-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-detour-accent)] outline-none"
           placeholder="Detour title"
         />
       </div>
@@ -49,7 +49,7 @@ export function DetourNodeFields({
         <textarea
           value={node.content || ''}
           onChange={(event) => onUpdate({ content: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-storylet-selected outline-none min-h-[60px] resize-y"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-detour-accent)] outline-none min-h-[60px] resize-y"
           placeholder="Detour summary/description"
         />
       </div>
@@ -100,7 +100,7 @@ export function DetourNodeFields({
               } : undefined,
             });
           }}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-storylet-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-detour-accent)] outline-none"
         >
           <option value="">Select storylet graph...</option>
           {storyletGraphs.map((g) => (
@@ -127,7 +127,7 @@ export function DetourNodeFields({
               });
             }
           }}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-storylet-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-detour-accent)] outline-none"
           placeholder="return_node_id"
         />
       </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageNode.tsx
@@ -64,16 +64,16 @@ export const PageNode = React.memo(function PageNode({ data, selected, id }: Nod
             </div>
             <div className="flex-1 min-w-0">
               <div className="text-xs uppercase tracking-wide">Page</div>
-              <div className="text-sm font-semibold text-df-text-primary truncate">{title}</div>
+              <div className="text-sm font-semibold text-foreground truncate">{title}</div>
             </div>
           </div>
           <div className="px-3 py-2 space-y-2">
-            <div className="text-[10px] uppercase tracking-wide text-df-text-tertiary">ID</div>
-            <div className="text-xs font-mono text-df-text-secondary bg-df-base/40 border border-df-node-border rounded px-2 py-1">
+            <div className="text-[10px] uppercase tracking-wide text-[var(--color-df-text-tertiary)]">ID</div>
+            <div className="text-xs font-mono text-[var(--color-df-text-secondary)] bg-[color-mix(in_oklab,var(--color-df-base)_40%,transparent)] border border-border rounded px-2 py-1">
               {id}
             </div>
             {summary && (
-              <div className="text-xs text-df-text-secondary leading-relaxed">{summary}</div>
+              <div className="text-xs text-[var(--color-df-text-secondary)] leading-relaxed">{summary}</div>
             )}
           </div>
           <Handle
@@ -86,20 +86,20 @@ export const PageNode = React.memo(function PageNode({ data, selected, id }: Nod
 
       <ContextMenuContent className="w-56">
         <ContextMenuItem onSelect={handleAddPage}>
-          <FilePlus size={14} className="mr-2 text-df-page" /> Add Page
+          <FilePlus size={14} className="mr-2 text-[var(--node-page-accent)]" /> Add Page
         </ContextMenuItem>
         <ContextMenuItem onSelect={handleAddChapter}>
-          <BookPlus size={14} className="mr-2 text-df-chapter" /> Add Chapter
+          <BookPlus size={14} className="mr-2 text-[var(--node-chapter-accent)]" /> Add Chapter
         </ContextMenuItem>
         <ContextMenuItem onSelect={handleAddAct}>
-          <LayoutList size={14} className="mr-2 text-df-act" /> Add Act
+          <LayoutList size={14} className="mr-2 text-[var(--node-act-accent)]" /> Add Act
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem onSelect={handleEditDialogue}>
-          <MessageSquareText size={14} className="mr-2 text-df-npc-selected" /> Edit Dialogue
+          <MessageSquareText size={14} className="mr-2 text-[var(--node-npc-accent)]" /> Edit Dialogue
         </ContextMenuItem>
         <ContextMenuItem onSelect={handleEditPage}>
-          <Edit3 size={14} className="mr-2 text-df-text-secondary" /> Edit Page Details
+          <Edit3 size={14} className="mr-2 text-[var(--color-df-text-secondary)]" /> Edit Page Details
         </ContextMenuItem>
         <ContextMenuSeparator />
         <ContextMenuItem 

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageNodeFields.tsx
@@ -15,7 +15,7 @@ export function PageNodeFields({ page, onUpdate }: PageNodeFieldsProps) {
           type="text"
           value={page.title || ''}
           onChange={(event) => onUpdate({ title: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-page-accent)] outline-none"
           placeholder="Page title"
         />
       </div>
@@ -24,7 +24,7 @@ export function PageNodeFields({ page, onUpdate }: PageNodeFieldsProps) {
         <textarea
           value={page.summary || ''}
           onChange={(event) => onUpdate({ summary: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none min-h-[100px] resize-y"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-page-accent)] outline-none min-h-[100px] resize-y"
           placeholder="Page summary"
         />
       </div>
@@ -34,7 +34,7 @@ export function PageNodeFields({ page, onUpdate }: PageNodeFieldsProps) {
           type="number"
           value={page.dialogueGraph || ''}
           onChange={(event) => onUpdate({ dialogueGraph: event.target.value ? Number(event.target.value) : null })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none font-mono"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-page-accent)] outline-none font-mono"
           placeholder="dialogue_graph_id"
         />
       </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerEdgeContextMenu.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerEdgeContextMenu.tsx
@@ -26,8 +26,8 @@ export function PlayerEdgeContextMenu({
 }: PlayerEdgeContextMenuProps) {
   return (
     <div className="fixed z-50" style={{ left: x, top: y }}>
-      <div className="bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[180px]">
-        <div className="px-3 py-1 text-[10px] text-df-text-secondary uppercase border-b border-df-sidebar-border">
+      <div className="bg-popover border border-border rounded-lg shadow-lg p-1 min-w-[180px]">
+        <div className="px-3 py-1 text-[10px] text-muted-foreground uppercase border-b border-border">
           Insert Node
         </div>
         {availableNodeTypes.map(type => (
@@ -37,14 +37,14 @@ export function PlayerEdgeContextMenu({
               onInsertNode(type, edgeId, graphX, graphY);
               onClose();
             }}
-            className="w-full text-left px-3 py-2 text-sm text-df-text-primary hover:bg-df-elevated rounded"
+            className="w-full text-left px-3 py-2 text-sm text-foreground hover:bg-accent rounded"
           >
             Insert {FORGE_NODE_TYPE_LABELS[type]}
           </button>
         ))}
         <button
           onClick={onClose}
-          className="w-full text-left px-3 py-2 text-sm text-df-text-secondary hover:bg-df-elevated rounded"
+          className="w-full text-left px-3 py-2 text-sm text-muted-foreground hover:bg-accent rounded"
         >
           Cancel
         </button>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNode.tsx
@@ -144,7 +144,7 @@ export const PlayerNode = React.memo(function PlayerNode({ data, selected }: Nod
         
         {/* Character Name - Center/Left */}
         <div className="flex-1 min-w-0">
-          <h3 className="text-base font-bold text-df-text-primary truncate leading-tight">
+          <h3 className="text-base font-bold text-foreground truncate leading-tight">
             {displayName}
           </h3>
         </div>
@@ -152,26 +152,32 @@ export const PlayerNode = React.memo(function PlayerNode({ data, selected }: Nod
         {/* Metadata Icons - Right side */}
         <div className="flex items-center gap-2 flex-shrink-0">
           {/* Node ID Icon */}
-          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-base/50 border border-df-control-border" title={`Node ID: ${node.id}`}>
-            <Hash size={12} className="text-df-text-secondary" />
-            <span className="text-[10px] font-mono text-df-text-secondary">{node.id}</span>
+          <div
+            className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--color-df-base)_50%,transparent)] border border-border"
+            title={`Node ID: ${node.id}`}
+          >
+            <Hash size={12} className="text-[var(--color-df-text-secondary)]" />
+            <span className="text-[10px] font-mono text-[var(--color-df-text-secondary)]">{node.id}</span>
           </div>
           
           {/* Type Icon */}
-          <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-player-selected/20 border border-df-player-selected/50" title="Player Node">
-            <GitBranch size={14} className="text-df-player-selected" />
-            <span className="text-[10px] font-semibold text-df-player-selected">PLAYER</span>
+          <div
+            className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--node-accent)_20%,transparent)] border border-[color-mix(in_oklab,var(--node-accent)_50%,transparent)]"
+            title="Player Node"
+          >
+            <GitBranch size={14} className="text-[var(--node-accent)]" />
+            <span className="text-[10px] font-semibold text-[var(--node-accent)]">PLAYER</span>
           </div>
         </div>
         
         {/* Start/End badge - Overlay on header */}
         {isStartNode && (
-          <div className="absolute top-1 right-1 bg-df-start text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+          <div className="absolute top-1 right-1 bg-[var(--node-start-border)] text-foreground text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
             <Play size={8} fill="currentColor" /> START
           </div>
         )}
         {isEndNode && (
-          <div className="absolute top-1 right-1 bg-df-end text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+          <div className="absolute top-1 right-1 bg-[var(--node-end-border)] text-foreground text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
             <Flag size={8} /> END
           </div>
         )}
@@ -188,9 +194,9 @@ export const PlayerNode = React.memo(function PlayerNode({ data, selected }: Nod
               }}
               className="relative group"
             >
-              <div className="node-choice bg-df-elevated border border-df-control-border rounded-lg px-3 py-2 flex items-start gap-2 transition-colors">
+              <div className="node-choice bg-card border border-border rounded-lg px-3 py-2 flex items-start gap-2 transition-colors">
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm text-df-text-primary leading-relaxed">
+                  <p className="text-sm text-foreground leading-relaxed">
                     &quot;{choice.text || 'Empty choice'}&quot;
                   </p>
                   
@@ -200,8 +206,7 @@ export const PlayerNode = React.memo(function PlayerNode({ data, selected }: Nod
                       {choice.setFlags.map(flagId => {
                         const flag = flagSchema?.flags.find(f => f.id === flagId);
                         const flagType = flag?.type || 'dialogue';
-                        const colorClass = flagType === 'dialogue' ? 'bg-df-flag-dialogue-bg text-df-flag-dialogue border-df-flag-dialogue' :
-                          getFlagColorClass(flagType);
+                        const colorClass = getFlagColorClass(flagType);
                         return (
                           <span key={flagId} className={`text-[8px] px-1 py-0.5 rounded-full border ${colorClass}`} title={flag?.name || flagId}>
                             {flagType === 'dialogue' ? 't' : flagType[0]}
@@ -239,11 +244,11 @@ export const PlayerNode = React.memo(function PlayerNode({ data, selected }: Nod
 
       <ContextMenuContent className="w-48">
         <ContextMenuItem onSelect={handleEdit}>
-          <Edit3 size={14} className="mr-2 text-df-npc-selected" /> Edit Node
+          <Edit3 size={14} className="mr-2 text-[var(--node-accent)]" /> Edit Node
         </ContextMenuItem>
         {node.id && (
           <ContextMenuItem onSelect={handleAddChoice}>
-            <Plus size={14} className="mr-2 text-df-player-selected" /> Add Choice
+            <Plus size={14} className="mr-2 text-[var(--node-accent)]" /> Add Choice
           </ContextMenuItem>
         )}
         {!isStartNode && node.id && (

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNodeFields.tsx
@@ -73,7 +73,7 @@ export function PlayerNodeFields({
   return (
     <div>
       <div>
-        <label className="text-[10px] text-df-text-secondary uppercase">Character</label>
+        <label className="text-[10px] text-[var(--color-df-text-secondary)] uppercase">Character</label>
         <CharacterSelector
           characters={characters}
           selectedCharacterId={node.characterId}
@@ -87,21 +87,21 @@ export function PlayerNodeFields({
           placeholder="Select character..."
           className="mb-2"
         />
-        <div className="text-[9px] text-df-text-tertiary mt-1">
+        <div className="text-[9px] text-[var(--color-df-text-tertiary)] mt-1">
           Or enter custom speaker name below
         </div>
       </div>
       <div>
-        <label className="text-[10px] text-df-text-secondary uppercase">Speaker (Custom)</label>
+        <label className="text-[10px] text-[var(--color-df-text-secondary)] uppercase">Speaker (Custom)</label>
         <div className="flex items-center gap-2">
-          <div className="w-8 h-8 rounded-full bg-df-control-bg border border-df-control-border flex items-center justify-center flex-shrink-0">
-            <User size={16} className="text-df-text-secondary" />
+          <div className="w-8 h-8 rounded-full bg-[var(--color-df-control-bg)] border border-border flex items-center justify-center flex-shrink-0">
+            <User size={16} className="text-[var(--color-df-text-secondary)]" />
           </div>
           <input
             type="text"
             value={node.speaker || ''}
             onChange={(event) => onUpdate({ speaker: event.target.value })}
-            className="flex-1 bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-player-selected outline-none"
+            className="flex-1 bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-player-accent)] outline-none"
             placeholder="Custom speaker name (optional)"
           />
         </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletNode.tsx
@@ -92,55 +92,58 @@ export const StoryletNode = React.memo(function StoryletNode({ data, selected }:
 
           <div className="bg-node-header border-b-2 border-node px-3 py-2.5 flex items-center gap-3 relative">
             <div className="w-14 h-14 rounded-full bg-node border-[3px] border-node flex items-center justify-center text-3xl shadow-lg flex-shrink-0">
-              <BookOpen size={20} className="text-df-npc-selected" />
+              <BookOpen size={20} className="text-[var(--node-accent)]" />
             </div>
 
             <div className="flex-1 min-w-0">
-              <h3 className="text-base font-bold text-df-text-primary truncate leading-tight">Storylet</h3>
+              <h3 className="text-base font-bold text-foreground truncate leading-tight">Storylet</h3>
             </div>
 
             <div className="flex items-center gap-2 flex-shrink-0">
               <div
-                className="flex items-center gap-1 px-2 py-1 rounded bg-df-base/50 border border-df-control-border"
+                className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--color-df-base)_50%,transparent)] border border-border"
                 title={`Node ID: ${node.id}`}
               >
-                <Hash size={12} className="text-df-text-secondary" />
-                <span className="text-[10px] font-mono text-df-text-secondary">{node.id}</span>
+                <Hash size={12} className="text-[var(--color-df-text-secondary)]" />
+                <span className="text-[10px] font-mono text-[var(--color-df-text-secondary)]">{node.id}</span>
               </div>
 
-              <div className="flex items-center gap-1 px-2 py-1 rounded bg-df-npc-selected/20 border border-df-npc-selected/50" title="Storylet Node">
-                <BookOpen size={14} className="text-df-npc-selected" />
-                <span className="text-[10px] font-semibold text-df-npc-selected">STORYLET</span>
+              <div
+                className="flex items-center gap-1 px-2 py-1 rounded bg-[color-mix(in_oklab,var(--node-accent)_20%,transparent)] border border-[color-mix(in_oklab,var(--node-accent)_50%,transparent)]"
+                title="Storylet Node"
+              >
+                <BookOpen size={14} className="text-[var(--node-accent)]" />
+                <span className="text-[10px] font-semibold text-[var(--node-accent)]">STORYLET</span>
               </div>
             </div>
 
             {isStartNode && (
-              <div className="absolute top-1 right-1 bg-df-start text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+              <div className="absolute top-1 right-1 bg-[var(--node-start-border)] text-foreground text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
                 <Play size={8} fill="currentColor" /> START
               </div>
             )}
             {isEndNode && (
-              <div className="absolute top-1 right-1 bg-df-end text-df-text-primary text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
+              <div className="absolute top-1 right-1 bg-[var(--node-end-border)] text-foreground text-[8px] font-bold px-1.5 py-0.5 rounded flex items-center gap-0.5 shadow-lg z-20">
                 <Flag size={8} /> END
               </div>
             )}
           </div>
 
           <div className="px-4 py-3 space-y-2">
-            <div className="bg-df-elevated border border-df-control-border rounded-lg px-4 py-3">
-              <p className="text-sm text-df-text-primary leading-relaxed">&quot;{contentPreview}&quot;</p>
+            <div className="bg-card border border-border rounded-lg px-4 py-3">
+              <p className="text-sm text-foreground leading-relaxed">&quot;{contentPreview}&quot;</p>
             </div>
 
             <div className="space-y-1">
-              <div className="text-[10px] text-df-text-secondary uppercase">Graph ID</div>
-              <div className="text-xs text-df-text-primary font-mono bg-df-base/40 border border-df-control-border rounded px-2 py-1">
+              <div className="text-[10px] text-[var(--color-df-text-secondary)] uppercase">Graph ID</div>
+              <div className="text-xs text-foreground font-mono bg-[color-mix(in_oklab,var(--color-df-base)_40%,transparent)] border border-border rounded px-2 py-1">
                 {graphId || 'Not set'}
               </div>
             </div>
 
             <div className="space-y-1">
-              <div className="text-[10px] text-df-text-secondary uppercase">Return Node ID</div>
-              <div className="text-xs text-df-text-primary font-mono bg-df-base/40 border border-df-control-border rounded px-2 py-1">
+              <div className="text-[10px] text-[var(--color-df-text-secondary)] uppercase">Return Node ID</div>
+              <div className="text-xs text-foreground font-mono bg-[color-mix(in_oklab,var(--color-df-base)_40%,transparent)] border border-border rounded px-2 py-1">
                 {returnNodeId || 'Not set'}
               </div>
             </div>
@@ -175,7 +178,7 @@ export const StoryletNode = React.memo(function StoryletNode({ data, selected }:
 
       <ContextMenuContent className="w-56">
         <ContextMenuItem onSelect={handleEdit}>
-          <Edit3 size={14} className="mr-2 text-df-npc-selected" /> Edit Node
+          <Edit3 size={14} className="mr-2 text-[var(--node-accent)]" /> Edit Node
         </ContextMenuItem>
 
         {graphId && (

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletNodeFields.tsx
@@ -56,7 +56,7 @@ export function StoryletNodeFields({
             const newGraphId = event.target.value ? parseInt(event.target.value) : undefined;
             onUpdateStoryletCall({ targetGraphId: newGraphId });
           }}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-storylet-accent)] outline-none"
         >
           <option value="">Select storylet graph...</option>
           {storyletGraphs.map((g) => (
@@ -65,7 +65,7 @@ export function StoryletNodeFields({
             </option>
           ))}
         </select>
-        <div className="text-[9px] text-df-text-tertiary mt-1">
+        <div className="text-[9px] text-[var(--color-df-text-tertiary)] mt-1">
           Or enter Template ID manually below
         </div>
       </div>
@@ -75,7 +75,7 @@ export function StoryletNodeFields({
           type="text"
           value={node.storyletCall?.targetGraphId || ''}
           onChange={(event) => onUpdateStoryletCall({ targetGraphId: parseInt(event.target.value || '0') || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-storylet-accent)] outline-none"
           placeholder="target_graph_id"
         />
       </div>
@@ -84,7 +84,7 @@ export function StoryletNodeFields({
         <select
           value={node.storyletCall?.mode || ''}
           onChange={(event) => onUpdateStoryletCall({ mode: event.target.value as ForgeStoryletCallMode })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-storylet-accent)] outline-none"
         >
           <option value="">Select mode...</option>
           <option value={FORGE_STORYLET_CALL_MODE.DETOUR_RETURN}>{FORGE_STORYLET_CALL_MODE.DETOUR_RETURN}</option>
@@ -97,7 +97,7 @@ export function StoryletNodeFields({
           type="text"
           value={node.storyletCall?.targetStartNodeId || ''}
           onChange={(event) => onUpdateStoryletCall({ targetStartNodeId: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-storylet-accent)] outline-none"
           placeholder="target_start_node_id"
         />
       </div>
@@ -108,7 +108,7 @@ export function StoryletNodeFields({
           type="text"
           value={node.storyletCall?.returnNodeId || ''}
           onChange={(event) => onUpdateStoryletCall({ returnNodeId: event.target.value || undefined })}
-          className="w-full bg-df-elevated border border-df-control-border rounded px-2 py-1 text-sm text-df-text-primary focus:border-df-npc-selected outline-none"
+          className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-storylet-accent)] outline-none"
           placeholder="return_node_id"
         />
       </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/shared/CharacterSelector.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/shared/CharacterSelector.tsx
@@ -83,19 +83,19 @@ export function CharacterSelector({
         variant="ghost"
         size="icon"
         onClick={handleClear}
-        className="flex-shrink-0 h-auto w-auto p-0.5 hover:bg-df-control-hover"
+        className="flex-shrink-0 h-auto w-auto p-0.5 hover:bg-accent"
         title="Clear character"
         type="button"
       >
-        <X size={compact ? 10 : 12} className="text-df-text-secondary" />
+        <X size={compact ? 10 : 12} className="text-muted-foreground" />
       </Button>
     </>
   ) : (
     <>
-      <User size={compact ? 10 : 14} className="text-df-text-secondary flex-shrink-0" />
+      <User size={compact ? 10 : 14} className="text-muted-foreground flex-shrink-0" />
       <span
         className={cn(
-          'text-df-text-secondary',
+          'text-muted-foreground',
           compact ? 'text-[10px]' : 'flex-1 text-left'
         )}
       >
@@ -109,17 +109,17 @@ export function CharacterSelector({
   const dropdownContent = (
     <DropdownMenuContent
       className={cn(
-        'bg-df-sidebar-bg border-df-sidebar-border',
+        'bg-popover border border-border',
         compact ? 'w-48 max-h-48' : 'w-full max-h-64'
       )}
       align="start"
     >
       {/* Search Input */}
-      <div className={cn('border-b border-df-sidebar-border', compact ? 'p-1.5' : 'p-2')}>
+      <div className={cn('border-b border-border', compact ? 'p-1.5' : 'p-2')}>
         <div className="relative">
           <Search
             size={compact ? 12 : 14}
-            className="absolute left-2 top-1/2 -translate-y-1/2 text-df-text-secondary pointer-events-none"
+            className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none"
           />
           <Input
             type="text"
@@ -127,7 +127,7 @@ export function CharacterSelector({
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search..."
             className={cn(
-              'bg-df-elevated border-df-control-border text-df-text-primary placeholder:text-df-text-tertiary focus:border-df-control-hover',
+              'bg-card border-border text-foreground placeholder:text-muted-foreground focus:border-[var(--color-df-control-hover)]',
               compact ? 'h-6 pl-6 text-[10px]' : 'pl-7'
             )}
             autoFocus
@@ -140,7 +140,7 @@ export function CharacterSelector({
         {filteredCharacters.length === 0 ? (
           <div
             className={cn(
-              'text-df-text-secondary text-center',
+              'text-muted-foreground text-center',
               compact ? 'p-2 text-[10px]' : 'p-3 text-sm'
             )}
           >
@@ -153,27 +153,27 @@ export function CharacterSelector({
               variant="ghost"
               onClick={() => handleSelect(id)}
               className={cn(
-                'w-full flex items-center justify-start hover:bg-df-elevated transition-colors',
+                'w-full flex items-center justify-start hover:bg-accent transition-colors',
                 compact
                   ? 'gap-1.5 px-2 py-1 h-auto'
                   : 'gap-2 px-3 py-2',
-                selectedCharacterId === id && 'bg-df-npc-selected/20'
+                selectedCharacterId === id && 'bg-[color-mix(in_oklab,var(--node-npc-accent)_20%,transparent)]'
               )}
             >
               <span className={cn('flex-shrink-0', compact ? 'text-sm' : 'text-lg')}>
                 {character.avatar || '👤'}
               </span>
               {compact ? (
-                <span className="text-[10px] text-df-text-primary truncate flex-1">
+                <span className="text-[10px] text-foreground truncate flex-1">
                   {character.name}
                 </span>
               ) : (
                 <div className="flex-1 min-w-0">
-                  <div className="text-sm text-df-text-primary font-medium truncate">
+                  <div className="text-sm text-foreground font-medium truncate">
                     {character.name}
                   </div>
                   {character.description && (
-                    <div className="text-xs text-df-text-secondary truncate">
+                    <div className="text-xs text-muted-foreground truncate">
                       {character.description}
                     </div>
                   )}
@@ -182,7 +182,7 @@ export function CharacterSelector({
               {selectedCharacterId === id && (
                 <div
                   className={cn(
-                    'flex-shrink-0 rounded-full bg-df-npc-selected',
+                    'flex-shrink-0 rounded-full bg-[var(--node-npc-accent)]',
                     compact ? 'w-1.5 h-1.5' : 'w-2 h-2'
                   )}
                 />
@@ -200,7 +200,7 @@ export function CharacterSelector({
         <Button
           variant="outline"
           className={cn(
-            'w-full flex items-center gap-2 bg-df-elevated border-df-control-border text-df-text-primary hover:border-df-control-hover transition-colors justify-start',
+            'w-full flex items-center gap-2 bg-card border-border text-foreground hover:border-[var(--color-df-control-hover)] transition-colors justify-start',
             compact && 'h-auto px-1.5 py-0.5 text-[10px]',
             className
           )}

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/shared/ContextMenuBase.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/shared/ContextMenuBase.tsx
@@ -34,14 +34,14 @@ export function ContextMenuBase({
     <ContextMenu onOpenChange={handleOpenChange}>
       <ContextMenuContent
         className={cn(
-          'bg-df-sidebar-bg border border-df-sidebar-border rounded-lg shadow-lg p-1 min-w-[150px]',
+          'bg-popover border border-border rounded-lg shadow-lg p-1 min-w-[150px]',
           className
         )}
         style={{ position: 'fixed', left: x, top: y, zIndex: 50 }}
         onCloseAutoFocus={(event) => event.preventDefault()}
       >
         {title && (
-          <ContextMenuLabel className="px-3 py-1 text-[10px] text-df-text-secondary uppercase border-b border-df-sidebar-border">
+          <ContextMenuLabel className="px-3 py-1 text-[10px] text-muted-foreground uppercase border-b border-border">
             {title}
           </ContextMenuLabel>
         )}
@@ -59,8 +59,8 @@ interface ContextMenuButtonProps {
 
 export function ContextMenuButton({ onClick, children, variant = 'primary' }: ContextMenuButtonProps) {
   const className = variant === 'primary'
-    ? 'w-full text-left px-3 py-2 text-sm text-df-text-primary hover:bg-df-elevated rounded'
-    : 'w-full text-left px-3 py-2 text-sm text-df-text-secondary hover:bg-df-elevated rounded';
+    ? 'w-full text-left px-3 py-2 text-sm text-foreground hover:bg-accent rounded'
+    : 'w-full text-left px-3 py-2 text-sm text-muted-foreground hover:bg-accent rounded';
   
   return (
     <ContextMenuItem onSelect={onClick} className={className}>

--- a/src/forge/lib/utils/flag-styles.ts
+++ b/src/forge/lib/utils/flag-styles.ts
@@ -7,13 +7,13 @@ import type { FlagType } from '@/forge/types/flags';
  * Uses design system color tokens (df-flag-*)
  */
 export const FLAG_COLOR_CLASSES: Record<FlagType, string> = {
-  [FLAG_TYPE.DIALOGUE]: 'bg-df-flag-dialogue-bg text-df-flag-dialogue border-df-flag-dialogue',
-  [FLAG_TYPE.QUEST]: 'bg-df-flag-quest-bg text-df-flag-quest border-df-flag-quest',
-  [FLAG_TYPE.ACHIEVEMENT]: 'bg-df-flag-achievement-bg text-df-flag-achievement border-df-flag-achievement',
-  [FLAG_TYPE.ITEM]: 'bg-df-flag-item-bg text-df-flag-item border-df-flag-item',
-  [FLAG_TYPE.STAT]: 'bg-df-flag-stat-bg text-df-flag-stat border-df-flag-stat',
-  [FLAG_TYPE.TITLE]: 'bg-df-flag-title-bg text-df-flag-title border-df-flag-title',
-  [FLAG_TYPE.GLOBAL]: 'bg-df-flag-global-bg text-df-flag-global border-df-flag-global',
+  [FLAG_TYPE.DIALOGUE]: 'bg-[var(--color-df-flag-dialogue-bg)] text-[var(--color-df-flag-dialogue)] border-[var(--color-df-flag-dialogue)]',
+  [FLAG_TYPE.QUEST]: 'bg-[var(--color-df-flag-quest-bg)] text-[var(--color-df-flag-quest)] border-[var(--color-df-flag-quest)]',
+  [FLAG_TYPE.ACHIEVEMENT]: 'bg-[var(--color-df-flag-achievement-bg)] text-[var(--color-df-flag-achievement)] border-[var(--color-df-flag-achievement)]',
+  [FLAG_TYPE.ITEM]: 'bg-[var(--color-df-flag-item-bg)] text-[var(--color-df-flag-item)] border-[var(--color-df-flag-item)]',
+  [FLAG_TYPE.STAT]: 'bg-[var(--color-df-flag-stat-bg)] text-[var(--color-df-flag-stat)] border-[var(--color-df-flag-stat)]',
+  [FLAG_TYPE.TITLE]: 'bg-[var(--color-df-flag-title-bg)] text-[var(--color-df-flag-title)] border-[var(--color-df-flag-title)]',
+  [FLAG_TYPE.GLOBAL]: 'bg-[var(--color-df-flag-global-bg)] text-[var(--color-df-flag-global)] border-[var(--color-df-flag-global)]',
 };
 
 /**

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -120,6 +120,13 @@
   --color-df-canvas-bg: oklch(0.16 0 0);
   --color-df-canvas-grid: oklch(0.22 0 0);
 
+  --minimap-bg: var(--color-df-canvas-bg);
+  --minimap-mask: oklch(0 0 0 / 0.7);
+  --minimap-node-default: var(--color-df-edge-dimmed);
+  --minimap-node-character: var(--node-npc-accent);
+  --minimap-node-player: var(--node-player-accent);
+  --minimap-node-conditional: var(--node-conditional-accent);
+
   --color-df-sidebar-bg: oklch(0.22 0 0);
   --color-df-sidebar-border: oklch(0.32 0 0);
   --color-df-sidebar-border-active: oklch(0.72 0.22 150);


### PR DESCRIPTION
### Motivation
- Move hard-coded color sources (hex literals and `bg-df-*`/`text-df-*`/`border-df-*` utilities) to semantic tokens and CSS-variable utilities to centralize theme control and enable context-aware coloring.
- Use domain/context tokens for the graph minimap so its background, mask, and node colors follow the theme variables instead of literal colors.
- Keep visual layout and structure unchanged while making color sources semantic and configurable.

### Description
- Added minimap design tokens to `styles/themes.css` (`--minimap-bg`, `--minimap-mask`, `--minimap-node-*`) and replaced hard-coded minimap colors in `GraphMiniMap.tsx` to use these variables and `maskColor` as a CSS variable.
- Replaced many `bg-df-*`, `text-df-*`, and `border-df-*` classes in node components and their fields with semantic utility classes such as `bg-card`, `text-foreground`, `text-muted-foreground`, `border-border` or direct CSS-variable Tailwind utilities like `text-[var(--node-accent)]` and `bg-[color-mix(...)]` (applied across CharacterNode, PlayerNode, ConditionalNode, StoryletNode, DetourNode, PageNode, ActNode, ChapterNode and their Fields/components).
- Updated shared UI pieces used by nodes (context menus and character selector) to semantic/popover tokens (`bg-popover`, `text-muted-foreground`, `hover:bg-accent`, etc.) to maintain consistent theming.
- Converted flag color helper values in `src/forge/lib/utils/flag-styles.ts` to CSS-variable utility classes (e.g., `bg-[var(--color-df-flag-dialogue-bg)] text-[var(...)]`) and updated usages to call `getFlagColorClass` uniformly.

### Testing
- Ran a build attempt with `npm run build`; the build failed due to an unrelated missing dependency error: `Cannot find package '@payloadcms/next' imported from next.config.mjs` (Next config environment issue), so integration/build validation could not complete.
- Attempted to run the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`; this also failed with the same `@payloadcms/next` import error, so runtime verification was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ec21b6c4832da4904910732bf2c8)