### PR TITLE
Add Lexical slash command menu and block drag handles

### DIFF
--- a/src/writer/components/WriterWorkspace/editor/LexicalEditor.tsx
+++ b/src/writer/components/WriterWorkspace/editor/LexicalEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
@@ -18,6 +18,7 @@ import { AiSelectionPlugin } from '@/writer/components/WriterWorkspace/editor/le
 import { CopilotKitPlugin } from '@/writer/components/WriterWorkspace/editor/lexical/plugins/CopilotKitPlugin';
 import { WriterEditorSessionProvider, createWriterEditorSessionStore } from '@/writer/components/WriterWorkspace/editor/hooks/useWriterEditorSession';
 import type { WriterDraftContent } from '@/writer/components/WriterWorkspace/store/writer-workspace-types';
+import { BlockHandlePlugin } from '@/writer/components/WriterWorkspace/editor/lexical/plugins/BlockHandlePlugin';
 
 const parseSerializedEditorState = (editor: LexicalEditorType, value: string) => {
   try {
@@ -46,6 +47,7 @@ export function LexicalEditor({
 }: LexicalEditorProps) {
   const initialValueRef = useRef(value);
   const sessionStoreRef = useRef(createWriterEditorSessionStore());
+  const [contentElem, setContentElem] = useState<HTMLDivElement | null>(null);
 
   const initialConfig = useMemo(() => ({
     namespace: 'WriterEditor',
@@ -84,7 +86,10 @@ export function LexicalEditor({
             <div className="relative flex min-h-0 flex-1 flex-col">
               <RichTextPlugin
                 contentEditable={
-                  <ContentEditable className="min-h-[240px] flex-1 px-4 py-4 text-sm text-df-text-primary outline-none" />
+                  <ContentEditable
+                    ref={setContentElem}
+                    className="min-h-[240px] flex-1 px-4 py-4 text-sm text-df-text-primary outline-none"
+                  />
                 }
                 placeholder={
                   <div className="pointer-events-none absolute left-4 top-4 text-sm text-df-text-tertiary">
@@ -93,6 +98,7 @@ export function LexicalEditor({
                 }
                 ErrorBoundary={LexicalErrorBoundary}
               />
+              {contentElem ? <BlockHandlePlugin anchorElem={contentElem} /> : null}
               <HistoryPlugin />
               <ListPlugin />
               <CheckListPlugin />

--- a/src/writer/components/WriterWorkspace/editor/lexical/plugins/BlockHandlePlugin.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/plugins/BlockHandlePlugin.tsx
@@ -1,0 +1,157 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  $getNodeByKey,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  DRAGSTART_COMMAND,
+  DROP_COMMAND,
+  type LexicalEditor,
+  type LexicalNode,
+} from 'lexical';
+import { LexicalDraggableBlockPlugin } from '@lexical/react/LexicalDraggableBlockPlugin';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+
+type BlockHandleMenuProps = {
+  anchorElem: HTMLElement;
+  blockElement: HTMLElement;
+  editor: LexicalEditor;
+  onClose: () => void;
+};
+
+const getTopLevelBlocksFromSelection = () => {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const blocks: LexicalNode[] = [];
+  for (const node of selection.getNodes()) {
+    const block = node.getTopLevelElementOrThrow();
+    const key = block.getKey();
+    if (!seen.has(key)) {
+      seen.add(key);
+      blocks.push(block);
+    }
+  }
+  return blocks;
+};
+
+const BlockHandleMenu = ({ anchorElem, blockElement, editor }: BlockHandleMenuProps) => {
+  const [style, setStyle] = useState<React.CSSProperties>({});
+  const [isHovered, setIsHovered] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  const updatePosition = useCallback(() => {
+    const blockRect = blockElement.getBoundingClientRect();
+    const anchorRect = anchorElem.getBoundingClientRect();
+    const top = blockRect.top - anchorRect.top + blockRect.height / 2;
+    setStyle({
+      top,
+      left: -28,
+    });
+  }, [anchorElem, blockElement]);
+
+  useEffect(() => {
+    updatePosition();
+    const handleMouseEnter = () => setIsHovered(true);
+    const handleMouseLeave = () => setIsHovered(false);
+    blockElement.addEventListener('mouseenter', handleMouseEnter);
+    blockElement.addEventListener('mouseleave', handleMouseLeave);
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      blockElement.removeEventListener('mouseenter', handleMouseEnter);
+      blockElement.removeEventListener('mouseleave', handleMouseLeave);
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [blockElement, updatePosition]);
+
+  const handleDragStart = () => {
+    editor.focus();
+  };
+
+  return (
+    <div
+      ref={menuRef}
+      className={`pointer-events-auto absolute flex h-6 w-6 items-center justify-center rounded-md border border-df-node-border bg-df-surface-2 text-df-text-secondary shadow-sm transition ${
+        isHovered ? 'opacity-100' : 'opacity-0'
+      }`}
+      style={style}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      <button
+        type="button"
+        onMouseDown={handleDragStart}
+        className="flex h-full w-full items-center justify-center text-xs"
+        aria-label="Drag block"
+      >
+        ⋮⋮
+      </button>
+    </div>
+  );
+};
+
+export function BlockHandlePlugin({ anchorElem }: { anchorElem: HTMLElement }) {
+  const [editor] = useLexicalComposerContext();
+  const draggingBlockKeys = useRef<string[]>([]);
+
+  useEffect(() => {
+    const removeDragStart = editor.registerCommand(
+      DRAGSTART_COMMAND,
+      () => {
+        editor.getEditorState().read(() => {
+          const blocks = getTopLevelBlocksFromSelection();
+          draggingBlockKeys.current =
+            blocks.length > 1 ? blocks.map((block) => block.getKey()) : [];
+        });
+        return false;
+      },
+      COMMAND_PRIORITY_LOW
+    );
+
+    const removeDrop = editor.registerCommand(
+      DROP_COMMAND,
+      (event) => {
+        if (draggingBlockKeys.current.length === 0) {
+          return false;
+        }
+        event.preventDefault();
+        editor.update(() => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection)) {
+            return;
+          }
+          const nodesToMove = draggingBlockKeys.current
+            .map((key) => $getNodeByKey(key))
+            .filter((node): node is LexicalNode => Boolean(node))
+            .map((node) => node.getTopLevelElementOrThrow());
+          nodesToMove.forEach((node) => node.remove());
+          if (nodesToMove.length > 0) {
+            selection.insertNodes(nodesToMove);
+          }
+        });
+        draggingBlockKeys.current = [];
+        return true;
+      },
+      COMMAND_PRIORITY_LOW
+    );
+
+    return () => {
+      removeDragStart();
+      removeDrop();
+    };
+  }, [editor]);
+
+  const menuComponent = useMemo(() => {
+    return (props: Omit<BlockHandleMenuProps, 'anchorElem'>) => (
+      <BlockHandleMenu {...props} anchorElem={anchorElem} />
+    );
+  }, [anchorElem]);
+
+  return (
+    <LexicalDraggableBlockPlugin anchorElem={anchorElem} menuComponent={menuComponent} />
+  );
+}

--- a/src/writer/components/WriterWorkspace/editor/lexical/plugins/SlashCommandPlugin.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/plugins/SlashCommandPlugin.tsx
@@ -1,0 +1,298 @@
+import React, { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  $createHeadingNode,
+  $createParagraphNode,
+  $createQuoteNode,
+  $createTextNode,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalNode,
+} from 'lexical';
+import { $createCodeNode } from '@lexical/code';
+import {
+  INSERT_CHECK_LIST_COMMAND,
+  INSERT_ORDERED_LIST_COMMAND,
+  INSERT_UNORDERED_LIST_COMMAND,
+} from '@lexical/list';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  LexicalTypeaheadMenuPlugin,
+  useBasicTypeaheadTriggerMatch,
+  LexicalTypeaheadMenuOption,
+  type MenuTextMatch,
+} from '@lexical/react/LexicalTypeaheadMenuPlugin';
+
+type SlashCommandAction = () => void;
+
+class SlashCommandOption extends LexicalTypeaheadMenuOption {
+  title: string;
+  description?: string;
+  keywords: string[];
+  onSelect: SlashCommandAction;
+
+  constructor({
+    title,
+    description,
+    keywords,
+    onSelect,
+  }: {
+    title: string;
+    description?: string;
+    keywords: string[];
+    onSelect: SlashCommandAction;
+  }) {
+    super(title);
+    this.title = title;
+    this.description = description;
+    this.keywords = keywords;
+    this.onSelect = onSelect;
+  }
+}
+
+const emptyOrWhitespace = (value: string) => value.trim().length === 0;
+
+const getTopLevelBlock = (node: LexicalNode | null) => {
+  if (!node) {
+    return null;
+  }
+  return node.getTopLevelElementOrThrow();
+};
+
+export function SlashCommandPlugin() {
+  const [editor] = useLexicalComposerContext();
+  const [query, setQuery] = useState<string | null>(null);
+
+  const checkForSlash = useBasicTypeaheadTriggerMatch('/', {
+    minLength: 0,
+  });
+
+  const insertBlock = (createNode: () => LexicalNode) => {
+    editor.update(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) {
+        return;
+      }
+      const activeBlock = getTopLevelBlock(selection.anchor.getNode());
+      const newNode = createNode();
+      selection.insertNodes([newNode]);
+      if (activeBlock && activeBlock.isAttached()) {
+        activeBlock.remove();
+      }
+      newNode.selectEnd();
+    });
+  };
+
+  const insertParagraph = () =>
+    insertBlock(() => {
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode(''));
+      return paragraph;
+    });
+
+  const insertHeading = (tag: 'h1' | 'h2' | 'h3') =>
+    insertBlock(() => {
+      const heading = $createHeadingNode(tag);
+      heading.append($createTextNode(''));
+      return heading;
+    });
+
+  const insertQuote = () =>
+    insertBlock(() => {
+      const quote = $createQuoteNode();
+      quote.append($createTextNode(''));
+      return quote;
+    });
+
+  const insertCallout = () =>
+    insertBlock(() => {
+      const callout = $createQuoteNode();
+      callout.append($createTextNode('Callout'));
+      return callout;
+    });
+
+  const insertCodeBlock = () =>
+    insertBlock(() => {
+      const code = $createCodeNode();
+      code.append($createTextNode(''));
+      return code;
+    });
+
+  const insertDivider = () =>
+    insertBlock(() => {
+      const divider = $createParagraphNode();
+      divider.append($createTextNode('---'));
+      return divider;
+    });
+
+  const insertTablePlaceholder = () =>
+    insertBlock(() => {
+      const table = $createParagraphNode();
+      table.append($createTextNode('[Table]'));
+      return table;
+    });
+
+  const insertImagePlaceholder = () =>
+    insertBlock(() => {
+      const image = $createParagraphNode();
+      image.append($createTextNode('[Image]'));
+      return image;
+    });
+
+  const baseOptions = useMemo(
+    () => [
+      new SlashCommandOption({
+        title: 'Paragraph',
+        description: 'Plain text block',
+        keywords: ['paragraph', 'text', 'body'],
+        onSelect: insertParagraph,
+      }),
+      new SlashCommandOption({
+        title: 'Heading 1',
+        description: 'Large section heading',
+        keywords: ['heading', 'h1', 'title'],
+        onSelect: () => insertHeading('h1'),
+      }),
+      new SlashCommandOption({
+        title: 'Heading 2',
+        description: 'Medium section heading',
+        keywords: ['heading', 'h2', 'subtitle'],
+        onSelect: () => insertHeading('h2'),
+      }),
+      new SlashCommandOption({
+        title: 'Heading 3',
+        description: 'Small section heading',
+        keywords: ['heading', 'h3'],
+        onSelect: () => insertHeading('h3'),
+      }),
+      new SlashCommandOption({
+        title: 'Bulleted list',
+        description: 'Start a bulleted list',
+        keywords: ['list', 'bullets'],
+        onSelect: () =>
+          editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined),
+      }),
+      new SlashCommandOption({
+        title: 'Ordered list',
+        description: 'Start a numbered list',
+        keywords: ['list', 'ordered', 'numbered'],
+        onSelect: () =>
+          editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined),
+      }),
+      new SlashCommandOption({
+        title: 'Checklist',
+        description: 'Checklist items',
+        keywords: ['list', 'check', 'todo'],
+        onSelect: () =>
+          editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND, undefined),
+      }),
+      new SlashCommandOption({
+        title: 'Quote',
+        description: 'Pull quote block',
+        keywords: ['quote', 'blockquote'],
+        onSelect: insertQuote,
+      }),
+      new SlashCommandOption({
+        title: 'Callout',
+        description: 'Highlighted callout block',
+        keywords: ['callout', 'note', 'highlight'],
+        onSelect: insertCallout,
+      }),
+      new SlashCommandOption({
+        title: 'Code block',
+        description: 'Monospace code block',
+        keywords: ['code', 'snippet'],
+        onSelect: insertCodeBlock,
+      }),
+      new SlashCommandOption({
+        title: 'Divider',
+        description: 'Horizontal divider',
+        keywords: ['divider', 'rule', 'separator'],
+        onSelect: insertDivider,
+      }),
+      new SlashCommandOption({
+        title: 'Table',
+        description: 'Insert a table placeholder',
+        keywords: ['table', 'grid'],
+        onSelect: insertTablePlaceholder,
+      }),
+      new SlashCommandOption({
+        title: 'Image',
+        description: 'Insert an image placeholder',
+        keywords: ['image', 'photo', 'media'],
+        onSelect: insertImagePlaceholder,
+      }),
+    ],
+    [editor]
+  );
+
+  const options = useMemo(() => {
+    if (query === null || emptyOrWhitespace(query)) {
+      return baseOptions;
+    }
+    const lowered = query.toLowerCase();
+    return baseOptions.filter(
+      (option) =>
+        option.title.toLowerCase().includes(lowered) ||
+        option.keywords.some((keyword) => keyword.includes(lowered))
+    );
+  }, [baseOptions, query]);
+
+  const onSelectOption = (
+    selectedOption: SlashCommandOption,
+    nodeToRemove: LexicalNode | null,
+    closeMenu: () => void
+  ) => {
+    editor.update(() => {
+      if (nodeToRemove) {
+        nodeToRemove.remove();
+      }
+    });
+    selectedOption.onSelect();
+    closeMenu();
+  };
+
+  return (
+    <LexicalTypeaheadMenuPlugin
+      onQueryChange={setQuery}
+      onSelectOption={onSelectOption}
+      triggerFn={(text) => {
+        const match = checkForSlash(text) as MenuTextMatch | null;
+        return match;
+      }}
+      options={options}
+      menuRenderFn={(anchorElementRef, { selectedIndex, selectOptionAndCleanUp }) => {
+        if (!anchorElementRef.current) {
+          return null;
+        }
+
+        return createPortal(
+          <div className="z-50 min-w-[240px] rounded-lg border border-df-node-border bg-df-surface-2 p-1 shadow-lg">
+            {options.map((option, index) => (
+              <button
+                key={option.key}
+                type="button"
+                className={`flex w-full flex-col gap-1 rounded-md px-3 py-2 text-left text-xs transition ${
+                  selectedIndex === index
+                    ? 'bg-df-control-bg text-df-text-primary'
+                    : 'text-df-text-secondary hover:bg-df-control-bg hover:text-df-text-primary'
+                }`}
+                onClick={() => selectOptionAndCleanUp(option)}
+              >
+                <span className="text-[12px] font-medium text-df-text-primary">
+                  {option.title}
+                </span>
+                {option.description ? (
+                  <span className="text-[11px] text-df-text-tertiary">
+                    {option.description}
+                  </span>
+                ) : null}
+              </button>
+            ))}
+          </div>,
+          anchorElementRef.current
+        );
+      }}
+    />
+  );
+}

