### PR TITLE
Serialize Lexical editor state in writer drafts

### DIFF
--- a/app/lib/writer/data-adapter/payload-writer-adapter.ts
+++ b/app/lib/writer/data-adapter/payload-writer-adapter.ts
@@ -3,6 +3,16 @@ import type { WriterDataAdapter, WriterActDoc, WriterChapterDoc, WriterPageDoc }
 import type { Act, Chapter, Page } from '@/app/payload-types';
 import { PAYLOAD_COLLECTIONS } from '@/app/payload-collections/enums';
 
+const normalizeBookBody = (value: unknown): string | null => {
+  if (!value) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value);
+};
+
 function mapAct(doc: Act): WriterActDoc {
   return {
     id: doc.id,
@@ -11,7 +21,7 @@ function mapAct(doc: Act): WriterActDoc {
     order: doc.order,
     project: typeof doc.project === 'number' ? doc.project : doc.project.id,
     bookHeading: doc.bookHeading ?? null,
-    bookBody: doc.bookBody ?? null,
+    bookBody: normalizeBookBody(doc.bookBody),
     _status: doc._status as 'draft' | 'published' | null,
   };
 }
@@ -25,7 +35,7 @@ function mapChapter(doc: Chapter): WriterChapterDoc {
     project: typeof doc.project === 'number' ? doc.project : doc.project.id,
     act: typeof doc.act === 'number' ? doc.act : doc.act.id,
     bookHeading: doc.bookHeading ?? null,
-    bookBody: doc.bookBody ?? null,
+    bookBody: normalizeBookBody(doc.bookBody),
     _status: doc._status as 'draft' | 'published' | null,
   };
 }
@@ -39,7 +49,7 @@ function mapPage(doc: Page): WriterPageDoc {
     project: typeof doc.project === 'number' ? doc.project : doc.project.id,
     chapter: typeof doc.chapter === 'number' ? doc.chapter : doc.chapter.id,
     dialogueGraph: typeof doc.dialogueGraph === 'number' ? doc.dialogueGraph : doc.dialogueGraph?.id ?? null,
-    bookBody: doc.bookBody ?? null,
+    bookBody: normalizeBookBody(doc.bookBody),
     archivedAt: doc.archivedAt ?? null,
     _status: doc._status as 'draft' | 'published' | null,
   };

--- a/src/writer/components/WriterWorkspace/editor/WriterEditorPane.tsx
+++ b/src/writer/components/WriterWorkspace/editor/WriterEditorPane.tsx
@@ -6,6 +6,7 @@ import {
   WRITER_SAVE_STATUS,
   WriterWorkspaceState,
 } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
+import { getPlainTextFromSerializedContent } from '@/writer/components/WriterWorkspace/store/writer-workspace-types';
 import { applyWriterPatchOps } from '@/writer/lib/editor/patches';
 import { LexicalEditor } from '@/writer/components/WriterWorkspace/editor/LexicalEditor';
 import { AutosavePlugin } from '@/writer/components/WriterWorkspace/editor/lexical/plugins/AutosavePlugin';
@@ -74,7 +75,9 @@ export function WriterEditorPane({ className }: WriterEditorPaneProps) {
     return applyWriterPatchOps(aiSnapshot, aiPreview);
   }, [aiPreview, aiSnapshot]);
 
-  const beforeContent = aiSnapshot?.content ?? draft?.content ?? activePage?.bookBody ?? '';
+  const beforeContent = aiSnapshot?.content
+    ?? draft?.content.plainText
+    ?? getPlainTextFromSerializedContent(activePage?.bookBody);
   const afterContent = aiPreviewSnapshot?.content ?? '';
   const hasPreview = Boolean(aiPreview && aiPreview.length > 0);
   const isLoading = aiProposalStatus === WRITER_AI_PROPOSAL_STATUS.LOADING;
