### PR TITLE
Add Forge media adapter types and media fields

### DIFF
--- a/app/payload-collections/collection-configs/media.ts
+++ b/app/payload-collections/collection-configs/media.ts
@@ -40,5 +40,37 @@ export const Media: CollectionConfig = {
       name: 'alt',
       type: 'text',
     },
+    {
+      name: 'externalProvider',
+      type: 'text',
+    },
+    {
+      name: 'externalId',
+      type: 'text',
+    },
+    {
+      name: 'externalUrl',
+      type: 'text',
+    },
+    {
+      name: 'secureUrl',
+      type: 'text',
+    },
+    {
+      name: 'width',
+      type: 'number',
+    },
+    {
+      name: 'height',
+      type: 'number',
+    },
+    {
+      name: 'format',
+      type: 'text',
+    },
+    {
+      name: 'resourceType',
+      type: 'text',
+    },
   ],
 }

--- a/src/forge/lib/data-adapter/media.ts
+++ b/src/forge/lib/data-adapter/media.ts
@@ -1,0 +1,19 @@
+export const FORGE_MEDIA_KIND = {
+  IMAGE: 'image',
+  VIDEO: 'video',
+  FILE: 'file',
+} as const;
+
+export type ForgeMediaKind = (typeof FORGE_MEDIA_KIND)[keyof typeof FORGE_MEDIA_KIND];
+
+export type ForgeMediaRecord = {
+  id: string;
+  url: string | null;
+  width?: number | null;
+  height?: number | null;
+  kind?: ForgeMediaKind | null;
+};
+
+export interface ForgeMediaAdapter {
+  resolveMedia(mediaId: string): Promise<ForgeMediaRecord | null>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,4 +38,5 @@ export {
 export { exportToYarn, importFromYarn } from '@/forge/lib/yarn-converter';
 export { initializeFlags, mergeFlagUpdates, validateFlags, getFlagValue } from '@/forge/components/shared/ForgeFlagManagerModal/FlagManager/utils/flag-manager';
 export * from '@/forge/lib/utils/forge-flow-helpers';
+export * from '@/forge/lib/data-adapter/media';
 // narrative-helpers and narrative-converter removed - use ForgeGraphDoc flow-first paradigm


### PR DESCRIPTION
### Motivation
- Allow storing Cloudinary or external provider metadata on the Payload `media` collection (public IDs, secure URL, dimensions, format) so external attachments can be resolved reliably. 
- Provide a Forge-specific media adapter type to normalize Payload media IDs into a stable, provider-agnostic media record for Forge runtime code. 

### Description
- Extended the Payload media collection at `app/payload-collections/collection-configs/media.ts` with fields: `externalProvider`, `externalId`, `externalUrl`, `secureUrl`, `width`, `height`, `format`, and `resourceType`. 
- Added `src/forge/lib/data-adapter/media.ts` containing `FORGE_MEDIA_KIND`, `ForgeMediaKind`, `ForgeMediaRecord`, and the `ForgeMediaAdapter` interface with `resolveMedia(mediaId: string): Promise<ForgeMediaRecord | null>`. 
- Re-exported the Forge media adapter types from the package entrypoint in `src/index.ts`. 

### Testing
- Ran the project build with `npm run build`, which failed due to an unrelated missing import error: `Cannot find package '@payloadcms/next' imported from next.config.mjs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac0cbdea4832d8268bac1f93131a2)