### PR TITLE
Update README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,8 @@ cp .env.example .env.local
 
 - **[docs/architecture/BOUNDARIES.md](./docs/architecture/BOUNDARIES.md)** - Layer boundaries and import rules
 - **[docs/architecture/FILE-PLACEMENT.md](./docs/architecture/FILE-PLACEMENT.md)** - File placement decision tree
+- **[docs/architecture/GLOSSARY.md](./docs/architecture/GLOSSARY.md)** - Architecture glossary
+- **[docs/architecture/PATTERNS.md](./docs/architecture/PATTERNS.md)** - Architecture patterns and recommended practices
 - **[ARCHITECTURE_REVIEW.md](./ARCHITECTURE_REVIEW.md)** - Architecture review and cleanup priorities
 
 ### Integration
@@ -542,6 +544,14 @@ cp .env.example .env.local
 
 - **[agents.md](./agents.md)** - AI agent guide (coding preferences, conventions)
 - **[docs/nodes-and-editors.md](./docs/nodes-and-editors.md)** - Node types and editor architecture
+
+### Domain Docs
+
+- **[docs/forge.md](./docs/forge.md)** - Forge domain overview
+- **[docs/writer.md](./docs/writer.md)** - Writer domain overview
+- **[docs/shared.md](./docs/shared.md)** - Shared domain overview
+- **[docs/ai.md](./docs/ai.md)** - AI domain overview
+- **[docs/runtime.md](./docs/runtime.md)** - Runtime systems overview
 
 ## 🧪 Development
 


### PR DESCRIPTION
### Motivation
- Add missing links in the main docs index so readers can quickly find the architecture glossary, patterns, and per-domain documentation for easier discovery and onboarding.

### Description
- Updated `README.md` to add links to `docs/architecture/GLOSSARY.md` and `docs/architecture/PATTERNS.md`, and added a new "Domain Docs" section linking `docs/forge.md`, `docs/writer.md`, `docs/shared.md`, `docs/ai.md`, and `docs/runtime.md`.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f1ef39bc832d950cc4102324ffb1)