### PR TITLE
Add multi-game-state support

### DIFF
--- a/src/forge/adapters/forge-data-adapter.ts
+++ b/src/forge/adapters/forge-data-adapter.ts
@@ -1,6 +1,6 @@
 // src/forge/adapter/forge-data-adapter.ts
 import type { ForgeGraphDoc, ForgeReactFlowJson, ForgeGraphKind } from '@/forge/types/forge-graph';
-import { ForgeGameState } from '@/forge/types/forge-game-state';
+import { ForgeGameState, ForgeGameStateRecord } from '@/forge/types/forge-game-state';
 import { ForgeAct } from '@/forge/types/narrative';
 import type { ForgeCharacter } from '@/forge/types/characters';
 
@@ -67,11 +67,15 @@ export interface ForgeDataAdapter {
     summary?: string | null;
     order: number;
   }): Promise<ForgeAct>;
-  getGameState(projectId: number): Promise<ForgeGameState>;
-  updateGameState(projectId: number, patch: Partial<ForgeGameState>): Promise<ForgeGameState>;
+  listGameStates(projectId: number): Promise<ForgeGameStateRecord[]>;
+  getGameState(gameStateId: number): Promise<ForgeGameStateRecord>;
+  getActiveGameStateId(projectId: number): Promise<number | null>;
+  setActiveGameState(projectId: number, gameStateId: number): Promise<void>;
+  updateGameState(gameStateId: number, patch: Partial<ForgeGameState>): Promise<ForgeGameStateRecord>;
   createGameState(input: {
     projectId: number;
-    state: unknown;
-  }): Promise<ForgeGameState>;
-  deleteGameState(projectId: number): Promise<void>;
+    name: string;
+    state: ForgeGameState;
+  }): Promise<ForgeGameStateRecord>;
+  deleteGameState(gameStateId: number): Promise<void>;
 }

--- a/src/forge/components/ForgeWorkspace/store/slices/gameState.slice.ts
+++ b/src/forge/components/ForgeWorkspace/store/slices/gameState.slice.ts
@@ -1,20 +1,28 @@
 import type { StateCreator } from "zustand"
-import type { ForgeGameState } from "@/forge/types/forge-game-state"
+import type { ForgeGameState, ForgeGameStateRecord } from "@/forge/types/forge-game-state"
 import type { FlagSchema } from "@/forge/types/flags"
 import type { ForgeWorkspaceState } from "../forge-workspace-store"
 
+const DEFAULT_GAME_STATE: ForgeGameState = { flags: {} }
+
 export interface GameStateSlice {
   activeFlagSchema: FlagSchema | undefined
+  gameStatesById: Record<string, ForgeGameStateRecord>
+  activeGameStateId: number | null
   activeGameState: ForgeGameState
   gameStateDraft: string
   gameStateError: string | null
   loadedFlagSchemaProjectId: number | null
-  loadedGameStateProjectId: number | null
+  loadedGameStatesProjectId: number | null
 }
 
 export interface GameStateActions {
   setActiveFlagSchema: (schema: FlagSchema | undefined, projectId?: number | null) => void
+  setGameStates: (states: ForgeGameStateRecord[], projectId?: number | null, activeGameStateId?: number | null) => void
+  setActiveGameStateId: (gameStateId: number | null, projectId?: number | null) => void
   setActiveGameState: (state: ForgeGameState, projectId?: number | null) => void
+  upsertGameState: (record: ForgeGameStateRecord, projectId?: number | null) => void
+  removeGameState: (gameStateId: number, projectId?: number | null) => void
   setGameStateDraft: (draft: string) => void
   setGameStateError: (error: string | null) => void
 }
