### PR TITLE
Update typecheck scripts for domains and Next.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "test:watch": "vitest --watch",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
+    "typecheck:domains": "tsc -b --pretty false",
+    "typecheck:next": "tsc -p tsconfig.next.json --pretty false",
     "prepublishOnly": "npm run build:lib",
     "postinstall": "node scripts/patch-undici.js",
     "sync": "./sync-to-repo.sh",


### PR DESCRIPTION
### Motivation
- Provide a dedicated domain-level typecheck using TypeScript project references and keep the Next.js typecheck separate to avoid mixing configs and targets.

### Description
- Add `typecheck:domains` script set to `tsc -b --pretty false` and `typecheck:next` set to `tsc -p tsconfig.next.json --pretty false` in `package.json`.

### Testing
- Ran `npm run build` to validate the repo build, which failed with `Cannot find package '@payloadcms/next' imported from next.config.mjs` (failure unrelated to the added typecheck scripts).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f6582e14832dbf821ad147107afe)