### PR TITLE
Add dependency-cruiser config with domain boundary rules and report outputs

### DIFF
--- a/dependency-cruiser.js
+++ b/dependency-cruiser.js
@@ -1,0 +1,83 @@
+module.exports = {
+  options: {
+    doNotFollow: {
+      path: 'node_modules'
+    },
+    exclude: {
+      path: 'node_modules|dist|.next|docs'
+    },
+    tsConfig: {
+      fileName: 'tsconfig.json'
+    },
+    enhancedResolveOptions: {
+      extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']
+    },
+    outputType: ['json', 'dot'],
+    outputTo: [
+      'docs/architecture/reports/deps/dependency-cruiser.json',
+      'docs/architecture/reports/deps/dependency-cruiser.dot'
+    ]
+  },
+  rules: [
+    {
+      name: 'src-no-app-dependency',
+      severity: 'error',
+      from: {
+        path: '^src/'
+      },
+      to: {
+        path: '^app/'
+      }
+    },
+    {
+      name: 'src-no-app-payload-types',
+      severity: 'error',
+      from: {
+        path: '^src/'
+      },
+      to: {
+        path: '^app/payload-types'
+      }
+    },
+    {
+      name: 'shared-isolation',
+      severity: 'error',
+      from: {
+        path: '^src/shared/'
+      },
+      to: {
+        path: '^src/(forge|writer|ai)/'
+      }
+    },
+    {
+      name: 'forge-only-imports-shared',
+      severity: 'error',
+      from: {
+        path: '^src/forge/'
+      },
+      to: {
+        path: '^src/(writer|ai)/'
+      }
+    },
+    {
+      name: 'writer-only-imports-shared',
+      severity: 'error',
+      from: {
+        path: '^src/writer/'
+      },
+      to: {
+        path: '^src/(forge|ai)/'
+      }
+    },
+    {
+      name: 'ai-only-imports-shared',
+      severity: 'error',
+      from: {
+        path: '^src/ai/'
+      },
+      to: {
+        path: '^src/(forge|writer)/'
+      }
+    }
+  ]
+};


### PR DESCRIPTION
### Motivation
- Enforce and document domain boundaries in the codebase and generate machine-readable architecture outputs for downstream validators and docs.

### Description
- Add `dependency-cruiser.js` that configures `tsconfig`, resolver extensions, excludes common build dirs, and emits `json` and `dot` outputs to `docs/architecture/reports/deps/`.
- Define domain boundary rules that forbid `src/` -> `app/`, prevent `src/` from importing `app/payload-types`, and enforce isolation/one-way imports between `src/shared/`, `src/forge/`, `src/writer/`, and `src/ai/`.
- Exclude `node_modules`, `dist`, `.next`, and `docs` from cruise, and set `doNotFollow` for `node_modules` to avoid external traversal.

### Testing
- Created the output directory `docs/architecture/reports/deps/` and validated the config file presence, and attempted `npm run build` which failed due to a missing package referenced by `next.config.mjs` (`@payloadcms/next`), so a full build-based validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e89cc198832da2d2f77c286b2a3c)