@@ -25,25 +33,97 @@ export function createGameStateSlice(
   flagSchema?: FlagSchema,
   gameState?: ForgeGameState
 ): GameStateSlice & GameStateActions {
-  const initialGameState: ForgeGameState = gameState ?? { flags: {} }
+  const initialGameState: ForgeGameState = gameState ?? DEFAULT_GAME_STATE
 
   return {
     activeFlagSchema: flagSchema,
+    gameStatesById: {},
+    activeGameStateId: null,
     activeGameState: initialGameState,
     gameStateDraft: JSON.stringify(initialGameState, null, 2),
     gameStateError: null,
     loadedFlagSchemaProjectId: null,
-    loadedGameStateProjectId: null,
+    loadedGameStatesProjectId: null,
     setActiveFlagSchema: (schema, projectId) => set({ 
       activeFlagSchema: schema,
       loadedFlagSchemaProjectId: projectId ?? null,
     }),
-    setActiveGameState: (state, projectId) => {
+    setGameStates: (states, projectId, nextActiveGameStateId) => {
+      const gameStatesById = states.reduce((acc, record) => {
+        acc[String(record.id)] = record
+        return acc
+      }, {} as Record<string, ForgeGameStateRecord>)
+      const resolvedActiveId = nextActiveGameStateId ?? get().activeGameStateId
+      const resolvedActiveState = resolvedActiveId ? gameStatesById[String(resolvedActiveId)]?.state : undefined
+      const fallbackRecord = states[0]
+      const activeGameState = resolvedActiveState ?? fallbackRecord?.state ?? DEFAULT_GAME_STATE
       set({
+        gameStatesById,
+        activeGameStateId: resolvedActiveState ? resolvedActiveId : fallbackRecord?.id ?? null,
+        activeGameState,
+        gameStateDraft: JSON.stringify(activeGameState, null, 2),
+        gameStateError: null,
+        loadedGameStatesProjectId: projectId ?? null,
+      })
+    },
+    setActiveGameStateId: (gameStateId, projectId) => {
+      const stateRecord = gameStateId ? get().gameStatesById[String(gameStateId)] : undefined
+      const nextState = stateRecord?.state ?? DEFAULT_GAME_STATE
+      set({
+        activeGameStateId: gameStateId,
+        activeGameState: nextState,
+        gameStateDraft: JSON.stringify(nextState, null, 2),
+        gameStateError: null,
+        loadedGameStatesProjectId: projectId ?? get().loadedGameStatesProjectId,
+      })
+    },
+    setActiveGameState: (state, projectId) => {
+      const activeGameStateId = get().activeGameStateId
+      const gameStatesById = { ...get().gameStatesById }
+      if (activeGameStateId !== null) {
+        const existingRecord = gameStatesById[String(activeGameStateId)]
+        if (existingRecord) {
+          gameStatesById[String(activeGameStateId)] = {
+            ...existingRecord,
+            state,
+          }
+        }
+      }
+      set({
+        gameStatesById,
         activeGameState: state,
         gameStateDraft: JSON.stringify(state, null, 2),
         gameStateError: null,
-        loadedGameStateProjectId: projectId ?? null,
+        loadedGameStatesProjectId: projectId ?? get().loadedGameStatesProjectId,
+      })
+    },
+    upsertGameState: (record, projectId) => {
+      const gameStatesById = {
+        ...get().gameStatesById,
+        [String(record.id)]: record,
+      }
+      const isActive = get().activeGameStateId === record.id
+      set({
+        gameStatesById,
+        activeGameState: isActive ? record.state : get().activeGameState,
+        gameStateDraft: isActive ? JSON.stringify(record.state, null, 2) : get().gameStateDraft,
+        gameStateError: null,
+        loadedGameStatesProjectId: projectId ?? get().loadedGameStatesProjectId,
+      })
+    },
+    removeGameState: (gameStateId, projectId) => {
+      const gameStatesById = { ...get().gameStatesById }
+      delete gameStatesById[String(gameStateId)]
+      const remaining = Object.values(gameStatesById)
+      const nextActiveId = get().activeGameStateId === gameStateId ? (remaining[0]?.id ?? null) : get().activeGameStateId
+      const nextActiveState = nextActiveId ? gameStatesById[String(nextActiveId)]?.state : DEFAULT_GAME_STATE
+      set({
+        gameStatesById,
+        activeGameStateId: nextActiveId,
+        activeGameState: nextActiveState ?? DEFAULT_GAME_STATE,
+        gameStateDraft: JSON.stringify(nextActiveState ?? DEFAULT_GAME_STATE, null, 2),
+        gameStateError: null,
+        loadedGameStatesProjectId: projectId ?? get().loadedGameStatesProjectId,
       })
     },
     setGameStateDraft: draft => set({ gameStateDraft: draft }),

--- a/src/forge/copilotkit/actions/workspace/forge-workspace-actions.ts
+++ b/src/forge/copilotkit/actions/workspace/forge-workspace-actions.ts
@@ -187,12 +187,16 @@ export function createGetGameStateAction(
     handler: async () => {
       const state = workspaceStore.getState();
       const gameState = state.activeGameState;
+      const activeGameStateId = state.activeGameStateId;
+      const activeGameStateRecord = activeGameStateId ? state.gameStatesById[String(activeGameStateId)] : undefined;
 
       if (!gameState) {
         return { error: 'No game state loaded' };
       }
 
       return {
+        id: activeGameStateId ?? undefined,
+        name: activeGameStateRecord?.name,
         flagCount: Object.keys(gameState.flags || {}).length,
         flags: gameState.flags,
       };

--- a/src/forge/types/forge-game-state.ts
+++ b/src/forge/types/forge-game-state.ts
@@ -30,6 +30,18 @@ export interface ForgeGameState {
 }
 
 /**
+ * Persisted game state record with metadata.
+ */
+export interface ForgeGameStateRecord {
+  id: number;
+  projectId: number;
+  name: string;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  state: ForgeGameState;
+}
+
+/**
  * Result returned when a dialogue completes
  */
 export interface DialogueResult {


### PR DESCRIPTION
### Motivation
- Introduce first-class support for multiple persisted game states per project so users can create/switch/delete named states instead of a single global state. 
- Surface metadata (id, name, timestamps, project) for each persisted state to enable UI listing and project-scoped active-state selection. 
- Wire backend adapter and workspace store so the UI and runtime consume the currently active state only and create a default on first project load.

### Description
- Add `ForgeGameStateRecord` to `src/forge/types/forge-game-state.ts` to wrap a `ForgeGameState` with metadata (`id`, `projectId`, `name`, `createdAt`, `updatedAt`, `state`).
- Expand `ForgeDataAdapter` in `src/forge/adapters/forge-data-adapter.ts` to list/get/create/update/delete game state records and to get/set the active state per project (`listGameStates`, `getGameState`, `getActiveGameStateId`, `setActiveGameState`, `createGameState`, `updateGameState`, `deleteGameState`).
- Implement Payload adapter mappings and operations in `app/lib/forge/data-adapter/payload-forge-adapter.ts` to map Payload `GameState` docs to `ForgeGameStateRecord`, expose listing, creation, update, deletion and store active game-state id in `project.settings.activeGameStateId`.
- Update workspace store and slice: `src/forge/components/ForgeWorkspace/store/slices/gameState.slice.ts` and `src/forge/components/ForgeWorkspace/store/forge-workspace-store.tsx` now keep `gameStatesById`, `activeGameStateId`, and new actions (`setGameStates`, `setActiveGameStateId`, `upsertGameState`, `removeGameState`) and maintain a fallback/default state when none exists.
- Update subscriptions in `src/forge/components/ForgeWorkspace/store/slices/subscriptions.ts` to fetch `listGameStates` and the active id on project change, auto-create a default state if none exist, and set the active state into the store.
- Add a simple state switcher UI in `src/forge/components/ForgeWorkspace/components/ForgeWorkspaceMenuBar.tsx` that lists states, allows creating a new named state, switching the active state, and deleting the active state (uses the data adapter when available and falls back to local store otherwise).
- Expose active state metadata in copilot actions (`src/forge/copilotkit/actions/workspace/forge-workspace-actions.ts`) so `getGameState` returns `id` and `name` alongside flags.

### Testing
- Ran `npm run build` which attempted a Next.js build but failed early with: `Cannot find package '@payloadcms/next' imported from next.config.mjs`, so a full build verification could not complete. 
- Ran `npm run dev` which failed with the same missing-package error, preventing local app startup and manual UI verification. 
- No unit test suite was executed as part of this rollout; changes are focused on types, adapter interfaces, store logic and UI wiring and require the host environment (Payload SDK) to fully validate integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ec307f50832da8dc01dc55e11cbc)