### PR TITLE
Add video template types and template input bindings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export * from '@/forge/types/flags';
 export * from '@/forge/types/forge-game-state';
 export * from '@/forge/types/characters';
 export * from '@/forge/types/constants';
+export * from '@/video';
 
 // Export game state utilities
 export { 

--- a/src/shared/types/bindings.ts
+++ b/src/shared/types/bindings.ts
@@ -11,7 +11,10 @@ export const buildTemplateInputKey = (scope: TemplateInputScope, key: string): s
 export const buildNodeTemplateInputKey = (key: string): string => buildTemplateInputKey(TEMPLATE_INPUT_SCOPE.NODE, key);
 
 export const TEMPLATE_INPUT_KEY = {
+  NODE_BACKGROUND: buildNodeTemplateInputKey('background'),
+  NODE_DIALOGUE: buildNodeTemplateInputKey('dialogue'),
   NODE_IMAGE: buildNodeTemplateInputKey('image'),
+  NODE_SPEAKER: buildNodeTemplateInputKey('speaker'),
 } as const;
 
 export type TemplateInputKey = typeof TEMPLATE_INPUT_KEY[keyof typeof TEMPLATE_INPUT_KEY];

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -1,0 +1,4 @@
+export * from './templates/types/video-composition';
+export * from './templates/types/video-layer';
+export * from './templates/types/video-scene';
+export * from './templates/types/video-template';

--- a/src/video/templates/types/video-composition.ts
+++ b/src/video/templates/types/video-composition.ts
@@ -1,0 +1,26 @@
+export interface VideoCompositionLayer {
+  id: string;
+  sceneId: string;
+  startMs: number;
+  endMs: number;
+  opacity?: number;
+  resolvedInputs?: Record<string, unknown>;
+}
+
+export interface VideoCompositionScene {
+  id: string;
+  templateSceneId: string;
+  startMs: number;
+  durationMs: number;
+  layers: VideoCompositionLayer[];
+}
+
+export interface VideoComposition {
+  id: string;
+  templateId: string;
+  width: number;
+  height: number;
+  frameRate: number;
+  durationMs: number;
+  scenes: VideoCompositionScene[];
+}

--- a/src/video/templates/types/video-layer.ts
+++ b/src/video/templates/types/video-layer.ts
@@ -1,0 +1,8 @@
+export interface VideoLayer {
+  id: string;
+  name?: string;
+  startMs: number;
+  durationMs?: number;
+  opacity?: number;
+  inputs?: Record<string, string>;
+}

--- a/src/video/templates/types/video-scene.ts
+++ b/src/video/templates/types/video-scene.ts
@@ -1,0 +1,9 @@
+import type { VideoLayer } from './video-layer';
+
+export interface VideoScene {
+  id: string;
+  name?: string;
+  durationMs: number;
+  layers: VideoLayer[];
+  inputs?: Record<string, string>;
+}

--- a/src/video/templates/types/video-template.ts
+++ b/src/video/templates/types/video-template.ts
@@ -1,0 +1,11 @@
+import type { VideoScene } from './video-scene';
+
+export interface VideoTemplate {
+  id: string;
+  name: string;
+  width: number;
+  height: number;
+  frameRate: number;
+  scenes: VideoScene[];
+  inputs?: Record<string, string>;
+}


### PR DESCRIPTION
### Motivation
- Provide first-class TypeScript types to model video templates, scenes, layers, and compiled compositions for video tooling. 
- Expose the new video types from the library public surface so other domains can import them consistently. 
- Standardize additional node-level template input keys (background, speaker, dialogue) using existing builder helpers instead of string literals.

### Description
- Added `src/video/templates/types/video-template.ts`, `video-scene.ts`, `video-layer.ts`, and `video-composition.ts` to define `VideoTemplate`, `VideoScene`, `VideoLayer`, and `VideoComposition*` types. 
- Created `src/video/index.ts` which exports the new video type modules. 
- Re-exported the `@/video` surface from `src/index.ts` to include the new types in the public API. 
- Extended `src/shared/types/bindings.ts` to add `TEMPLATE_INPUT_KEY` entries `NODE_BACKGROUND`, `NODE_SPEAKER`, and `NODE_DIALOGUE` using the `buildNodeTemplateInputKey` helper.

### Testing
- Ran `npm run build` which failed due to a missing package import (`@payloadcms/next` referenced from `next.config.mjs`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696acc080520832d8952eae855ee20b3)