### PR TITLE
Add image-generation support to OpenRouter AI adapter and types

### DIFF
--- a/app/lib/ai/ai-adapter.ts
+++ b/app/lib/ai/ai-adapter.ts
@@ -14,6 +14,8 @@ export type {
   AiEditProposal,
   AiError,
   AiFailureResponse,
+  AiImageGenerationRequest,
+  AiImageGenerationResult,
   AiPlan,
   AiPlanStep,
   AiPlanStepApplyResult,
@@ -79,6 +81,7 @@ const defaultAdapter: AiAdapter = {
   createPlan: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
   proposePlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
   applyPlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+  generateImage: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
 };
 
 export const isServerSideApplyEnabled = () =>

--- a/src/ai/aiadapter/openrouter/openrouter-adapter.ts
+++ b/src/ai/aiadapter/openrouter/openrouter-adapter.ts
@@ -6,12 +6,14 @@ import { generateText, streamText } from 'ai';
 import type {
   AiAdapter,
   AiEditProposal,
+  AiImageGenerationRequest,
+  AiImageGenerationResult,
   AiPlan,
   AiPlanStepApplyResult,
   AiPlanStepProposal,
   AiResponse,
   AiStreamResponse,
-} from '@/src/lib/aiadapter/types';
+} from '@/ai/aiadapter/types';
 import { getOpenRouterConfig, type OpenRouterConfig } from './config';
 
 const OPENROUTER_MODEL_MODE = {
@@ -182,6 +184,34 @@ const normalizeEditProposal = (
 const createTimeoutSignal = (timeoutMs: number) =>
   timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
 
+const buildImageGenerationPayload = (
+  payload: AiImageGenerationRequest,
+  config: OpenRouterConfig
+): AiImageGenerationRequest => ({
+  ...payload,
+  model: payload.model ?? config.models.fast,
+});
+
+const parseOpenRouterError = async (response: Response) => {
+  try {
+    const payload = (await response.json()) as {
+      error?: { message?: string };
+      message?: string;
+    };
+    if (payload?.error?.message) {
+      return payload.error.message;
+    }
+    if (payload?.message) {
+      return payload.message;
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      return error.message;
+    }
+  }
+  return 'OpenRouter request failed.';
+};
+
 export const createOpenRouterAdapter = (
   config: OpenRouterConfig = getOpenRouterConfig()
 ): AiAdapter => {
@@ -192,6 +222,7 @@ export const createOpenRouterAdapter = (
       createPlan: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
       proposePlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
       applyPlanStep: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
+      generateImage: async () => errorResponse(NOT_CONFIGURED_MESSAGE, 501),
     };
   }
 
@@ -269,5 +300,34 @@ export const createOpenRouterAdapter = (
       errorResponse('Plan step proposals are not configured.', 501),
     applyPlanStep: async (): Promise<AiResponse<AiPlanStepApplyResult>> =>
       errorResponse('Plan step apply is not configured.', 501),
+    generateImage: async (
+      payload: AiImageGenerationRequest
+    ): Promise<AiResponse<AiImageGenerationResult>> => {
+      try {
+        const response = await fetch(`${config.baseUrl}/images/generations`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${config.apiKey}`,
+          },
+          body: JSON.stringify(buildImageGenerationPayload(payload, config)),
+          signal: createTimeoutSignal(config.timeoutMs),
+        });
+
+        if (!response.ok) {
+          return errorResponse(await parseOpenRouterError(response), response.status);
+        }
+
+        const data = (await response.json()) as AiImageGenerationResult;
+        return { ok: true, data };
+      } catch (error) {
+        return errorResponse(
+          error instanceof Error
+            ? error.message
+            : 'OpenRouter image generation request failed.',
+          502
+        );
+      }
+    },
   };
 };

--- a/src/ai/aiadapter/types.ts
+++ b/src/ai/aiadapter/types.ts
@@ -45,6 +45,28 @@ export type AiPlanStepApplyResult = {
   patch?: string;
 };
 
+export type AiImageGenerationRequest = {
+  prompt: string;
+  model?: string;
+  size?: string;
+  n?: number;
+  response_format?: 'url' | 'b64_json';
+  quality?: string;
+  style?: string;
+  seed?: number;
+  user?: string;
+};
+
+export type AiImageGenerationResult = {
+  created?: number;
+  data: Array<{
+    url?: string;
+    b64_json?: string;
+    revised_prompt?: string;
+  }>;
+  model?: string;
+};
+
 export type AiStreamResponse = {
   stream: ReadableStream<Uint8Array>;
   status?: number;
@@ -63,4 +85,7 @@ export interface AiAdapter {
   createPlan: (payload: unknown) => Promise<AiResponse<AiPlan>>;
   proposePlanStep: (payload: AiPlanStepRequest) => Promise<AiResponse<AiPlanStepProposal>>;
   applyPlanStep?: (payload: AiPlanStepRequest) => Promise<AiResponse<AiPlanStepApplyResult>>;
+  generateImage: (
+    payload: AiImageGenerationRequest
+  ) => Promise<AiResponse<AiImageGenerationResult>>;
 }


### PR DESCRIPTION
### Motivation
- Enable image generation through the existing AI adapter surface so image requests use the same OpenRouter config and error-handling pipeline as other AI operations.
- Avoid creating a parallel adapter implementation by extending the shared adapter types and the OpenRouter adapter implementation.

### Description
- Added `AiImageGenerationRequest` and `AiImageGenerationResult` types and extended `AiAdapter` with a `generateImage` method in `src/ai/aiadapter/types.ts`.
- Implemented `generateImage` in `src/ai/aiadapter/openrouter/openrouter-adapter.ts` using `getOpenRouterConfig()`, added `buildImageGenerationPayload` to apply defaults, and `parseOpenRouterError` to normalize remote errors, and POSTs to `${config.baseUrl}/images/generations` with timeout and error handling.
- Updated `app/lib/ai/ai-adapter.ts` to export the new image-generation types and include `generateImage` in the default adapter surface so the app can call the method consistently.

### Testing
- Ran `npm run build` to exercise the changes, which failed due to an unrelated environment/package issue: "Cannot find package '@payloadcms/next' imported from next.config.mjs".

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac0a83588832d90f5932aab2dbc8b)