### PR TITLE
Add architecture glossary

### DIFF
--- a/docs/architecture/GLOSSARY.md
+++ b/docs/architecture/GLOSSARY.md
@@ -1,0 +1,45 @@
+# Glossary
+
+## Host (app/)
+
+- Next.js + PayloadCMS application code.
+- Owns runtime integration, API routes, and generated types.
+- Host may import from src/ (shared/domain/ai).
+
+## Shared (src/shared/)
+
+- Cross-domain types, utilities, and UI primitives.
+- Lowest common layer used by domain packages.
+- No dependencies on host or domain-specific packages.
+
+## Domains (src/forge/, src/writer/)
+
+- Domain-specific types, stores, components, and libraries.
+- May depend on shared and AI layers.
+- Forge ↔ Writer cross-imports are prohibited.
+
+## AI (src/ai/)
+
+- Shared AI infrastructure and domain AI adapters.
+- Can depend on shared types/utilities.
+- Domain layers can depend on AI, never the reverse.
+
+## Workspace Store
+
+- Domain state, persistent, slice-based, emits events.
+
+## Editor Session Store
+
+- Per-instance UI state, ephemeral, editor-specific.
+
+## Editor Shell
+
+- Bridge between editor library and domain, handles events, provides dispatch.
+
+## Command Pattern
+
+- Typed actions via dispatch, testable, consistent.
+
+## Modal Management
+
+- Workspace store viewState slice + modal switcher component.


### PR DESCRIPTION
### Motivation
- Provide a concise, canonical glossary for architecture and workspace terminology to live in the docs site at `docs/architecture/GLOSSARY.md`.

### Description
- Add `docs/architecture/GLOSSARY.md` containing definitions for `Host (app/)`, `Shared (src/shared/)`, `Domains (src/forge/, src/writer/)`, `AI (src/ai/)`, `Workspace Store`, `Editor Session Store`, `Editor Shell`, `Command Pattern`, and `Modal Management`.

### Testing
- Ran `npm run build` to validate the site build, which failed due to a missing package error: `Cannot find package '@payloadcms/next'` referenced from `next.config.mjs`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e9a5ac70832d8f978ce95095a9da)