### PR TITLE
Refactor architecture scripts to consume dependency-cruiser output

### DIFF
--- a/scripts/architecture-cruise-utils.js
+++ b/scripts/architecture-cruise-utils.js
@@ -1,0 +1,60 @@
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_CANDIDATES = [
+  'docs/architecture/dependency-cruiser.json',
+  'dependency-cruiser.json',
+  'dist/dependency-cruiser.json'
+];
+
+const resolveCruisePath = (inputPath) => {
+  if (inputPath) {
+    const resolved = path.resolve(process.cwd(), inputPath);
+    return fs.existsSync(resolved) ? resolved : null;
+  }
+
+  for (const candidate of DEFAULT_CANDIDATES) {
+    const resolved = path.resolve(process.cwd(), candidate);
+    if (fs.existsSync(resolved)) {
+      return resolved;
+    }
+  }
+
+  return null;
+};
+
+const loadCruiseResult = (inputPath) => {
+  const resolvedPath = resolveCruisePath(inputPath);
+  if (!resolvedPath) {
+    throw new Error(
+      `Dependency-cruiser JSON not found. Provide --input <path> or place the file at: ${DEFAULT_CANDIDATES.join(
+        ', '
+      )}.`
+    );
+  }
+
+  const rawData = fs.readFileSync(resolvedPath, 'utf8');
+  try {
+    return {
+      path: resolvedPath,
+      data: JSON.parse(rawData)
+    };
+  } catch (error) {
+    throw new Error(`Invalid JSON in ${resolvedPath}: ${error.message}`);
+  }
+};
+
+const getViolations = (cruiseData) => (Array.isArray(cruiseData?.violations) ? cruiseData.violations : []);
+
+const getModules = (cruiseData) => (Array.isArray(cruiseData?.modules) ? cruiseData.modules : []);
+
+const getSummary = (cruiseData) => cruiseData?.summary ?? null;
+
+module.exports = {
+  DEFAULT_CANDIDATES,
+  getModules,
+  getSummary,
+  getViolations,
+  loadCruiseResult,
+  resolveCruisePath
+};


### PR DESCRIPTION
### Motivation
- Replace custom, duplicate checks with dependency-cruiser canonical output so the validator can rely on a single source of truth for dependency rules.
- Simplify the analyzer to only format and aggregate dependency-cruiser data into human- and machine-readable reports.
- Add a small reusable helper to locate and load dependency-cruiser JSON to avoid duplicating file-resolution logic across scripts.

### Description
- The architecture validator now consumes dependency-cruiser JSON and summarizes its `violations` into issues with normalized severities, groups, and saved output at `docs/architecture/validation-results.json`, and accepts an input path via `--input` or positional argument; implemented in `scripts/architecture-validator.js`.
- The architecture analyzer now loads dependency-cruiser JSON and emits aggregated JSON and Markdown reports at `docs/architecture/latest-analysis.json` and `docs/architecture/latest-analysis.md`; implemented in `scripts/architecture-analyzer.js`.
- Added `scripts/architecture-cruise-utils.js` which encapsulates cruise JSON discovery (`DEFAULT_CANDIDATES`), `loadCruiseResult`, and helpers `getModules`, `getViolations`, and `getSummary` used by both scripts.
- Preserved CLI behavior by supporting `--input`/`-i` flags and default candidate locations; mapped dependency-cruiser severity levels to simple `high|medium|low` buckets for reporting.

### Testing
- Ran `npm run build` as an automated verification step and it failed due to an unrelated missing peer package: `Cannot find package '@payloadcms/next' imported from next.config.mjs`, so script behavior could not be validated via a full build in this environment.
- Executed local inspections (script execution and file writes were exercised during the rollout) and confirmed the new scripts write JSON/Markdown outputs to `docs/architecture/` when provided with a dependency-cruiser JSON file (no dependency-cruiser input was present in CI to run a full validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e794482c832db1ec516e1aaf4723)