@@ -116,7 +119,7 @@ export function WriterEditorPane({ className }: WriterEditorPaneProps) {
           <>
             <LexicalEditor
               key={activePage.id}
-              value={draft?.content ?? activePage.bookBody ?? ''}
+              value={draft?.content.serialized ?? activePage.bookBody ?? ''}
               placeholder="Start writing..."
               onChange={(nextValue) => {
                 if (!activePageId) {

--- a/src/writer/components/WriterWorkspace/store/slices/editor.slice.ts
+++ b/src/writer/components/WriterWorkspace/store/slices/editor.slice.ts
@@ -1,11 +1,11 @@
 import type { StateCreator } from 'zustand';
 import type { ForgePage } from '@/forge/types/narrative';
-import type { WriterWorkspaceState, WriterDraftState } from '../writer-workspace-types';
-import { WRITER_SAVE_STATUS } from '../writer-workspace-types';
+import type { WriterWorkspaceState, WriterDraftState, WriterDraftContent } from '../writer-workspace-types';
+import { createWriterDraftContent, WRITER_SAVE_STATUS } from '../writer-workspace-types';
 
 const createDraftFromPage = (page: ForgePage): WriterDraftState => ({
   title: page.title,
-  content: page.bookBody ?? '',
+  content: createWriterDraftContent(page.bookBody),
   status: WRITER_SAVE_STATUS.SAVED,
   error: null,
   revision: 0,
@@ -18,7 +18,7 @@ export interface EditorSlice {
 
 export interface EditorActions {
   setDraftTitle: (pageId: number, title: string) => void;
-  setDraftContent: (pageId: number, content: string) => void;
+  setDraftContent: (pageId: number, content: WriterDraftContent) => void;
   saveNow: (pageId?: number) => Promise<void>;
   createDraftForPage: (page: ForgePage) => void;
   setEditorError: (error: string | null) => void;
@@ -141,7 +141,7 @@ export function createEditorSlice(
         }
         const nextPages = state.pages.map((page) =>
           page.id === targetId
-            ? { ...page, title: draft.title, bookBody: draft.content }
+            ? { ...page, title: draft.title, bookBody: draft.content.serialized }
             : page
         );
         return {

--- a/src/writer/components/WriterWorkspace/store/slices/navigation.slice.ts
+++ b/src/writer/components/WriterWorkspace/store/slices/navigation.slice.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from 'zustand';
 import type { WriterWorkspaceState } from '../writer-workspace-types';
+import { createWriterDraftContent, WRITER_SAVE_STATUS } from '../writer-workspace-types';
 
 export interface NavigationSlice {
   activePageId: number | null;
@@ -41,8 +42,8 @@ export function createNavigationSlice(
         // Create draft for page
         const draft = {
           title: page.title,
-          content: page.bookBody ?? '',
-          status: 'saved' as const,
+          content: createWriterDraftContent(page.bookBody),
+          status: WRITER_SAVE_STATUS.SAVED,
           error: null,
           revision: 0,
         };

--- a/src/writer/components/WriterWorkspace/store/writer-workspace-store.tsx
+++ b/src/writer/components/WriterWorkspace/store/writer-workspace-store.tsx
@@ -19,6 +19,7 @@ import { createEvent } from '@/writer/events/events';
 import { WRITER_EVENT_TYPE } from '@/writer/events/writer-events';
 import type {
   WriterDraftState,
+  WriterDraftContent,
   WriterSaveStatus,
   WriterAiProposalStatus,
   WriterAiPreviewMeta,
@@ -32,6 +33,7 @@ import {
 export type { WriterDocSnapshot, WriterPatchOp, WriterSelectionSnapshot } from '@/writer/types/writer-ai-types';
 export type {
   WriterDraftState,
+  WriterDraftContent,
   WriterSaveStatus,
   WriterAiProposalStatus,
   WriterAiPreviewMeta,
@@ -81,7 +83,7 @@ export interface WriterWorkspaceState {
 
     // Editor actions
     setDraftTitle: (pageId: number, title: string) => void;
-    setDraftContent: (pageId: number, content: string) => void;
+    setDraftContent: (pageId: number, content: WriterDraftContent) => void;
     saveNow: (pageId?: number) => Promise<void>;
     createDraftForPage: (page: ForgePage) => void;
     setEditorError: (error: string | null) => void;

--- a/src/writer/copilotkit/actions/workspace/writer-workspace-actions.ts
+++ b/src/writer/copilotkit/actions/workspace/writer-workspace-actions.ts
@@ -7,6 +7,8 @@
 
 import type { StoreApi } from 'zustand/vanilla';
 import type { WriterWorkspaceState } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
+import { WRITER_SAVE_STATUS } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
+import { getPlainTextFromSerializedContent } from '@/writer/components/WriterWorkspace/store/writer-workspace-types';
 import type { Parameter } from '@copilotkit/shared';
 import type { FrontendAction } from '@copilotkit/react-core';
 import { WRITER_ACTION_NAME } from '../../constants/writer-action-names';
@@ -68,10 +70,11 @@ export function createGetCurrentPageAction(
         return { error: 'No page selected' };
       }
       const draft = state.drafts[page.id];
+      const plainText = draft?.content.plainText ?? getPlainTextFromSerializedContent(page.bookBody);
       return {
         title: page.title,
-        content: draft?.content ?? page.bookBody ?? '',
-        hasUnsavedChanges: draft?.status === 'dirty',
+        content: plainText,
+        hasUnsavedChanges: draft?.status === WRITER_SAVE_STATUS.DIRTY,
       };
     },
   };


### PR DESCRIPTION
### Motivation

- Persist rich Lexical editor state instead of only plaintext so editor state can be round-tripped, and enable richer AI/patch operations that reference both serialized state and plain text.
- Keep backward compatibility for existing plain-text page bodies by extracting/using plain text when serialized state is not present.
- Ensure the writer data adapter preserves serialized payloads when saving/loading from Payload so `bookBody` can hold serialized editor state.

### Description

- Changed the Lexical editor to serialize state in `OnChangePlugin` and provide a parsed/hydrated `editorState` on startup; `OnChange` now sends `{ serialized, plainText }` and the composer attempts to `parseEditorState` from JSON before falling back to inserting a paragraph with the plain text (files: `LexicalEditor.tsx`).
- Replaced draft `content: string` with a structured `WriterDraftContent` `{ serialized: string; plainText: string }` and added helpers `createWriterDraftContent` and `getPlainTextFromSerializedContent` (file: `writer-workspace-types.ts`).
- Updated editor/navigator/AI slices and workspace store to create drafts from `bookBody` using `createWriterDraftContent`, to use `content.plainText` for AI snapshots and previews, and to persist `content.serialized` back to pages as `bookBody` when saving (files: `editor.slice.ts`, `navigation.slice.ts`, `ai.slice.ts`, `writer-workspace-store.tsx`).
- Adjusted Copilot/workspace actions to return plain-text payloads and to check draft dirty status against the `WRITER_SAVE_STATUS` constant (file: `writer-workspace-actions.ts`).
- Normalized Payload adapter `bookBody` handling so non-string payloads are JSON-stringified and strings are preserved, allowing stored serialized Lexical state to round-trip intact (file: `payload-writer-adapter.ts`).

### Testing

- Attempted a full build with `npm run build`, but the build failed due to an external environment dependency: `Cannot find package '@payloadcms/next' imported from next.config.mjs`, so automated build did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a1f89fa04832db882c6f669e1fb5d)