### PR TITLE
Add template binding key helpers

### DIFF
--- a/src/shared/types/bindings.ts
+++ b/src/shared/types/bindings.ts
@@ -1,0 +1,17 @@
+export const TEMPLATE_INPUT_SCOPE = {
+  NODE: 'node',
+  GRAPH: 'graph',
+  PROJECT: 'project',
+} as const;
+
+export type TemplateInputScope = typeof TEMPLATE_INPUT_SCOPE[keyof typeof TEMPLATE_INPUT_SCOPE];
+
+export const buildTemplateInputKey = (scope: TemplateInputScope, key: string): string => `${scope}.${key}`;
+
+export const buildNodeTemplateInputKey = (key: string): string => buildTemplateInputKey(TEMPLATE_INPUT_SCOPE.NODE, key);
+
+export const TEMPLATE_INPUT_KEY = {
+  NODE_IMAGE: buildNodeTemplateInputKey('image'),
+} as const;
+
+export type TemplateInputKey = typeof TEMPLATE_INPUT_KEY[keyof typeof TEMPLATE_INPUT_KEY];

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -31,4 +31,6 @@ export const DOM_EVENT_TYPE = {
     ARROW_RIGHT: 'ArrowRight',
   } as const;
   
-  export type KeyboardKey = typeof KEYBOARD_KEY[keyof typeof KEYBOARD_KEY];
+export type KeyboardKey = typeof KEYBOARD_KEY[keyof typeof KEYBOARD_KEY];
+
+export * from './bindings';


### PR DESCRIPTION
### Motivation
- Centralize construction and usage of template input binding keys (for example node image bindings) to avoid scattered string literals and follow the project rule of using constants over ad-hoc strings.

### Description
- Add `src/shared/types/bindings.ts` which exports `TEMPLATE_INPUT_SCOPE`, `buildTemplateInputKey`, `buildNodeTemplateInputKey`, and `TEMPLATE_INPUT_KEY.NODE_IMAGE` for consistent template input key construction.
- Re-export the new bindings from `src/shared/types/index.ts` so the helpers are available from the shared types barrel.

### Testing
- Ran `npm run build` (Next build) which failed with `Cannot find package '@payloadcms/next' imported from next.config.mjs`, so the project build did not complete.
- No unit tests were added or modified as part of this change; no other automated test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac0e30a8c832d815a2b712de3701e)