### PR TITLE
Update architecture workflow report paths

### DIFF
--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -39,18 +39,18 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: architecture-reports
-          path: docs/architecture/
+          path: docs/architecture/reports/
           retention-days: 30
         
       - name: Comment PR with results
         if: github.event_name == 'pull_request'
-          uses: actions/github-script@v7
-          with:
-            script: |
+        uses: actions/github-script@v7
+        with:
+          script: |
             const fs = require('fs');
             
             try {
-              const reportData = JSON.parse(fs.readFileSync('docs/architecture/latest-analysis.json', 'utf8'));
+              const reportData = JSON.parse(fs.readFileSync('docs/architecture/reports/latest.json', 'utf8'));
               const { issues, summary } = reportData;
               
               const hasIssues = issues.some(category => 
@@ -155,7 +155,7 @@ jobs:
         run: |
           npm run arch:report
           mkdir -p public/architecture
-          cp docs/architecture/* public/architecture/
+          cp docs/architecture/reports/* public/architecture/
         
       - name: Deploy to staging
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
### Motivation

- Ensure the CI uploads and reads only the generated architecture report outputs rather than the whole `docs/architecture` tree.  
- Align the GitHub Action comment and deployment copy steps with what the local scripts actually write (e.g. `latest.json` / `latest.md` in a `reports/` folder).

### Description

- Changed the artifact upload path in `.github/workflows/architecture.yml` from `docs/architecture/` to `docs/architecture/reports/`.  
- Updated the PR comment script to read the generated report from `docs/architecture/reports/latest.json` instead of `docs/architecture/latest-analysis.json`.  
- Updated the deployment artifact generation step to copy `docs/architecture/reports/*` into `public/architecture/` instead of copying the entire `docs/architecture` folder.

### Testing

- Ran `npm run build` locally which failed due to a missing package (`Error: Cannot find package '@payloadcms/next'`), so no full build verification was possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e65fce04832dbfee8d3e4934e002)