### PR TITLE
Add writer media (image/file/embed) lexical nodes and media/table plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@lexical/markdown": "^0.35.0",
         "@lexical/react": "^0.35.0",
         "@lexical/rich-text": "^0.35.0",
+        "@lexical/table": "^0.35.0",
         "@payloadcms/db-sqlite": "^3.70.0",
         "@payloadcms/next": "^3.70.0",
         "@payloadcms/richtext-lexical": "^3.70.0",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@lexical/markdown": "^0.35.0",
     "@lexical/react": "^0.35.0",
     "@lexical/rich-text": "^0.35.0",
+    "@lexical/table": "^0.35.0",
     "@payloadcms/db-sqlite": "^3.70.0",
     "@payloadcms/next": "^3.70.0",
     "@payloadcms/richtext-lexical": "^3.70.0",

--- a/src/writer/components/WriterWorkspace/editor/lexical/nodes.ts
+++ b/src/writer/components/WriterWorkspace/editor/lexical/nodes.ts
@@ -2,6 +2,12 @@ import { HeadingNode, QuoteNode } from '@lexical/rich-text';
 import { ListItemNode, ListNode } from '@lexical/list';
 import { CodeNode, CodeHighlightNode } from '@lexical/code';
 import { LinkNode, AutoLinkNode } from '@lexical/link';
