### PR TITLE
Enforce host import restrictions in ESLint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,10 @@
 const baseRestrictedPatterns = [
   "app/**",
+  "app/payload-types",
   "@/app/**",
+  "@/app/payload-types",
   "@magicborn/dialogue-forge/app/**",
+  "@magicborn/dialogue-forge/app/payload-types",
   "payload-types",
   "**/payload-types",
   "**/payload-types/**",
@@ -51,7 +54,7 @@ module.exports = {
       files: ["src/**/*.{js,jsx,ts,tsx}", "src/**/*.d.ts"],
       rules: {
         "no-restricted-imports": [
-          "warn",
+          "error",
           {
             patterns: baseRestrictedPatterns,
           },
@@ -62,7 +65,7 @@ module.exports = {
       files: ["src/forge/**/*.{js,jsx,ts,tsx}", "src/forge/**/*.d.ts"],
       rules: {
         "no-restricted-imports": [
-          "warn",
+          "error",
           {
             patterns: forgeRestrictedPatterns,
           },
@@ -73,7 +76,7 @@ module.exports = {
       files: ["src/writer/**/*.{js,jsx,ts,tsx}", "src/writer/**/*.d.ts"],
       rules: {
         "no-restricted-imports": [
-          "warn",
+          "error",
           {
             patterns: writerRestrictedPatterns,
           },
@@ -84,7 +87,7 @@ module.exports = {
       files: ["src/shared/**/*.{js,jsx,ts,tsx}", "src/shared/**/*.d.ts"],
       rules: {
         "no-restricted-imports": [
-          "warn",
+          "error",
           {
             patterns: sharedRestrictedPatterns,
           },


### PR DESCRIPTION
### Motivation
- Prevent library code under `src/**` from importing host app types and specific host payload types to preserve architecture boundaries. 
- Make import-boundary violations fail fast by promoting restricted-import checks to errors instead of warnings so CI and local builds catch them earlier.

### Description
- Updated `.eslintrc.cjs` to explicitly block `app/payload-types`, `@/app/payload-types`, and `@magicborn/dialogue-forge/app/payload-types` by adding them to `baseRestrictedPatterns`. 
- Escalated the `no-restricted-imports` rule severity from `warn` to `error` for `src/**`, `src/forge/**`, `src/writer/**`, and `src/shared/**` override blocks. 
- Change is limited to the ESLint configuration file `./.eslintrc.cjs` and enforces existing architecture import-direction rules more strictly.

### Testing
- Ran `npm run build` to validate the repository build, which failed with `Error: Cannot find package '@payloadcms/next' imported from next.config.mjs`, indicating an unrelated missing dependency; the ESLint config change itself applied without runtime errors. 
- No unit tests were modified or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fbd6e01c832d9826a61a68f75948)