### PR TITLE
Render WriterPlugins inside LexicalEditor and remove direct ListPlugin

### DIFF
--- a/src/writer/components/WriterWorkspace/editor/LexicalEditor.tsx
+++ b/src/writer/components/WriterWorkspace/editor/LexicalEditor.tsx
@@ -5,10 +5,10 @@ import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
-import { ListPlugin } from '@lexical/react/LexicalListPlugin';
 import { $createParagraphNode, $createTextNode, $getRoot, type LexicalEditor as LexicalEditorType } from 'lexical';
 import { writerNodes } from '@/writer/components/WriterWorkspace/editor/lexical/nodes';
 import { ToolbarPlugin } from '@/writer/components/WriterWorkspace/editor/lexical/plugins/ToolbarPlugin';
+import { WriterPlugins } from '@/writer/components/WriterWorkspace/editor/lexical/plugins/WriterPlugins';
 import { writerTheme } from '@/writer/components/WriterWorkspace/editor/lexical/theme';
 import { AiSelectionPlugin } from '@/writer/components/WriterWorkspace/editor/lexical/plugins/AiSelectionPlugin';
 import { CopilotKitPlugin } from '@/writer/components/WriterWorkspace/editor/lexical/plugins/CopilotKitPlugin';
@@ -75,37 +75,37 @@ export function LexicalEditor({
             <ToolbarPlugin />
             <AiSelectionPlugin />
             <CopilotKitPlugin />
+            <WriterPlugins />
             <div className="relative flex min-h-0 flex-1 flex-col">
-            <RichTextPlugin
-              contentEditable={
-                <ContentEditable className="min-h-[240px] flex-1 px-4 py-4 text-sm text-df-text-primary outline-none" />
-              }
-              placeholder={
-                <div className="pointer-events-none absolute left-4 top-4 text-sm text-df-text-tertiary">
-                  {placeholder}
-                </div>
-              }
-              ErrorBoundary={LexicalErrorBoundary}
-            />
-            <HistoryPlugin />
-            <ListPlugin />
-            <OnChangePlugin
-              onChange={(editorState) => {
-                if (!onChange) {
-                  return;
+              <RichTextPlugin
+                contentEditable={
+                  <ContentEditable className="min-h-[240px] flex-1 px-4 py-4 text-sm text-df-text-primary outline-none" />
                 }
-                const serializedState = JSON.stringify(editorState.toJSON());
-                editorState.read(() => {
-                  onChange({
-                    serialized: serializedState,
-                    plainText: $getRoot().getTextContent(),
+                placeholder={
+                  <div className="pointer-events-none absolute left-4 top-4 text-sm text-df-text-tertiary">
+                    {placeholder}
+                  </div>
+                }
+                ErrorBoundary={LexicalErrorBoundary}
+              />
+              <HistoryPlugin />
+              <OnChangePlugin
+                onChange={(editorState) => {
+                  if (!onChange) {
+                    return;
+                  }
+                  const serializedState = JSON.stringify(editorState.toJSON());
+                  editorState.read(() => {
+                    onChange({
+                      serialized: serializedState,
+                      plainText: $getRoot().getTextContent(),
+                    });
                   });
-                });
-              }}
-            />
+                }}
+              />
+            </div>
           </div>
-        </div>
-      </LexicalComposer>
+        </LexicalComposer>
       </WriterEditorSessionProvider>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Centralize Lexical plugins used by the writer editor so shared behavior (markdown, links, lists, paste handling) lives in one place instead of being duplicated in `LexicalEditor`.

### Description
- Import and render `WriterPlugins` inside the `LexicalComposer` in `src/writer/components/WriterWorkspace/editor/LexicalEditor.tsx` and remove the redundant direct `ListPlugin` usage.
- `WriterPlugins` already provides `LinkPlugin`, `MarkdownShortcutPlugin`, and `MarkdownPastePlugin` and also includes `AutoFocusPlugin` and a centralized `ListPlugin` for list behavior.
- Minor layout/indentation cleanup around the plugin wiring in the editor component.

### Testing
- Ran the build with `npm run build`, which failed due to a missing dev-time dependency (`@payloadcms/next` referenced by `next.config.mjs`), so no further automated test results are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a225df0a0832da8008032bed12bfc)