+import { TableCellNode, TableNode, TableRowNode } from '@lexical/table';
+import {
+  EmbedBlockNode,
+  FileAttachmentNode,
+  ImageBlockNode,
+} from '@/writer/components/WriterWorkspace/editor/lexical/nodes/MediaNodes';
 
 export const writerNodes = [
   HeadingNode,
@@ -12,4 +18,10 @@ export const writerNodes = [
   CodeHighlightNode,
   LinkNode,
   AutoLinkNode,
+  TableNode,
+  TableRowNode,
+  TableCellNode,
+  ImageBlockNode,
+  FileAttachmentNode,
+  EmbedBlockNode,
 ];

--- a/src/writer/components/WriterWorkspace/editor/lexical/nodes/MediaNodes.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/nodes/MediaNodes.tsx
@@ -1,0 +1,904 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  DecoratorNode,
+  $getNodeByKey,
+  type EditorConfig,
+  type LexicalEditor,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from 'lexical';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useWriterWorkspaceStore } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
+import type { WriterMediaRecord } from '@/writer/lib/data-adapter/media';
+import { WRITER_MEDIA_KIND } from '@/writer/lib/data-adapter/media';
+import {
+  WRITER_LEXICAL_NODE_TYPE,
+  WRITER_MEDIA_ALIGNMENT,
+  type WriterMediaAlignment,
+} from './media-constants';
+import {
+  OPEN_EMBED_DIALOG_COMMAND,
+  OPEN_MEDIA_PICKER_COMMAND,
+} from '@/writer/components/WriterWorkspace/editor/lexical/plugins/MediaPlugin';
+
+type SerializedWriterImageNode = Spread<{
+  type: typeof WRITER_LEXICAL_NODE_TYPE.IMAGE;
+  version: 1;
+  mediaId: string;
+  altText: string;
+  caption: string;
+  alignment: WriterMediaAlignment;
+  width: number;
+  height: number | null;
+}, SerializedLexicalNode>;
+
+type SerializedWriterFileNode = Spread<{
+  type: typeof WRITER_LEXICAL_NODE_TYPE.FILE;
+  version: 1;
+  mediaId: string;
+  label: string;
+  caption: string;
+  alignment: WriterMediaAlignment;
+  width: number;
+}, SerializedLexicalNode>;
+
+type SerializedWriterEmbedNode = Spread<{
+  type: typeof WRITER_LEXICAL_NODE_TYPE.EMBED;
+  version: 1;
+  mediaId: string;
+  title: string;
+  caption: string;
+  alignment: WriterMediaAlignment;
+  width: number;
+  height: number;
+  fallbackUrl?: string | null;
+}, SerializedLexicalNode>;
+
+const clampWidth = (value: number) => Math.min(100, Math.max(25, value));
+
+const useResolvedMedia = (mediaId: string) => {
+  const dataAdapter = useWriterWorkspaceStore((state) => state.dataAdapter);
+  const [record, setRecord] = useState<WriterMediaRecord | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+    if (!dataAdapter?.resolveMedia || !mediaId) {
+      setRecord(null);
+      return;
+    }
+    setIsLoading(true);
+    dataAdapter
+      .resolveMedia(mediaId)
+      .then((resolved) => {
+        if (!isMounted) return;
+        setRecord(resolved ?? null);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setRecord(null);
+      })
+      .finally(() => {
+        if (!isMounted) return;
+        setIsLoading(false);
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, [dataAdapter, mediaId]);
+
+  return { record, isLoading };
+};
+
+const alignmentClass = (alignment: WriterMediaAlignment) => {
+  if (alignment === WRITER_MEDIA_ALIGNMENT.CENTER) {
+    return 'mx-auto';
+  }
+  if (alignment === WRITER_MEDIA_ALIGNMENT.RIGHT) {
+    return 'ml-auto';
+  }
+  return 'mr-auto';
+};
+
+const controlButton =
+  'rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-secondary transition hover:text-df-text-primary';
+
+type MediaControlsProps = {
+  alignment: WriterMediaAlignment;
+  width: number;
+  onAlign: (alignment: WriterMediaAlignment) => void;
+  onResize: (width: number) => void;
+};
+
+const MediaControls = ({ alignment, width, onAlign, onResize }: MediaControlsProps) => (
+  <div className="flex flex-wrap items-center gap-2">
+    <button
+      type="button"
+      className={controlButton}
+      onClick={() => onAlign(WRITER_MEDIA_ALIGNMENT.LEFT)}
+      aria-pressed={alignment === WRITER_MEDIA_ALIGNMENT.LEFT}
+    >
+      Left
+    </button>
+    <button
+      type="button"
+      className={controlButton}
+      onClick={() => onAlign(WRITER_MEDIA_ALIGNMENT.CENTER)}
+      aria-pressed={alignment === WRITER_MEDIA_ALIGNMENT.CENTER}
+    >
+      Center
+    </button>
+    <button
+      type="button"
+      className={controlButton}
+      onClick={() => onAlign(WRITER_MEDIA_ALIGNMENT.RIGHT)}
+      aria-pressed={alignment === WRITER_MEDIA_ALIGNMENT.RIGHT}
+    >
+      Right
+    </button>
+    <label className="flex items-center gap-2 text-[11px] text-df-text-secondary">
+      Width
+      <input
+        type="range"
+        min={25}
+        max={100}
+        step={5}
+        value={width}
+        onChange={(event) => onResize(Number(event.target.value))}
+      />
+      <span className="text-[11px] text-df-text-tertiary">{width}%</span>
+    </label>
+  </div>
+);
+
+type ImageBlockComponentProps = {
+  nodeKey: NodeKey;
+  mediaId: string;
+  altText: string;
+  caption: string;
+  alignment: WriterMediaAlignment;
+  width: number;
+  height: number | null;
+};
+
+const ImageBlockComponent = ({
+  nodeKey,
+  mediaId,
+  altText,
+  caption,
+  alignment,
+  width,
+  height,
+}: ImageBlockComponentProps) => {
+  const [editor] = useLexicalComposerContext();
+  const { record, isLoading } = useResolvedMedia(mediaId);
+  const resolvedUrl = record?.url ?? null;
+
+  const updateNode = useCallback(
+    (updater: (node: ImageBlockNode) => void) => {
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if (node instanceof ImageBlockNode) {
+          updater(node);
+        }
+      });
+    },
+    [editor, nodeKey]
+  );
+
+  const onAltChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateNode((node) => node.setAltText(event.target.value));
+  };
+
+  const onCaptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateNode((node) => node.setCaption(event.target.value));
+  };
+
+  const onAlign = (next: WriterMediaAlignment) => {
+    updateNode((node) => node.setAlignment(next));
+  };
+
+  const onResize = (nextWidth: number) => {
+    updateNode((node) => node.setWidth(nextWidth));
+  };
+
+  const onReplace = () => {
+    editor.dispatchCommand(OPEN_MEDIA_PICKER_COMMAND, {
+      kind: WRITER_MEDIA_KIND.IMAGE,
+      nodeKey,
+    });
+  };
+
+  return (
+    <figure className="my-4 flex flex-col gap-3">
+      <div className={`flex flex-col gap-2 ${alignmentClass(alignment)}`} style={{ width: `${width}%` }}>
+        {resolvedUrl ? (
+          <img
+            src={resolvedUrl}
+            alt={altText}
+            className="h-auto w-full rounded-md border border-df-node-border object-cover"
+            style={height ? { height } : undefined}
+          />
+        ) : (
+          <div className="flex h-40 items-center justify-center rounded-md border border-dashed border-df-node-border text-xs text-df-text-tertiary">
+            {isLoading ? 'Loading image…' : 'No image selected'}
+          </div>
+        )}
+        <div className="flex flex-wrap items-center gap-2">
+          <button type="button" className={controlButton} onClick={onReplace}>
+            {resolvedUrl ? 'Replace' : 'Select image'}
+          </button>
+          <MediaControls alignment={alignment} width={width} onAlign={onAlign} onResize={onResize} />
+        </div>
+      </div>
+      <div className="flex flex-col gap-2 text-[11px] text-df-text-secondary">
+        <label className="flex flex-col gap-1">
+          Alt text
+          <input
+            className="rounded-md border border-df-control-border bg-df-surface-2 px-2 py-1 text-xs text-df-text-primary"
+            value={altText}
+            onChange={onAltChange}
+            placeholder="Describe the image"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          Caption
+          <input
+            className="rounded-md border border-df-control-border bg-df-surface-2 px-2 py-1 text-xs text-df-text-primary"
+            value={caption}
+            onChange={onCaptionChange}
+            placeholder="Optional caption"
+          />
+        </label>
+      </div>
+    </figure>
+  );
+};
+
+export class ImageBlockNode extends DecoratorNode<JSX.Element> {
+  __mediaId: string;
+  __altText: string;
+  __caption: string;
+  __alignment: WriterMediaAlignment;
+  __width: number;
+  __height: number | null;
+
+  static getType() {
+    return WRITER_LEXICAL_NODE_TYPE.IMAGE;
+  }
+
+  static clone(node: ImageBlockNode) {
+    return new ImageBlockNode(
+      node.__mediaId,
+      node.__altText,
+      node.__caption,
+      node.__alignment,
+      node.__width,
+      node.__height,
+      node.__key
+    );
+  }
+
+  constructor(
+    mediaId: string,
+    altText = '',
+    caption = '',
+    alignment: WriterMediaAlignment = WRITER_MEDIA_ALIGNMENT.CENTER,
+    width = 100,
+    height: number | null = null,
+    key?: NodeKey
+  ) {
+    super(key);
+    this.__mediaId = mediaId;
+    this.__altText = altText;
+    this.__caption = caption;
+    this.__alignment = alignment;
+    this.__width = clampWidth(width);
+    this.__height = height;
+  }
+
+  static importJSON(serializedNode: SerializedWriterImageNode) {
+    return $createImageBlockNode(
+      serializedNode.mediaId,
+      serializedNode.altText,
+      serializedNode.caption,
+      serializedNode.alignment,
+      serializedNode.width,
+      serializedNode.height
+    );
+  }
+
+  exportJSON(): SerializedWriterImageNode {
+    return {
+      type: WRITER_LEXICAL_NODE_TYPE.IMAGE,
+      version: 1,
+      mediaId: this.__mediaId,
+      altText: this.__altText,
+      caption: this.__caption,
+      alignment: this.__alignment,
+      width: this.__width,
+      height: this.__height,
+    };
+  }
+
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  updateDOM(): boolean {
+    return false;
+  }
+
+  decorate(editor: LexicalEditor, _config: EditorConfig): JSX.Element {
+    return (
+      <ImageBlockComponent
+        nodeKey={this.getKey()}
+        mediaId={this.__mediaId}
+        altText={this.__altText}
+        caption={this.__caption}
+        alignment={this.__alignment}
+        width={this.__width}
+        height={this.__height}
+      />
+    );
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  setMediaId(mediaId: string) {
+    const writable = this.getWritable();
+    writable.__mediaId = mediaId;
+  }
+
+  setAltText(altText: string) {
+    const writable = this.getWritable();
+    writable.__altText = altText;
+  }
+
+  setCaption(caption: string) {
+    const writable = this.getWritable();
+    writable.__caption = caption;
+  }
+
+  setAlignment(alignment: WriterMediaAlignment) {
+    const writable = this.getWritable();
+    writable.__alignment = alignment;
+  }
+
+  setWidth(width: number) {
+    const writable = this.getWritable();
+    writable.__width = clampWidth(width);
+  }
+
+  setHeight(height: number | null) {
+    const writable = this.getWritable();
+    writable.__height = height;
+  }
+
+  getMediaId() {
+    return this.__mediaId;
+  }
+}
+
+export const $createImageBlockNode = (
+  mediaId: string,
+  altText = '',
+  caption = '',
+  alignment: WriterMediaAlignment = WRITER_MEDIA_ALIGNMENT.CENTER,
+  width = 100,
+  height: number | null = null
+) => new ImageBlockNode(mediaId, altText, caption, alignment, width, height);
+
+export const $isImageBlockNode = (node: LexicalNode | null | undefined): node is ImageBlockNode =>
+  node instanceof ImageBlockNode;
+
+type FileAttachmentComponentProps = {
+  nodeKey: NodeKey;
+  mediaId: string;
+  label: string;
+  caption: string;
+  alignment: WriterMediaAlignment;
+  width: number;
+};
+
+const FileAttachmentComponent = ({
+  nodeKey,
+  mediaId,
+  label,
+  caption,
+  alignment,
+  width,
+}: FileAttachmentComponentProps) => {
+  const [editor] = useLexicalComposerContext();
+  const { record, isLoading } = useResolvedMedia(mediaId);
+  const resolvedUrl = record?.url ?? null;
+  const displayLabel = record?.filename ?? label ?? 'Attachment';
+
+  const updateNode = useCallback(
+    (updater: (node: FileAttachmentNode) => void) => {
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if (node instanceof FileAttachmentNode) {
+          updater(node);
+        }
+      });
+    },
+    [editor, nodeKey]
+  );
+
+  const onLabelChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateNode((node) => node.setLabel(event.target.value));
+  };
+
+  const onCaptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateNode((node) => node.setCaption(event.target.value));
+  };
+
+  const onAlign = (next: WriterMediaAlignment) => {
+    updateNode((node) => node.setAlignment(next));
+  };
+
+  const onResize = (nextWidth: number) => {
+    updateNode((node) => node.setWidth(nextWidth));
+  };
+
+  const onReplace = () => {
+    editor.dispatchCommand(OPEN_MEDIA_PICKER_COMMAND, {
+      kind: WRITER_MEDIA_KIND.FILE,
+      nodeKey,
+    });
+  };
+
+  return (
+    <div className="my-4 flex flex-col gap-3">
+      <div className={`${alignmentClass(alignment)} flex flex-col gap-2`} style={{ width: `${width}%` }}>
+        <div className="flex flex-col gap-2 rounded-md border border-df-node-border bg-df-surface-2 px-4 py-3">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex flex-col">
+              <span className="text-xs font-medium text-df-text-primary">
+                {displayLabel}
+              </span>
+              <span className="text-[11px] text-df-text-tertiary">
+                {record?.mimeType ?? 'File attachment'}
+              </span>
+            </div>
+            {resolvedUrl ? (
+              <a
+                href={resolvedUrl}
+                className="text-[11px] text-df-text-secondary underline"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Download
+              </a>
+            ) : (
+              <span className="text-[11px] text-df-text-tertiary">
+                {isLoading ? 'Loading…' : 'No file selected'}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button type="button" className={controlButton} onClick={onReplace}>
+              {resolvedUrl ? 'Replace' : 'Select file'}
+            </button>
+            <MediaControls alignment={alignment} width={width} onAlign={onAlign} onResize={onResize} />
+          </div>
+        </div>
+        <div className="flex flex-col gap-2 text-[11px] text-df-text-secondary">
+          <label className="flex flex-col gap-1">
+            Label
+            <input
+              className="rounded-md border border-df-control-border bg-df-surface-2 px-2 py-1 text-xs text-df-text-primary"
+              value={label}
+              onChange={onLabelChange}
+              placeholder="Attachment label"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            Caption
+            <input
+              className="rounded-md border border-df-control-border bg-df-surface-2 px-2 py-1 text-xs text-df-text-primary"
+              value={caption}
+              onChange={onCaptionChange}
+              placeholder="Optional caption"
+            />
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export class FileAttachmentNode extends DecoratorNode<JSX.Element> {
+  __mediaId: string;
+  __label: string;
+  __caption: string;
+  __alignment: WriterMediaAlignment;
+  __width: number;
+
+  static getType() {
+    return WRITER_LEXICAL_NODE_TYPE.FILE;
+  }
+
+  static clone(node: FileAttachmentNode) {
+    return new FileAttachmentNode(
+      node.__mediaId,
+      node.__label,
+      node.__caption,
+      node.__alignment,
+      node.__width,
+      node.__key
+    );
+  }
+
+  constructor(
+    mediaId: string,
+    label = '',
+    caption = '',
+    alignment: WriterMediaAlignment = WRITER_MEDIA_ALIGNMENT.LEFT,
+    width = 100,
+    key?: NodeKey
+  ) {
+    super(key);
+    this.__mediaId = mediaId;
+    this.__label = label;
+    this.__caption = caption;
+    this.__alignment = alignment;
+    this.__width = clampWidth(width);
+  }
+
+  static importJSON(serializedNode: SerializedWriterFileNode) {
+    return $createFileAttachmentNode(
+      serializedNode.mediaId,
+      serializedNode.label,
+      serializedNode.caption,
+      serializedNode.alignment,
+      serializedNode.width
+    );
+  }
+
+  exportJSON(): SerializedWriterFileNode {
+    return {
+      type: WRITER_LEXICAL_NODE_TYPE.FILE,
+      version: 1,
+      mediaId: this.__mediaId,
+      label: this.__label,
+      caption: this.__caption,
+      alignment: this.__alignment,
+      width: this.__width,
+    };
+  }
+
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  updateDOM(): boolean {
+    return false;
+  }
+
+  decorate(editor: LexicalEditor, _config: EditorConfig): JSX.Element {
+    return (
+      <FileAttachmentComponent
+        nodeKey={this.getKey()}
+        mediaId={this.__mediaId}
+        label={this.__label}
+        caption={this.__caption}
+        alignment={this.__alignment}
+        width={this.__width}
+      />
+    );
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  setMediaId(mediaId: string) {
+    const writable = this.getWritable();
+    writable.__mediaId = mediaId;
+  }
+
+  setLabel(label: string) {
+    const writable = this.getWritable();
+    writable.__label = label;
+  }
+
+  setCaption(caption: string) {
+    const writable = this.getWritable();
+    writable.__caption = caption;
+  }
+
+  setAlignment(alignment: WriterMediaAlignment) {
+    const writable = this.getWritable();
+    writable.__alignment = alignment;
+  }
+
+  setWidth(width: number) {
+    const writable = this.getWritable();
+    writable.__width = clampWidth(width);
+  }
+}
+
+export const $createFileAttachmentNode = (
+  mediaId: string,
+  label = '',
+  caption = '',
+  alignment: WriterMediaAlignment = WRITER_MEDIA_ALIGNMENT.LEFT,
+  width = 100
+) => new FileAttachmentNode(mediaId, label, caption, alignment, width);
+
+export const $isFileAttachmentNode = (node: LexicalNode | null | undefined): node is FileAttachmentNode =>
+  node instanceof FileAttachmentNode;
+
+type EmbedBlockComponentProps = {
+  nodeKey: NodeKey;
+  mediaId: string;
+  title: string;
+  caption: string;
+  alignment: WriterMediaAlignment;
+  width: number;
+  height: number;
+  fallbackUrl?: string | null;
+};
+
+const EmbedBlockComponent = ({
+  nodeKey,
+  mediaId,
+  title,
+  caption,
+  alignment,
+  width,
+  height,
+  fallbackUrl,
+}: EmbedBlockComponentProps) => {
+  const [editor] = useLexicalComposerContext();
+  const { record, isLoading } = useResolvedMedia(mediaId);
+  const resolvedUrl = record?.url ?? fallbackUrl ?? null;
+  const displayTitle = record?.title ?? title ?? 'Embed';
+
+  const updateNode = useCallback(
+    (updater: (node: EmbedBlockNode) => void) => {
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if (node instanceof EmbedBlockNode) {
+          updater(node);
+        }
+      });
+    },
+    [editor, nodeKey]
+  );
+
+  const onTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateNode((node) => node.setTitle(event.target.value));
+  };
+
+  const onCaptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    updateNode((node) => node.setCaption(event.target.value));
+  };
+
+  const onAlign = (next: WriterMediaAlignment) => {
+    updateNode((node) => node.setAlignment(next));
+  };
+
+  const onResize = (nextWidth: number) => {
+    updateNode((node) => node.setWidth(nextWidth));
+  };
+
+  const onResizeHeight = (nextHeight: number) => {
+    updateNode((node) => node.setHeight(nextHeight));
+  };
+
+  const onEdit = () => {
+    editor.dispatchCommand(OPEN_EMBED_DIALOG_COMMAND, { nodeKey });
+  };
+
+  return (
+    <figure className="my-4 flex flex-col gap-3">
+      <div className={`${alignmentClass(alignment)} flex flex-col gap-2`} style={{ width: `${width}%` }}>
+        {resolvedUrl ? (
+          <iframe
+            src={resolvedUrl}
+            title={displayTitle}
+            className="w-full rounded-md border border-df-node-border"
+            style={{ height }}
+          />
+        ) : (
+          <div className="flex h-40 items-center justify-center rounded-md border border-dashed border-df-node-border text-xs text-df-text-tertiary">
+            {isLoading ? 'Loading embed…' : 'No embed selected'}
+          </div>
+        )}
+        <div className="flex flex-wrap items-center gap-2">
+          <button type="button" className={controlButton} onClick={onEdit}>
+            {resolvedUrl ? 'Edit embed' : 'Set embed URL'}
+          </button>
+          <MediaControls alignment={alignment} width={width} onAlign={onAlign} onResize={onResize} />
+          <label className="flex items-center gap-2 text-[11px] text-df-text-secondary">
+            Height
+            <input
+              type="range"
+              min={160}
+              max={720}
+              step={20}
+              value={height}
+              onChange={(event) => onResizeHeight(Number(event.target.value))}
+            />
+            <span className="text-[11px] text-df-text-tertiary">{height}px</span>
+          </label>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2 text-[11px] text-df-text-secondary">
+        <label className="flex flex-col gap-1">
+          Title
+          <input
+            className="rounded-md border border-df-control-border bg-df-surface-2 px-2 py-1 text-xs text-df-text-primary"
+            value={title}
+            onChange={onTitleChange}
+            placeholder="Embed title"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          Caption
+          <input
+            className="rounded-md border border-df-control-border bg-df-surface-2 px-2 py-1 text-xs text-df-text-primary"
+            value={caption}
+            onChange={onCaptionChange}
+            placeholder="Optional caption"
+          />
+        </label>
+      </div>
+    </figure>
+  );
+};
+
+export class EmbedBlockNode extends DecoratorNode<JSX.Element> {
+  __mediaId: string;
+  __title: string;
+  __caption: string;
+  __alignment: WriterMediaAlignment;
+  __width: number;
+  __height: number;
+  __fallbackUrl: string | null;
+
+  static getType() {
+    return WRITER_LEXICAL_NODE_TYPE.EMBED;
+  }
+
+  static clone(node: EmbedBlockNode) {
+    return new EmbedBlockNode(
+      node.__mediaId,
+      node.__title,
+      node.__caption,
+      node.__alignment,
+      node.__width,
+      node.__height,
+      node.__fallbackUrl,
+      node.__key
+    );
+  }
+
+  constructor(
+    mediaId: string,
+    title = '',
+    caption = '',
+    alignment: WriterMediaAlignment = WRITER_MEDIA_ALIGNMENT.CENTER,
+    width = 100,
+    height = 360,
+    fallbackUrl: string | null = null,
+    key?: NodeKey
+  ) {
+    super(key);
+    this.__mediaId = mediaId;
+    this.__title = title;
+    this.__caption = caption;
+    this.__alignment = alignment;
+    this.__width = clampWidth(width);
+    this.__height = height;
+    this.__fallbackUrl = fallbackUrl;
+  }
+
+  static importJSON(serializedNode: SerializedWriterEmbedNode) {
+    return $createEmbedBlockNode(
+      serializedNode.mediaId,
+      serializedNode.title,
+      serializedNode.caption,
+      serializedNode.alignment,
+      serializedNode.width,
+      serializedNode.height,
+      serializedNode.fallbackUrl ?? null
+    );
+  }
+
+  exportJSON(): SerializedWriterEmbedNode {
+    return {
+      type: WRITER_LEXICAL_NODE_TYPE.EMBED,
+      version: 1,
+      mediaId: this.__mediaId,
+      title: this.__title,
+      caption: this.__caption,
+      alignment: this.__alignment,
+      width: this.__width,
+      height: this.__height,
+      fallbackUrl: this.__fallbackUrl,
+    };
+  }
+
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  updateDOM(): boolean {
+    return false;
+  }
+
+  decorate(editor: LexicalEditor, _config: EditorConfig): JSX.Element {
+    return (
+      <EmbedBlockComponent
+        nodeKey={this.getKey()}
+        mediaId={this.__mediaId}
+        title={this.__title}
+        caption={this.__caption}
+        alignment={this.__alignment}
+        width={this.__width}
+        height={this.__height}
+        fallbackUrl={this.__fallbackUrl}
+      />
+    );
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  setMediaId(mediaId: string) {
+    const writable = this.getWritable();
+    writable.__mediaId = mediaId;
+  }
+
+  setTitle(title: string) {
+    const writable = this.getWritable();
+    writable.__title = title;
+  }
+
+  setCaption(caption: string) {
+    const writable = this.getWritable();
+    writable.__caption = caption;
+  }
+
+  setAlignment(alignment: WriterMediaAlignment) {
+    const writable = this.getWritable();
+    writable.__alignment = alignment;
+  }
+
+  setWidth(width: number) {
+    const writable = this.getWritable();
+    writable.__width = clampWidth(width);
+  }
+
+  setHeight(height: number) {
+    const writable = this.getWritable();
+    writable.__height = height;
+  }
+
+  setFallbackUrl(url: string | null) {
+    const writable = this.getWritable();
+    writable.__fallbackUrl = url;
+  }
+}
+
+export const $createEmbedBlockNode = (
+  mediaId: string,
+  title = '',
+  caption = '',
+  alignment: WriterMediaAlignment = WRITER_MEDIA_ALIGNMENT.CENTER,
+  width = 100,
+  height = 360,
+  fallbackUrl: string | null = null
+) => new EmbedBlockNode(mediaId, title, caption, alignment, width, height, fallbackUrl);
+
+export const $isEmbedBlockNode = (node: LexicalNode | null | undefined): node is EmbedBlockNode =>
+  node instanceof EmbedBlockNode;

--- a/src/writer/components/WriterWorkspace/editor/lexical/nodes/media-constants.ts
+++ b/src/writer/components/WriterWorkspace/editor/lexical/nodes/media-constants.ts
@@ -1,0 +1,14 @@
+export const WRITER_MEDIA_ALIGNMENT = {
+  LEFT: 'left',
+  CENTER: 'center',
+  RIGHT: 'right',
+} as const;
+
+export type WriterMediaAlignment =
+  (typeof WRITER_MEDIA_ALIGNMENT)[keyof typeof WRITER_MEDIA_ALIGNMENT];
+
+export const WRITER_LEXICAL_NODE_TYPE = {
+  IMAGE: 'writer-image',
+  FILE: 'writer-file',
+  EMBED: 'writer-embed',
+} as const;

--- a/src/writer/components/WriterWorkspace/editor/lexical/plugins/MediaPlugin.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/plugins/MediaPlugin.tsx
@@ -1,0 +1,274 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  $getNodeByKey,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_HIGH,
+  COMMAND_PRIORITY_LOW,
+  DROP_COMMAND,
+  PASTE_COMMAND,
+  createCommand,
+  type LexicalCommand,
+  type NodeKey,
+} from 'lexical';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useWriterWorkspaceStore } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
+import {
+  $createEmbedBlockNode,
+  $createFileAttachmentNode,
+  $createImageBlockNode,
+  EmbedBlockNode,
+  FileAttachmentNode,
+  ImageBlockNode,
+} from '@/writer/components/WriterWorkspace/editor/lexical/nodes/MediaNodes';
+import { WRITER_MEDIA_KIND, type WriterMediaKind } from '@/writer/lib/data-adapter/media';
+
+type MediaPickerPayload = {
+  kind: WriterMediaKind;
+  nodeKey?: NodeKey;
+};
+
+type EmbedDialogPayload = {
+  nodeKey?: NodeKey;
+};
+
+export const OPEN_MEDIA_PICKER_COMMAND: LexicalCommand<MediaPickerPayload> = createCommand();
+export const OPEN_EMBED_DIALOG_COMMAND: LexicalCommand<EmbedDialogPayload> = createCommand();
+
+const acceptForKind = (kind: WriterMediaKind) => {
+  if (kind === WRITER_MEDIA_KIND.IMAGE) {
+    return 'image/*';
+  }
+  if (kind === WRITER_MEDIA_KIND.FILE) {
+    return '*/*';
+  }
+  return '*/*';
+};
+
+const isImageFile = (file: File) => file.type.startsWith('image/');
+
+export function MediaPlugin() {
+  const [editor] = useLexicalComposerContext();
+  const dataAdapter = useWriterWorkspaceStore((state) => state.dataAdapter);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [pickerPayload, setPickerPayload] = useState<MediaPickerPayload | null>(null);
+
+  const replaceNodeMedia = useCallback(
+    (nodeKey: NodeKey, mediaId: string, fallbackLabel?: string, fallbackUrl?: string | null) => {
+      editor.update(() => {
+        const node = $getNodeByKey(nodeKey);
+        if (node instanceof ImageBlockNode) {
+          node.setMediaId(mediaId);
+          return;
+        }
+        if (node instanceof FileAttachmentNode) {
+          node.setMediaId(mediaId);
+          if (fallbackLabel) {
+            node.setLabel(fallbackLabel);
+          }
+          return;
+        }
+        if (node instanceof EmbedBlockNode) {
+          node.setMediaId(mediaId);
+          if (fallbackUrl) {
+            node.setFallbackUrl(fallbackUrl);
+          }
+        }
+      });
+    },
+    [editor]
+  );
+
+  const insertNodeForUpload = useCallback(
+    (mediaId: string, file: File) => {
+      editor.update(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          return;
+        }
+        if (isImageFile(file)) {
+          selection.insertNodes([$createImageBlockNode(mediaId)]);
+        } else {
+          selection.insertNodes([$createFileAttachmentNode(mediaId, file.name)]);
+        }
+      });
+    },
+    [editor]
+  );
+
+  const uploadFiles = useCallback(
+    async (files: File[], payload: MediaPickerPayload | null) => {
+      if (!dataAdapter?.uploadMedia) {
+        return;
+      }
+      if (payload?.nodeKey && files.length > 0) {
+        const file = files[0];
+        const result = await dataAdapter.uploadMedia(file);
+        if (!result?.mediaId) {
+          return;
+        }
+        replaceNodeMedia(payload.nodeKey, result.mediaId, file.name);
+        return;
+      }
+      await Promise.all(
+        files.map(async (file) => {
+          const result = await dataAdapter.uploadMedia(file);
+          if (!result?.mediaId) {
+            return;
+          }
+          insertNodeForUpload(result.mediaId, file);
+        })
+      );
+    },
+    [dataAdapter, insertNodeForUpload, replaceNodeMedia]
+  );
+
+  const openEmbedDialog = useCallback(
+    async (payload: EmbedDialogPayload) => {
+      const url = window.prompt('Embed URL');
+      if (!url) {
+        return;
+      }
+      if (dataAdapter?.createEmbed) {
+        const result = await dataAdapter.createEmbed(url);
+        if (!result?.mediaId) {
+          return;
+        }
+        if (payload.nodeKey) {
+          replaceNodeMedia(payload.nodeKey, result.mediaId, undefined, url);
+          return;
+        }
+        editor.update(() => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection)) {
+            return;
+          }
+          selection.insertNodes([
+            $createEmbedBlockNode(result.mediaId, '', '', undefined, 100, 360, url),
+          ]);
+        });
+        return;
+      }
+      const mediaId = url;
+      if (payload.nodeKey) {
+        replaceNodeMedia(payload.nodeKey, mediaId, undefined, url);
+        return;
+      }
+      editor.update(() => {
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) {
+          return;
+        }
+        selection.insertNodes([$createEmbedBlockNode(mediaId, '', '', undefined, 100, 360, url)]);
+      });
+    },
+    [dataAdapter, editor, replaceNodeMedia]
+  );
+
+  const onInputChange: React.ChangeEventHandler<HTMLInputElement> = async (event) => {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = '';
+    if (files.length === 0) {
+      return;
+    }
+    const payload = pickerPayload;
+    setPickerPayload(null);
+    await uploadFiles(files, payload);
+  };
+
+  const handleOpenPicker = useCallback(
+    (payload: MediaPickerPayload) => {
+      if (!dataAdapter?.uploadMedia || !inputRef.current) {
+        return;
+      }
+      setPickerPayload(payload);
+      inputRef.current.accept = acceptForKind(payload.kind);
+      inputRef.current.multiple = !payload.nodeKey;
+      inputRef.current.click();
+    },
+    [dataAdapter]
+  );
+
+  const handleDrop = useCallback(
+    (event: DragEvent) => {
+      if (!dataAdapter?.uploadMedia) {
+        return false;
+      }
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      if (files.length === 0) {
+        return false;
+      }
+      event.preventDefault();
+      void uploadFiles(files, null);
+      return true;
+    },
+    [dataAdapter, uploadFiles]
+  );
+
+  const handlePaste = useCallback(
+    (event: ClipboardEvent) => {
+      if (!dataAdapter?.uploadMedia) {
+        return false;
+      }
+      const files = Array.from(event.clipboardData?.files ?? []);
+      if (files.length === 0) {
+        return false;
+      }
+      event.preventDefault();
+      void uploadFiles(files, null);
+      return true;
+    },
+    [dataAdapter, uploadFiles]
+  );
+
+  const registerCommands = useMemo(
+    () => [
+      editor.registerCommand(
+        OPEN_MEDIA_PICKER_COMMAND,
+        (payload) => {
+          handleOpenPicker(payload);
+          return true;
+        },
+        COMMAND_PRIORITY_HIGH
+      ),
+      editor.registerCommand(
+        OPEN_EMBED_DIALOG_COMMAND,
+        (payload) => {
+          void openEmbedDialog(payload);
+          return true;
+        },
+        COMMAND_PRIORITY_HIGH
+      ),
+      editor.registerCommand(
+        DROP_COMMAND,
+        (event: DragEvent) => {
+          return handleDrop(event);
+        },
+        COMMAND_PRIORITY_LOW
+      ),
+      editor.registerCommand(
+        PASTE_COMMAND,
+        (event: ClipboardEvent) => {
+          return handlePaste(event);
+        },
+        COMMAND_PRIORITY_LOW
+      ),
+    ],
+    [editor, handleDrop, handleOpenPicker, handlePaste, openEmbedDialog]
+  );
+
+  React.useEffect(() => {
+    return () => {
+      registerCommands.forEach((unregister) => unregister());
+    };
+  }, [registerCommands]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="file"
+      className="hidden"
+      onChange={onInputChange}
+    />
+  );
+}