--- a/src/writer/components/WriterWorkspace/editor/lexical/plugins/WriterPlugins.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/plugins/WriterPlugins.tsx
@@ -5,6 +5,7 @@ import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
 import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import { TRANSFORMERS } from '@lexical/markdown';
 import { MarkdownPastePlugin } from './MarkdownPastePlugin';
+import { SlashCommandPlugin } from './SlashCommandPlugin';
 
 export function WriterPlugins() {
   return (
@@ -14,6 +15,7 @@ export function WriterPlugins() {
       <LinkPlugin />
       <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
       <MarkdownPastePlugin />
+      <SlashCommandPlugin />
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide an in-editor slash command to quickly insert or transform common block types (heading, list, quote, callout, code, divider, table, image) to speed up content authoring.
- Surface a block handle UI (hover chrome) so users can drag/reorder blocks and visibly operate on multi-block selections.
- Integrate these UX improvements into the existing Writer editor pipeline so they work with Lexical’s selection and node APIs.

### Description
- Added `SlashCommandPlugin` (`src/.../SlashCommandPlugin.tsx`) which uses `LexicalTypeaheadMenuPlugin` and `useBasicTypeaheadTriggerMatch('/')` to show a typeahead menu and inserts/transforms blocks via `selection.insertNodes`, Lexical node creators (e.g. `$createHeadingNode`, `$createParagraphNode`, `$createCodeNode`) and list commands (`INSERT_*_LIST_COMMAND`).
- Added `BlockHandlePlugin` (`src/.../BlockHandlePlugin.tsx`) which provides a hover handle UI rendered by `LexicalDraggableBlockPlugin`, registers `DRAGSTART_COMMAND` and `DROP_COMMAND`, and supports multi-block selection moves by collecting top-level block keys, resolving with `$getNodeByKey`, removing source nodes and reinserting them with `selection.insertNodes`.
- Wired the new plugins into the editor by adding `<SlashCommandPlugin />` to `WriterPlugins` and mounting `<BlockHandlePlugin />` in `LexicalEditor` using a `ref` to the content editable element as the `anchorElem`.
- Implemented small UI behavior such as hover show/hide for the handle and a simple menu render portal for the slash command options.

### Testing
- Ran `npm run build` to exercise the Next.js build and bundling, which failed due to a missing dependency: `Cannot find package '@payloadcms/next' imported from next.config.mjs`.
- Ran `npm run dev` which also failed with the same `next.config.mjs` import error, so runtime/browser verification was not completed.
- No unit tests were added or executed for the new components as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6c4206fc832d9700676721a2b055)