### PR TITLE
Introduce shared tsconfig.base and per-domain tsconfig references

### DIFF
--- a/src/ai/tsconfig.json
+++ b/src/ai/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["**/*"]
+}

--- a/src/forge/tsconfig.json
+++ b/src/forge/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["**/*"]
+}

--- a/src/shared/tsconfig.json
+++ b/src/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["**/*"]
+}

--- a/src/styles/tsconfig.json
+++ b/src/styles/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["**/*"]
+}

--- a/src/video/tsconfig.json
+++ b/src/video/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["**/*"]
+}

--- a/src/writer/tsconfig.json
+++ b/src/writer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["**/*"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "esnext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "preserve",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "incremental": true,
+    "isolatedModules": true,
+    "allowJs": true,
+    "paths": {
+      "@/shared/*": ["./src/shared/*"],
+      "@/ai/*": ["./src/ai/*"],
+      "@/forge/*": ["./src/forge/*"],
+      "@/writer/*": ["./src/writer/*"],
+      "@/host/*": ["./app/lib/*"],
+      "@/*": ["./*"],
+      "@magicborn/dialogue-forge": ["./src"],
+      "@magicborn/dialogue-forge/*": ["./src/*"],
+      "@payload-config": ["./app/payload.config.ts"],
+      "@payloadcms/ui": ["./node_modules/@payloadcms/ui"],
+      "@payloadcms/ui/*": ["./node_modules/@payloadcms/ui/*"]
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,76 +1,13 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "module": "esnext",
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
-    "jsx": "preserve",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "noEmit": true,
-    "incremental": true,
-    "isolatedModules": true,
-    "allowJs": true,
-    "paths": {
-      "@/shared/*": [
-        "./src/shared/*"
-      ],
-      "@/ai/*": [
-        "./src/ai/*"
-      ],
-      "@/forge/*": [
-        "./src/forge/*"
-      ],
-      "@/writer/*": [
-        "./src/writer/*"
-      ],
-      "@/host/*": [
-        "./app/lib/*"
-      ],
-      "@/*": [
-        "./*"
-      ],
-      "@magicborn/dialogue-forge": [
-        "./src"
-      ],
-      "@magicborn/dialogue-forge/*": [
-        "./src/*"
-      ],
-      "@payload-config": [
-        "./app/payload.config.ts"
-      ],
-      "@payloadcms/ui": [
-        "./node_modules/@payloadcms/ui"
-      ],
-      "@payloadcms/ui/*": [
-        "./node_modules/@payloadcms/ui/*"
-      ]
-    },
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
-  "include": [
-    "next-env.d.ts",
-    "src/**/*",
-    "app/**/*",
-    "components/**/*",
-    "styles/**/*",
-    ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    ".next"
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.next.json" },
+    { "path": "./src/ai" },
+    { "path": "./src/forge" },
+    { "path": "./src/shared" },
+    { "path": "./src/styles" },
+    { "path": "./src/video" },
+    { "path": "./src/writer" }
   ]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,28 +1,16 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020", "DOM"],
     "jsx": "react",
     "declaration": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
-    "resolveJsonModule": true,
     "types": ["node"],
-    "paths": {
-      "@/shared/*": ["./src/shared/*"],
-      "@/ai/*": ["./src/ai/*"],
-      "@/forge/*": ["./src/forge/*"],
-      "@/writer/*": ["./src/writer/*"],
-      "@/host/*": ["./app/lib/*"]
-    }
+    "noEmit": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "app", "components", "styles", ".next"]
 }
-

--- a/tsconfig.next.json
+++ b/tsconfig.next.json
@@ -1,36 +1,16 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
+    "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "react-jsx",
-    "incremental": true,
+    "noEmit": true,
     "plugins": [
       {
         "name": "next"
       }
-    ],
-    "paths": {
-      "@/shared/*": ["./src/shared/*"],
-      "@/ai/*": ["./src/ai/*"],
-      "@/forge/*": ["./src/forge/*"],
-      "@/writer/*": ["./src/writer/*"],
-      "@/host/*": ["./app/lib/*"],
-      "@/*": ["./*"],
-      "@magicborn/dialogue-forge/*": ["./src/*"]
-    }
+    ]
   },
   "include": [
     "next-env.d.ts",
@@ -39,9 +19,5 @@
     "styles/**/*",
     ".next/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "src"
-  ]
+  "exclude": ["node_modules", "dist", "src"]
 }


### PR DESCRIPTION
### Motivation
- Centralize common TypeScript compiler options into a single base config so library/Next configs can share the same settings. 
- Convert the root `tsconfig.json` into a solution-style file that references buildable domain projects to enable composite/incremental builds. 

### Description
- Add `tsconfig.base.json` containing common `compilerOptions` and path mappings. 
- Replace root `tsconfig.json` content with a solution `references` array that points at `tsconfig.lib.json`, `tsconfig.next.json`, and per-domain folders under `src/`. 
- Update `tsconfig.lib.json` and `tsconfig.next.json` to `extends` the base config and remove duplicated options. 
- Add per-domain `tsconfig.json` files under `src/ai`, `src/forge`, `src/shared`, `src/styles`, `src/video`, and `src/writer` with `composite: true` so each domain can participate in project references. 

### Testing
- Ran `npm run build` (Next build); the command failed in this environment due to a missing dependency (`@payloadcms/next`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f3106f9c832d981f5b32c4ba89f7)