### PR TITLE
Add baseUrl to tsconfig for consistent path alias resolution

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,6 +4,7 @@
     "module": "esnext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "jsx": "preserve",
+    "baseUrl": ".",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/tsconfig.next.json
+++ b/tsconfig.next.json
@@ -5,6 +5,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "jsx": "react-jsx",
+    "baseUrl": ".",
     "noEmit": true,
     "plugins": [
       {


### PR DESCRIPTION
### Motivation
- Ensure TypeScript path aliases resolve from the repository root by adding a shared `baseUrl` so imports like `@/shared/*` and `@magicborn/dialogue-forge/*` resolve consistently across tools.

### Description
- Add `"baseUrl": "."` to `tsconfig.base.json` and mirror it in `tsconfig.next.json` so the Next.js project and library share the same base resolution for configured `paths`.

### Testing
- Ran `npm run build` which invokes the Next.js build and it failed due to a missing package (`Error: Cannot find package '@payloadcms/next'` when loading `next.config.mjs`), so TypeScript config changes were applied but the full build could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f700a0d8832da67076eb7cddc1fb)