### PR TITLE
Add WriterTopBar, sidebar search/New-page action, and per-page full-width toggle

### DIFF
--- a/app/lib/writer/data-adapter/payload-writer-adapter.ts
+++ b/app/lib/writer/data-adapter/payload-writer-adapter.ts
@@ -176,5 +176,24 @@ export function makePayloadWriterAdapter(opts?: {
       }) as Page;
       return mapPage(doc);
     },
+    async createPage(input: {
+      title: string;
+      project: number;
+      chapter: number;
+      order: number;
+      bookBody?: string | null;
+    }): Promise<WriterPageDoc> {
+      const doc = await payload.create({
+        collection: PAYLOAD_COLLECTIONS.PAGES,
+        data: {
+          title: input.title,
+          project: input.project,
+          chapter: input.chapter,
+          order: input.order,
+          bookBody: input.bookBody ?? null,
+        },
+      }) as Page;
+      return mapPage(doc);
+    },
   };
 }

--- a/src/writer/components/WriterWorkspace/layout/WriterLayout.tsx
+++ b/src/writer/components/WriterWorkspace/layout/WriterLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
 import { useWriterWorkspaceStore } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
+import { WriterTopBar } from '@/writer/components/WriterWorkspace/layout/WriterTopBar';
 
 interface WriterLayoutProps {
   sidebar: ReactNode;
@@ -10,8 +11,15 @@ interface WriterLayoutProps {
 
 export function WriterLayout({ sidebar, editor, className }: WriterLayoutProps) {
   const activePageId = useWriterWorkspaceStore((state) => state.activePageId);
+  const pageLayout = useWriterWorkspaceStore((state) => state.pageLayout);
   const hasActivePage = activePageId !== null;
   const contextNodeType = hasActivePage ? FORGE_NODE_TYPE.PAGE : null;
+  const isFullWidth = activePageId
+    ? pageLayout.fullWidthByPageId[activePageId] ?? false
+    : false;
+  const contentClassName = isFullWidth
+    ? 'w-full'
+    : 'mx-auto w-full max-w-4xl';
 
   return (
     <div
@@ -25,7 +33,12 @@ export function WriterLayout({ sidebar, editor, className }: WriterLayoutProps) 
         {sidebar}
       </aside>
       <section className="flex min-h-0 flex-1 flex-col">
-        {editor}
+        <div className={`flex min-h-0 flex-1 flex-col gap-2 ${contentClassName}`}>
+          <WriterTopBar />
+          <div className="flex min-h-0 flex-1 flex-col">
+            {editor}
+          </div>
+        </div>
       </section>
     </div>
   );

--- a/src/writer/components/WriterWorkspace/layout/WriterTopBar.tsx
+++ b/src/writer/components/WriterWorkspace/layout/WriterTopBar.tsx
@@ -1,0 +1,105 @@
+import React, { useMemo } from 'react';
+import { ChevronRight, Maximize2, Minimize2 } from 'lucide-react';
+import { useWriterWorkspaceStore } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
+
+export function WriterTopBar() {
+  const acts = useWriterWorkspaceStore((state) => state.acts);
+  const chapters = useWriterWorkspaceStore((state) => state.chapters);
+  const pages = useWriterWorkspaceStore((state) => state.pages);
+  const drafts = useWriterWorkspaceStore((state) => state.drafts);
+  const activePageId = useWriterWorkspaceStore((state) => state.activePageId);
+  const pageLayout = useWriterWorkspaceStore((state) => state.pageLayout);
+  const togglePageFullWidth = useWriterWorkspaceStore((state) => state.actions.togglePageFullWidth);
+
+  const activePage = useMemo(
+    () => pages.find((page) => page.id === activePageId) ?? null,
+    [pages, activePageId]
+  );
+  const activeChapter = useMemo(
+    () => chapters.find((chapter) => chapter.id === activePage?.chapter) ?? null,
+    [chapters, activePage?.chapter]
+  );
+  const activeAct = useMemo(
+    () => acts.find((act) => act.id === activeChapter?.act) ?? null,
+    [acts, activeChapter?.act]
+  );
+  const draftTitle = activePageId ? drafts[activePageId]?.title ?? '' : '';
+  const pageTitle =
+    draftTitle.trim() ||
+    activePage?.title ||
+    (activePageId ? 'Untitled page' : 'Select a page');
+  const isFullWidth = activePageId
+    ? pageLayout.fullWidthByPageId[activePageId] ?? false
+    : false;
+
+  const metadata = useMemo(() => {
+    if (!activePage) {
+      return [];
+    }
+    return [
+      activePage._status
+        ? { label: 'Status', value: activePage._status }
+        : null,
+      activePage.summary
+        ? { label: 'Summary', value: activePage.summary }
+        : null,
+    ].filter(Boolean) as Array<{ label: string; value: string }>;
+  }, [activePage]);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-df-node-border bg-df-editor-bg px-4 py-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <nav className="flex flex-wrap items-center gap-2 text-xs text-df-text-tertiary">
+            {activeAct ? (
+              <span className="truncate">{activeAct.title}</span>
+            ) : (
+              <span className="text-df-text-tertiary">Workspace</span>
+            )}
+            {activeChapter ? (
+              <>
+                <ChevronRight size={12} className="text-df-text-tertiary" />
+                <span className="truncate">{activeChapter.title}</span>
+              </>
+            ) : null}
+            {activePage ? (
+              <>
+                <ChevronRight size={12} className="text-df-text-tertiary" />
+                <span className="truncate">{activePage.title}</span>
+              </>
+            ) : null}
+          </nav>
+          <div className="mt-1 text-base font-semibold text-df-text-primary">
+            {pageTitle}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="flex items-center gap-2 rounded-md border border-df-control-border bg-df-control-bg px-3 py-1 text-xs text-df-text-secondary transition hover:text-df-text-primary disabled:opacity-50"
+          onClick={() => {
+            if (activePageId) {
+              togglePageFullWidth(activePageId);
+            }
+          }}
+          disabled={!activePageId}
+          aria-pressed={isFullWidth}
+        >
+          {isFullWidth ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+          Full width
+        </button>
+      </div>
+      {metadata.length > 0 ? (
+        <div className="flex flex-wrap gap-3 text-xs text-df-text-tertiary">
+          {metadata.map((item) => (
+            <div key={item.label} className="flex items-center gap-2">
+              <span className="text-[11px] font-semibold uppercase tracking-wide text-df-text-tertiary">
+                {item.label}
+              </span>
+              <span className="text-df-text-secondary">{item.value}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/writer/components/WriterWorkspace/sidebar/WriterTree.tsx
+++ b/src/writer/components/WriterWorkspace/sidebar/WriterTree.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import { Book, BookOpen, FileText } from 'lucide-react';
+import { Book, BookOpen, FileText, Plus, Search } from 'lucide-react';
 import { useWriterWorkspaceStore } from '@/writer/components/WriterWorkspace/store/writer-workspace-store';
 import { WriterTreeRow } from './WriterTreeRow';
 
@@ -12,10 +12,14 @@ export function WriterTree({ className }: WriterTreeProps) {
   const chapters = useWriterWorkspaceStore((state) => state.chapters);
   const pages = useWriterWorkspaceStore((state) => state.pages);
   const activePageId = useWriterWorkspaceStore((state) => state.activePageId);
+  const dataAdapter = useWriterWorkspaceStore((state) => state.dataAdapter);
   const setActivePageId = useWriterWorkspaceStore((state) => state.actions.setActivePageId);
+  const setPages = useWriterWorkspaceStore((state) => state.actions.setPages);
 
   const [expandedActIds, setExpandedActIds] = useState<Set<number>>(() => new Set());
   const [expandedChapterIds, setExpandedChapterIds] = useState<Set<number>>(() => new Set());
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
 
   const sortedActs = useMemo(
     () => [...acts].sort((a, b) => a.order - b.order),
@@ -31,6 +35,15 @@ export function WriterTree({ className }: WriterTreeProps) {
     () => [...pages].sort((a, b) => a.order - b.order),
     [pages]
   );
+
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const isSearching = normalizedQuery.length > 0;
+  const matchesQuery = (value: string) => value.toLowerCase().includes(normalizedQuery);
+  const hasSearchMatches = isSearching
+    ? sortedActs.some((act) => matchesQuery(act.title)) ||
+      sortedChapters.some((chapter) => matchesQuery(chapter.title)) ||
+      sortedPages.some((page) => matchesQuery(page.title))
+    : true;
 
   useEffect(() => {
     if (sortedActs.length > 0 && expandedActIds.size === 0) {
@@ -92,10 +105,73 @@ export function WriterTree({ className }: WriterTreeProps) {
     });
   };
 
+  const handleCreatePage = async () => {
+    if (!dataAdapter?.createPage || isCreating) {
+      return;
+    }
+    const activePage = pages.find((page) => page.id === activePageId) ?? null;
+    const targetChapter =
+      chapters.find((chapter) => chapter.id === activePage?.chapter) ??
+      sortedChapters[0] ??
+      null;
+    if (!targetChapter) {
+      return;
+    }
+    const chapterPages = sortedPages.filter((page) => page.chapter === targetChapter.id);
+    const nextOrder =
+      chapterPages.length > 0
+        ? Math.max(...chapterPages.map((page) => page.order)) + 1
+        : 1;
+
+    setIsCreating(true);
+    try {
+      const newPage = await dataAdapter.createPage({
+        title: 'New page',
+        project: targetChapter.project,
+        chapter: targetChapter.id,
+        order: nextOrder,
+        bookBody: '',
+      });
+      setPages([...pages, newPage]);
+      setActivePageId(newPage.id);
+      setExpandedChapterIds((prev) => new Set(prev).add(targetChapter.id));
+      if (targetChapter.act) {
+        setExpandedActIds((prev) => new Set(prev).add(targetChapter.act));
+      }
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const canCreatePage = Boolean(dataAdapter?.createPage && chapters.length > 0);
+
   return (
     <div className={`flex min-h-0 flex-1 flex-col gap-2 ${className ?? ''}`}>
-      <div className="rounded-lg border border-df-node-border bg-df-editor-bg px-3 py-2 text-xs font-semibold uppercase tracking-wide text-df-text-tertiary">
-        Narrative Outline
+      <div className="rounded-lg border border-df-node-border bg-df-editor-bg p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-xs font-semibold uppercase tracking-wide text-df-text-tertiary">
+            Narrative Outline
+          </div>
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-[11px] text-df-text-secondary transition hover:text-df-text-primary disabled:opacity-50"
+            onClick={() => void handleCreatePage()}
+            disabled={!canCreatePage || isCreating}
+          >
+            <Plus size={12} />
+            New page
+          </button>
+        </div>
+        <div className="mt-2 flex items-center gap-2 rounded-md border border-df-control-border bg-df-control-bg px-2 py-1 text-xs text-df-text-secondary">
+          <Search size={14} />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search acts, chapters, pages..."
+            className="w-full bg-transparent text-xs text-df-text-primary outline-none placeholder:text-df-text-tertiary"
+          />
+        </div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto rounded-lg border border-df-node-border bg-df-editor-bg p-2">
         {sortedActs.length === 0 ? (
@@ -103,58 +179,100 @@ export function WriterTree({ className }: WriterTreeProps) {
             No acts available.
           </div>
         ) : (
-          sortedActs.map((act) => {
-            const actChapters = sortedChapters.filter((chapter) => chapter.act === act.id);
-            const isActExpanded = expandedActIds.has(act.id);
-
-            return (
-              <div key={act.id} className="space-y-1">
-                <WriterTreeRow
-                  label={act.title}
-                  depth={0}
-                  icon={<BookOpen size={14} />}
-                  hasChildren={actChapters.length > 0}
-                  isExpanded={isActExpanded}
-                  onToggle={() => toggleAct(act.id)}
-                  onSelect={() => toggleAct(act.id)}
-                />
-
-                {isActExpanded &&
-                  actChapters.map((chapter) => {
-                    const chapterPages = sortedPages.filter(
-                      (page) => page.chapter === chapter.id
+          sortedActs
+            .filter((act) => {
+              if (!isSearching) {
+                return true;
+              }
+              if (matchesQuery(act.title)) {
+                return true;
+              }
+              const actChapters = sortedChapters.filter((chapter) => chapter.act === act.id);
+              return actChapters.some((chapter) => {
+                if (matchesQuery(chapter.title)) {
+                  return true;
+                }
+                return sortedPages.some(
+                  (page) => page.chapter === chapter.id && matchesQuery(page.title)
+                );
+              });
+            })
+            .map((act) => {
+              const actChapters = sortedChapters.filter((chapter) => chapter.act === act.id);
+              const actMatches = isSearching && matchesQuery(act.title);
+              const visibleChapters = actMatches
+                ? actChapters
+                : actChapters.filter((chapter) => {
+                    if (!isSearching) {
+                      return true;
+                    }
+                    if (matchesQuery(chapter.title)) {
+                      return true;
+                    }
+                    return sortedPages.some(
+                      (page) => page.chapter === chapter.id && matchesQuery(page.title)
                     );
-                    const isChapterExpanded = expandedChapterIds.has(chapter.id);
+                  });
+              const isActExpanded = isSearching || expandedActIds.has(act.id);
 
-                    return (
-                      <div key={chapter.id} className="space-y-1">
-                        <WriterTreeRow
-                          label={chapter.title}
-                          depth={1}
-                          icon={<Book size={14} />}
-                          hasChildren={chapterPages.length > 0}
-                          isExpanded={isChapterExpanded}
-                          onToggle={() => toggleChapter(chapter.id)}
-                          onSelect={() => toggleChapter(chapter.id)}
-                        />
+              return (
+                <div key={act.id} className="space-y-1">
+                  <WriterTreeRow
+                    label={act.title}
+                    depth={0}
+                    icon={<BookOpen size={14} />}
+                    hasChildren={actChapters.length > 0}
+                    isExpanded={isActExpanded}
+                    onToggle={() => toggleAct(act.id)}
+                    onSelect={() => toggleAct(act.id)}
+                  />
 
-                        {isChapterExpanded &&
-                          chapterPages.map((page) => (
-                            <WriterTreeRow
-                              key={page.id}
-                              label={page.title}
-                              depth={2}
-                              icon={<FileText size={14} />}
-                              isSelected={activePageId === page.id}
-                              onSelect={() => setActivePageId(page.id)}
-                            />
-                          ))}
-                      </div>
-                    );
-                  })}
-              </div>
-            );
-          })
+                  {isActExpanded &&
+                    visibleChapters.map((chapter) => {
+                      const chapterPages = sortedPages.filter(
+                        (page) => page.chapter === chapter.id
+                      );
+                      const chapterMatches =
+                        actMatches || (isSearching && matchesQuery(chapter.title));
+                      const visiblePages = chapterMatches
+                        ? chapterPages
+                        : chapterPages.filter((page) => matchesQuery(page.title));
+                      const isChapterExpanded = isSearching || expandedChapterIds.has(chapter.id);
+
+                      return (
+                        <div key={chapter.id} className="space-y-1">
+                          <WriterTreeRow
+                            label={chapter.title}
+                            depth={1}
+                            icon={<Book size={14} />}
+                            hasChildren={chapterPages.length > 0}
+                            isExpanded={isChapterExpanded}
+                            onToggle={() => toggleChapter(chapter.id)}
+                            onSelect={() => toggleChapter(chapter.id)}
+                          />
+
+                          {isChapterExpanded &&
+                            visiblePages.map((page) => (
+                              <WriterTreeRow
+                                key={page.id}
+                                label={page.title}
+                                depth={2}
+                                icon={<FileText size={14} />}
+                                isSelected={activePageId === page.id}
+                                onSelect={() => setActivePageId(page.id)}
+                              />
+                            ))}
+                        </div>
+                      );
+                    })}
+                </div>
+              );
+            })
+        )}
+        {isSearching && sortedActs.length > 0 && !hasSearchMatches && (
+          <div className="rounded-md border border-df-control-border bg-df-control-bg p-3 text-xs text-df-text-tertiary">
+            No matching pages found.
+          </div>
         )}
       </div>
     </div>

--- a/src/writer/components/WriterWorkspace/store/slices/viewState.slice.ts
+++ b/src/writer/components/WriterWorkspace/store/slices/viewState.slice.ts
@@ -23,15 +23,24 @@ export interface WriterModalState {
   isSettingsModalOpen: boolean;
 }
 
+export interface WriterPageLayoutState {
+  fullWidthByPageId: Record<number, boolean>;
+}
+
 const defaultModalState: WriterModalState = {
   isYarnModalOpen: false,
   isPlayModalOpen: false,
   isSettingsModalOpen: false,
 };
 
+const defaultPageLayout: WriterPageLayoutState = {
+  fullWidthByPageId: {},
+};
+
 export interface ViewStateSlice {
   modalState: WriterModalState;
   panelLayout: WriterPanelLayoutState;
+  pageLayout: WriterPageLayoutState;
 }
 
 export interface ViewStateActions {
@@ -44,6 +53,8 @@ export interface ViewStateActions {
   togglePanel: (panel: 'sidebar' | 'editor') => void;
   dockPanel: (panel: 'sidebar' | 'editor') => void;
   undockPanel: (panel: 'sidebar' | 'editor') => void;
+  setPageFullWidth: (pageId: number, value: boolean) => void;
+  togglePageFullWidth: (pageId: number) => void;
 }
 
 export function createViewStateSlice(
@@ -53,6 +64,7 @@ export function createViewStateSlice(
   return {
     modalState: defaultModalState,
     panelLayout: defaultPanelLayout,
+    pageLayout: defaultPageLayout,
     openYarnModal: () =>
       set((state) => ({
         modalState: { ...state.modalState, isYarnModalOpen: true },
@@ -104,6 +116,26 @@ export function createViewStateSlice(
           [panel]: {
             ...state.panelLayout[panel],
             isDocked: false,
+          },
+        },
+      })),
+    setPageFullWidth: (pageId, value) =>
+      set((state) => ({
+        pageLayout: {
+          ...state.pageLayout,
+          fullWidthByPageId: {
+            ...state.pageLayout.fullWidthByPageId,
+            [pageId]: value,
+          },
+        },
+      })),
+    togglePageFullWidth: (pageId) =>
+      set((state) => ({
+        pageLayout: {
+          ...state.pageLayout,
+          fullWidthByPageId: {
+            ...state.pageLayout.fullWidthByPageId,
+            [pageId]: !state.pageLayout.fullWidthByPageId[pageId],
           },
         },
       })),

--- a/src/writer/components/WriterWorkspace/store/writer-workspace-store.tsx
+++ b/src/writer/components/WriterWorkspace/store/writer-workspace-store.tsx
@@ -69,6 +69,7 @@ export interface WriterWorkspaceState {
   // View state slice
   modalState: ReturnType<typeof createViewStateSlice>['modalState'];
   panelLayout: ReturnType<typeof createViewStateSlice>['panelLayout'];
+  pageLayout: ReturnType<typeof createViewStateSlice>['pageLayout'];
 
   // Data adapter
   dataAdapter?: WriterDataAdapter;
@@ -99,6 +100,19 @@ export interface WriterWorkspaceState {
     toggleActExpanded: (actId: number) => void;
     toggleChapterExpanded: (chapterId: number) => void;
     setNavigationError: (error: string | null) => void;
+
+    // View state actions
+    openYarnModal: () => void;
+    closeYarnModal: () => void;
+    openPlayModal: () => void;
+    closePlayModal: () => void;
+    openSettingsModal: () => void;
+    closeSettingsModal: () => void;
+    togglePanel: (panel: 'sidebar' | 'editor') => void;
+    dockPanel: (panel: 'sidebar' | 'editor') => void;
+    undockPanel: (panel: 'sidebar' | 'editor') => void;
+    setPageFullWidth: (pageId: number, value: boolean) => void;
+    togglePageFullWidth: (pageId: number) => void;
   };
 }
 
@@ -235,6 +249,8 @@ export function createWriterWorkspaceStore(
             togglePanel: viewStateSlice.togglePanel,
             dockPanel: viewStateSlice.dockPanel,
             undockPanel: viewStateSlice.undockPanel,
+            setPageFullWidth: viewStateSlice.setPageFullWidth,
+            togglePageFullWidth: viewStateSlice.togglePageFullWidth,
           },
         };
       }),

--- a/src/writer/components/WriterWorkspace/store/writer-workspace-types.ts
+++ b/src/writer/components/WriterWorkspace/store/writer-workspace-types.ts
@@ -102,6 +102,7 @@ export interface WriterWorkspaceState {
   navigationError: string | null;
   modalState: unknown;
   panelLayout: unknown;
+  pageLayout: unknown;
   dataAdapter?: unknown;
   actions: Record<string, unknown>;
 }

--- a/src/writer/lib/data-adapter/writer-adapter.ts
+++ b/src/writer/lib/data-adapter/writer-adapter.ts
@@ -18,6 +18,13 @@ export interface WriterDataAdapter {
   updateAct(actId: number, patch: Partial<WriterActDoc>): Promise<WriterActDoc>;
   updateChapter(chapterId: number, patch: Partial<WriterChapterDoc>): Promise<WriterChapterDoc>;
   updatePage(pageId: number, patch: Partial<WriterPageDoc>): Promise<WriterPageDoc>;
+  createPage?: (input: {
+    title: string;
+    project: number;
+    chapter: number;
+    order: number;
+    bookBody?: string | null;
+  }) => Promise<WriterPageDoc>;
 
   uploadMedia?(file: File): Promise<WriterMediaUploadResult>;
   resolveMedia?(mediaId: string): Promise<WriterMediaRecord | null>;


### PR DESCRIPTION
### Motivation

- Provide a compact top bar with breadcrumbs, page title and metadata to make the editor header more informative.  
- Allow users to quickly find pages and create new pages from the sidebar.  
- Provide a per-page layout toggle so authors can expand the editor to full width when needed and persist that preference in workspace state.

### Description

- Add `WriterTopBar` (`src/writer/components/WriterWorkspace/layout/WriterTopBar.tsx`) that displays breadcrumbs, page title, optional metadata and a `Full width` toggle wired to workspace actions.  
- Integrate `WriterTopBar` into `WriterLayout` and apply per-page width via `pageLayout.fullWidthByPageId`, using the class `mx-auto w-full max-w-4xl` when not full-width or `w-full` when full-width.  
- Extend view state with `WriterPageLayoutState` and new actions `setPageFullWidth` / `togglePageFullWidth` in `src/writer/components/WriterWorkspace/store/slices/viewState.slice.ts` and expose `pageLayout` and the new actions through the workspace store types and store (`writer-workspace-types.ts` and `writer-workspace-store.tsx`).  
- Add sidebar search and a `New page` action in `WriterTree` (`src/writer/components/WriterWorkspace/sidebar/WriterTree.tsx`), including client-side filtering and a `handleCreatePage` helper that calls `dataAdapter.createPage` and updates workspace state.  
- Add optional `createPage` API to `WriterDataAdapter` (`src/writer/lib/data-adapter/writer-adapter.ts`) and implement it in the payload adapter (`app/lib/writer/data-adapter/payload-writer-adapter.ts`).

### Testing

- Ran the Next.js build with `npm run build`; the build failed due to a missing external dependency with the message: `Cannot find package '@payloadcms/next' imported from /workspace/dialogue-forge/next.config.mjs`.  
- No other automated test suites were executed in this rollout because the build error prevents a full app build/run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a7a4ac954832da02cd8f48a945f5d)