### PR TITLE
Add frame-to-template input mapper for video templates

### DIFF
--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -2,6 +2,7 @@ export * from './templates/types/video-composition';
 export * from './templates/types/video-layer';
 export * from './templates/types/video-scene';
 export * from './templates/types/video-template';
+export * from './templates/compile/frames-to-inputs';
 export * from './workspace/VideoTemplateWorkspace';
 export * from './workspace/video-template-workspace-actions';
 export * from './workspace/video-template-workspace-contracts';

--- a/src/video/templates/compile/frames-to-inputs.ts
+++ b/src/video/templates/compile/frames-to-inputs.ts
@@ -1,0 +1,89 @@
+import { TEMPLATE_INPUT_KEY } from '@/src/shared/types/bindings';
+import type { Frame, PresentationLayer, PresentationState } from '@/src/forge/runtime/engine/types';
+
+export type FrameTemplateInputs = {
+  frameId: string;
+  kind: Frame['kind'];
+  source: Frame['source'];
+  inputs: Record<string, unknown>;
+};
+
+const resolvePresentationValue = (layer?: PresentationLayer): unknown => {
+  if (!layer) {
+    return undefined;
+  }
+
+  const { resolved, refId, payload } = layer.directive;
+
+  if (resolved !== undefined) {
+    return resolved;
+  }
+
+  if (refId !== undefined) {
+    return refId;
+  }
+
+  if (payload && Object.keys(payload).length > 0) {
+    return payload;
+  }
+
+  return layer.key;
+};
+
+const pickHighestPriorityLayer = (
+  layers: Record<string, PresentationLayer> | undefined,
+): PresentationLayer | undefined => {
+  if (!layers) {
+    return undefined;
+  }
+
+  const entries = Object.entries(layers);
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  return entries
+    .map(([, layer]) => layer)
+    .sort((first, second) => {
+      if (first.priority === second.priority) {
+        return first.key.localeCompare(second.key);
+      }
+
+      return second.priority - first.priority;
+    })[0];
+};
+
+const toTemplateInputs = (frame: Frame): Record<string, unknown> => {
+  const inputs: Record<string, unknown> = {};
+  const presentation: PresentationState | undefined = frame.presentation;
+
+  if (frame.content) {
+    inputs[TEMPLATE_INPUT_KEY.NODE_DIALOGUE] = frame.content;
+  }
+
+  if (frame.speaker) {
+    inputs[TEMPLATE_INPUT_KEY.NODE_SPEAKER] = frame.speaker;
+  }
+
+  if (presentation?.background) {
+    inputs[TEMPLATE_INPUT_KEY.NODE_BACKGROUND] = resolvePresentationValue(presentation.background);
+  }
+
+  const portraitLayer = pickHighestPriorityLayer(presentation?.portraits);
+  const overlayLayer = pickHighestPriorityLayer(presentation?.overlays);
+  const imageLayer = portraitLayer ?? overlayLayer;
+
+  if (imageLayer) {
+    inputs[TEMPLATE_INPUT_KEY.NODE_IMAGE] = resolvePresentationValue(imageLayer);
+  }
+
+  return inputs;
+};
+
+export const framesToTemplateInputs = (frames: Frame[]): FrameTemplateInputs[] =>
+  frames.map((frame) => ({
+    frameId: frame.id,
+    kind: frame.kind,
+    source: frame.source,
+    inputs: toTemplateInputs(frame),
+  }));


### PR DESCRIPTION
### Motivation

- Provide a pure, testable conversion from engine `Frame[]` to template inputs so video templates can be populated from runtime frames.
- Ensure dialogue, speaker, and presentation data resolve to the canonical template input keys used by the template editor.

### Description

- Add `src/video/templates/compile/frames-to-inputs.ts` which exports `framesToTemplateInputs` and `FrameTemplateInputs` and contains pure helpers `toTemplateInputs`, `resolvePresentationValue`, and `pickHighestPriorityLayer`.
- The mapper writes values to the shared `TEMPLATE_INPUT_KEY` keys: `NODE_DIALOGUE`, `NODE_SPEAKER`, `NODE_BACKGROUND`, and `NODE_IMAGE`.
- Presentation layers are resolved deterministically by priority and tie-broken by layer key, and resolved values prefer directive `resolved` then `refId` then `payload` then the layer key.
- Export the mapper from the video package entry in `src/video/index.ts`.

### Testing

- Ran `npm run build` to validate integration, but the build failed due to a missing `@payloadcms/next` dependency referenced by `next.config.mjs` (unrelated environmental issue), so no compiled build artifact was produced.
- No automated unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ad9795d90832db81e1d70f8278c44)