--- a/src/writer/components/WriterWorkspace/editor/lexical/plugins/SlashCommandPlugin.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/plugins/SlashCommandPlugin.tsx
@@ -15,6 +15,7 @@ import {
   INSERT_ORDERED_LIST_COMMAND,
   INSERT_UNORDERED_LIST_COMMAND,
 } from '@lexical/list';
+import { INSERT_TABLE_COMMAND } from '@lexical/table';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import {
   LexicalTypeaheadMenuPlugin,
@@ -22,6 +23,11 @@ import {
   LexicalTypeaheadMenuOption,
   type MenuTextMatch,
 } from '@lexical/react/LexicalTypeaheadMenuPlugin';
+import {
+  OPEN_EMBED_DIALOG_COMMAND,
+  OPEN_MEDIA_PICKER_COMMAND,
+} from '@/writer/components/WriterWorkspace/editor/lexical/plugins/MediaPlugin';
+import { WRITER_MEDIA_KIND } from '@/writer/lib/data-adapter/media';
 
 type SlashCommandAction = () => void;
 
@@ -125,19 +131,21 @@ export function SlashCommandPlugin() {
       return divider;
     });
 
-  const insertTablePlaceholder = () =>
-    insertBlock(() => {
-      const table = $createParagraphNode();
-      table.append($createTextNode('[Table]'));
-      return table;
+  const insertTable = () =>
+    editor.dispatchCommand(INSERT_TABLE_COMMAND, { rows: '3', columns: '3' });
+
+  const insertImage = () =>
+    editor.dispatchCommand(OPEN_MEDIA_PICKER_COMMAND, {
+      kind: WRITER_MEDIA_KIND.IMAGE,
     });
 
-  const insertImagePlaceholder = () =>
-    insertBlock(() => {
-      const image = $createParagraphNode();
-      image.append($createTextNode('[Image]'));
-      return image;
+  const insertFile = () =>
+    editor.dispatchCommand(OPEN_MEDIA_PICKER_COMMAND, {
+      kind: WRITER_MEDIA_KIND.FILE,
     });
+
+  const insertEmbed = () =>
+    editor.dispatchCommand(OPEN_EMBED_DIALOG_COMMAND, {});
 
   const baseOptions = useMemo(
     () => [
@@ -212,15 +220,27 @@ export function SlashCommandPlugin() {
       }),
       new SlashCommandOption({
         title: 'Table',
-        description: 'Insert a table placeholder',
+        description: 'Insert a table',
         keywords: ['table', 'grid'],
-        onSelect: insertTablePlaceholder,
+        onSelect: insertTable,
       }),
       new SlashCommandOption({
         title: 'Image',
-        description: 'Insert an image placeholder',
+        description: 'Insert an image',
         keywords: ['image', 'photo', 'media'],
-        onSelect: insertImagePlaceholder,
+        onSelect: insertImage,
+      }),
+      new SlashCommandOption({
+        title: 'File attachment',
+        description: 'Upload a file',
+        keywords: ['file', 'attachment', 'upload'],
+        onSelect: insertFile,
+      }),
+      new SlashCommandOption({
+        title: 'Embed',
+        description: 'Embed an external URL',
+        keywords: ['embed', 'video', 'iframe'],
+        onSelect: insertEmbed,
       }),
     ],
     [editor]

--- a/src/writer/components/WriterWorkspace/editor/lexical/plugins/TablePlugin.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/plugins/TablePlugin.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { TablePlugin as LexicalTablePlugin } from '@lexical/react/LexicalTablePlugin';
+
+export function TablePlugin() {
+  return <LexicalTablePlugin />;
+}

--- a/src/writer/components/WriterWorkspace/editor/lexical/plugins/ToolbarPlugin.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/plugins/ToolbarPlugin.tsx
@@ -15,8 +15,20 @@ import {
   REMOVE_LIST_COMMAND,
   $isListNode,
 } from '@lexical/list';
+import {
+  INSERT_TABLE_COMMAND,
+  $insertTableRowAtSelection,
+  $insertTableColumnAtSelection,
+  $deleteTableRowAtSelection,
+  $deleteTableColumnAtSelection,
+} from '@lexical/table';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { useWriterWorkspaceStore } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
+import {
+  OPEN_EMBED_DIALOG_COMMAND,
+  OPEN_MEDIA_PICKER_COMMAND,
+} from '@/writer/components/WriterWorkspace/editor/lexical/plugins/MediaPlugin';
+import { WRITER_MEDIA_KIND } from '@/writer/lib/data-adapter/media';
 
 const toolbarButtonBase =
   'rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-secondary transition hover:text-df-text-primary';
@@ -210,6 +222,94 @@ export function ToolbarPlugin() {
         aria-label="Clear formatting"
       >
         Clear
+      </button>
+      <button
+        type="button"
+        className={toolbarButtonBase}
+        onClick={() =>
+          editor.dispatchCommand(OPEN_MEDIA_PICKER_COMMAND, {
+            kind: WRITER_MEDIA_KIND.IMAGE,
+          })
+        }
+        aria-label="Insert image"
+      >
+        Image
+      </button>
+      <button
+        type="button"
+        className={toolbarButtonBase}
+        onClick={() =>
+          editor.dispatchCommand(OPEN_MEDIA_PICKER_COMMAND, {
+            kind: WRITER_MEDIA_KIND.FILE,
+          })
+        }
+        aria-label="Insert file attachment"
+      >
+        File
+      </button>
+      <button
+        type="button"
+        className={toolbarButtonBase}
+        onClick={() => editor.dispatchCommand(OPEN_EMBED_DIALOG_COMMAND, {})}
+        aria-label="Insert embed"
+      >
+        Embed
+      </button>
+      <button
+        type="button"
+        className={toolbarButtonBase}
+        onClick={() => editor.dispatchCommand(INSERT_TABLE_COMMAND, { rows: '3', columns: '3' })}
+        aria-label="Insert table"
+      >
+        Table
+      </button>
+      <button
+        type="button"
+        className={toolbarButtonBase}
+        onClick={() =>
+          editor.update(() => {
+            $insertTableRowAtSelection(true);
+          })
+        }
+        aria-label="Insert table row"
+      >
+        Row +
+      </button>
+      <button
+        type="button"
+        className={toolbarButtonBase}
+        onClick={() =>
+          editor.update(() => {
+            $insertTableColumnAtSelection(true);
+          })
+        }
+        aria-label="Insert table column"
+      >
+        Col +
+      </button>
+      <button
+        type="button"
+        className={toolbarButtonBase}
+        onClick={() =>
+          editor.update(() => {
+            $deleteTableRowAtSelection();
+          })
+        }
+        aria-label="Delete table row"
+      >
+        Row -
+      </button>
+      <button
+        type="button"
+        className={toolbarButtonBase}
+        onClick={() =>
+          editor.update(() => {
+            $deleteTableColumnAtSelection();
+          })
+        }
+        aria-label="Delete table column"
+      >
+        Col -
       </button>
       <button
         type="button"

--- a/src/writer/components/WriterWorkspace/editor/lexical/plugins/WriterPlugins.tsx
+++ b/src/writer/components/WriterWorkspace/editor/lexical/plugins/WriterPlugins.tsx
@@ -6,16 +6,20 @@ import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPl
 import { TRANSFORMERS } from '@lexical/markdown';
 import { MarkdownPastePlugin } from './MarkdownPastePlugin';
 import { SlashCommandPlugin } from './SlashCommandPlugin';
+import { MediaPlugin } from './MediaPlugin';
+import { TablePlugin } from './TablePlugin';
 
 export function WriterPlugins() {
   return (
     <>
       <AutoFocusPlugin />
+      <MediaPlugin />
       <ListPlugin />
       <LinkPlugin />
       <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
       <MarkdownPastePlugin />
       <SlashCommandPlugin />
+      <TablePlugin />
     </>
   );
 }

--- a/src/writer/components/WriterWorkspace/editor/lexical/theme.ts
+++ b/src/writer/components/WriterWorkspace/editor/lexical/theme.ts
@@ -22,6 +22,9 @@ export const writerTheme = {
     superscript: 'align-super text-[0.75em]',
   },
   code: 'block whitespace-pre-wrap rounded-md bg-df-surface px-3 py-2 font-mono text-sm text-df-text-primary',
+  table: 'w-full border-collapse',
+  tableRow: 'border-b border-df-node-border',
+  tableCell: 'min-w-[80px] border border-df-node-border p-2 align-top text-sm',
   codeHighlight: {
     atrule: 'text-sky-300',
     attr: 'text-emerald-300',

--- a/src/writer/lib/data-adapter/media.ts
+++ b/src/writer/lib/data-adapter/media.ts
@@ -1,0 +1,23 @@
+export const WRITER_MEDIA_KIND = {
+  IMAGE: 'image',
+  FILE: 'file',
+  EMBED: 'embed',
+} as const;
+
+export type WriterMediaKind = (typeof WRITER_MEDIA_KIND)[keyof typeof WRITER_MEDIA_KIND];
+
+export type WriterMediaRecord = {
+  id: string;
+  url: string | null;
+  filename?: string | null;
+  mimeType?: string | null;
+  width?: number | null;
+  height?: number | null;
+  title?: string | null;
+  kind?: WriterMediaKind | null;
+};
+
+export type WriterMediaUploadResult = {
+  mediaId: string;
+  record?: WriterMediaRecord | null;
+};

--- a/src/writer/lib/data-adapter/writer-adapter.ts
+++ b/src/writer/lib/data-adapter/writer-adapter.ts
@@ -1,4 +1,5 @@
 import type { ForgeAct, ForgeChapter, ForgePage } from '@/forge/types/narrative';
+import type { WriterMediaRecord, WriterMediaUploadResult } from './media';
 
 export type WriterActDoc = ForgeAct;
 export type WriterChapterDoc = ForgeChapter;
@@ -17,4 +18,8 @@ export interface WriterDataAdapter {
   updateAct(actId: number, patch: Partial<WriterActDoc>): Promise<WriterActDoc>;
   updateChapter(chapterId: number, patch: Partial<WriterChapterDoc>): Promise<WriterChapterDoc>;
   updatePage(pageId: number, patch: Partial<WriterPageDoc>): Promise<WriterPageDoc>;
+
+  uploadMedia?(file: File): Promise<WriterMediaUploadResult>;
+  resolveMedia?(mediaId: string): Promise<WriterMediaRecord | null>;
+  createEmbed?(url: string): Promise<WriterMediaUploadResult>;
 }


### PR DESCRIPTION
### Motivation
- Add first-class media block support (image, file attachment, embed) to the Writer Lexical editor while keeping Payload as the source of truth by storing `mediaId` and resolving URLs through the writer data adapter.
- Provide basic authoring UX for media: insert via picker/drag-drop/paste, alt text/caption editing, alignment and width resizing, and a simple embed dialog flow.
- Enable simple table creation and basic row/column editing to support tabular content in the writer. 

### Description
- Added media types and constants plus decorator-based Lexical nodes for image, file, and embed blocks with serialization, controls, and a React UI decorator: `src/writer/components/WriterWorkspace/editor/lexical/nodes/MediaNodes.tsx` and `media-constants.ts`. 
- Extended the writer data adapter API and introduced media types: `src/writer/lib/data-adapter/media.ts` and added optional methods `uploadMedia`, `resolveMedia`, and `createEmbed` to `WriterDataAdapter` in `writer-adapter.ts`. 
- Implemented a `MediaPlugin` providing file picker, drag/drop, paste handling, upload flow, and embed dialog plus exported commands `OPEN_MEDIA_PICKER_COMMAND` and `OPEN_EMBED_DIALOG_COMMAND` in `src/writer/components/WriterWorkspace/editor/lexical/plugins/MediaPlugin.tsx`. 
- Wired media and table insertion into the editor UI by updating the toolbar and slash command plugin, registering the media/table plugins, adding `@lexical/table` usage, and registering media nodes in the node list and theme: `ToolbarPlugin.tsx`, `SlashCommandPlugin.tsx`, `WriterPlugins.tsx`, `TablePlugin.tsx`, `nodes.ts`, and `theme.ts`. 

### Testing
- Ran package changes with `npm install` (package lock updated) and `npm install --package-lock-only --ignore-scripts` which completed with standard warnings about deprecated packages. 
- Executed `npm run build`, which produced a build with compiler warnings and several Lexical import/compat warnings and noted ESLint not installed in the environment; the toolchain reported issues that need resolving in the environment (warnings/errors related to Lexical exports and ESLint). 
- Started development server (`npm run dev`) and attempted a Playwright capture of `/writer`, but the headless browser step timed out/crashed in this environment so no screenshot could be produced, and the dev compilation surfaced Lexical import/export mismatches that must be addressed before full runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6dcea154832d841d6a96a4d09964)