### PR TITLE
Add canonical binding key builders for node/graph/media bindings

### DIFF
--- a/src/shared/types/bindings.ts
+++ b/src/shared/types/bindings.ts
@@ -1,3 +1,39 @@
+/**
+ * Canonical binding keys map runtime bindings to Forge graphs via dot-delimited scopes.
+ *
+ * - `node.*` keys map to data on individual graph nodes (e.g., node images, speakers).
+ * - `graph.*` keys map to graph-level properties (e.g., background, template overrides).
+ * - `media.*` keys map to media assets referenced by nodes or graphs.
+ *
+ * Prefer the builders below to avoid hard-coded string literals.
+ */
+export const BINDING_SCOPE = {
+  NODE: 'node',
+  GRAPH: 'graph',
+  MEDIA: 'media',
+} as const;
+
+export type BindingScope = typeof BINDING_SCOPE[keyof typeof BINDING_SCOPE];
+
+export const buildBindingKey = (scope: BindingScope, key: string): string => `${scope}.${key}`;
+
+export const buildNodeBindingKey = (key: string): string => buildBindingKey(BINDING_SCOPE.NODE, key);
+export const buildGraphBindingKey = (key: string): string => buildBindingKey(BINDING_SCOPE.GRAPH, key);
+export const buildMediaBindingKey = (key: string): string => buildBindingKey(BINDING_SCOPE.MEDIA, key);
+
+export const BINDING_KEY = {
+  NODE_IMAGE: buildNodeBindingKey('image'),
+  NODE_BACKGROUND: buildNodeBindingKey('background'),
+  NODE_SPEAKER: buildNodeBindingKey('speaker'),
+  NODE_TEMPLATE_OVERRIDE: buildNodeBindingKey('templateOverride'),
+  GRAPH_BACKGROUND: buildGraphBindingKey('background'),
+  GRAPH_TEMPLATE_OVERRIDE: buildGraphBindingKey('templateOverride'),
+  MEDIA_IMAGE: buildMediaBindingKey('image'),
+  MEDIA_VIDEO: buildMediaBindingKey('video'),
+} as const;
+
+export type BindingKey = typeof BINDING_KEY[keyof typeof BINDING_KEY];
+
 export const TEMPLATE_INPUT_SCOPE = {
   NODE: 'node',
   GRAPH: 'graph',
@@ -11,7 +47,7 @@ export const buildTemplateInputKey = (scope: TemplateInputScope, key: string): s
 export const buildNodeTemplateInputKey = (key: string): string => buildTemplateInputKey(TEMPLATE_INPUT_SCOPE.NODE, key);
 
 export const TEMPLATE_INPUT_KEY = {
-  NODE_IMAGE: buildNodeTemplateInputKey('image'),
+  NODE_IMAGE: BINDING_KEY.NODE_IMAGE,
 } as const;
 
 export type TemplateInputKey = typeof TEMPLATE_INPUT_KEY[keyof typeof TEMPLATE_INPUT_KEY];


### PR DESCRIPTION
### Motivation
- Provide canonical, reusable binding key constants and helper builders to avoid string literals when referencing node/graph/media bindings. 
- Make binding keys explicit for common runtime slots (node image, background, speaker, template overrides) and link template input keys to those canonical bindings.

### Description
- Added `BINDING_SCOPE` and `BindingScope` plus `buildBindingKey`, `buildNodeBindingKey`, `buildGraphBindingKey`, and `buildMediaBindingKey` helper builders in `src/shared/types/bindings.ts`.
- Introduced `BINDING_KEY` and `BindingKey` with constants for `NODE_IMAGE`, `NODE_BACKGROUND`, `NODE_SPEAKER`, `NODE_TEMPLATE_OVERRIDE`, `GRAPH_BACKGROUND`, `GRAPH_TEMPLATE_OVERRIDE`, `MEDIA_IMAGE`, and `MEDIA_VIDEO`.
- Added JSDoc explaining canonical binding scopes and how dot-delimited keys map to graph nodes and graph-level properties.
- Mapped the existing `TEMPLATE_INPUT_KEY.NODE_IMAGE` to the canonical `BINDING_KEY.NODE_IMAGE` so template inputs use the same constant values, and kept existing `TEMPLATE_INPUT_*` helpers.
- The bindings file is exported from `src/shared/types/index.ts` (via existing `export * from './bindings'`) so the builders/constants are available from the shared types entry.

### Testing
- Ran `npm run build` to validate the change, which exited with an error: `Cannot find package '@payloadcms/next' imported from next.config.mjs` so the build did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696acc210850832da654ea4983972a1d)