### PR TITLE
Align dependency-cruiser boundaries with ESLint rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,6 +28,22 @@ const writerRestrictedPatterns = [
 
 const sharedRestrictedPatterns = [
   ...baseRestrictedPatterns,
+  "**/ai/**",
+  "**/forge/**",
+  "**/writer/**",
+  "@/src/ai/**",
+  "@/src/forge/**",
+  "@/src/writer/**",
+  "@magicborn/dialogue-forge/src/ai/**",
+  "@magicborn/dialogue-forge/src/forge/**",
+  "@magicborn/dialogue-forge/src/writer/**",
+  "src/ai/**",
+  "src/forge/**",
+  "src/writer/**",
+];
+
+const aiRestrictedPatterns = [
+  ...baseRestrictedPatterns,
   "**/forge/**",
   "**/writer/**",
   "@/src/forge/**",
@@ -90,6 +106,17 @@ module.exports = {
           "error",
           {
             patterns: sharedRestrictedPatterns,
+          },
+        ],
+      },
+    },
+    {
+      files: ["src/ai/**/*.{js,jsx,ts,tsx}", "src/ai/**/*.d.ts"],
+      rules: {
+        "no-restricted-imports": [
+          "error",
+          {
+            patterns: aiRestrictedPatterns,
           },
         ],
       },

--- a/dependency-cruiser.js
+++ b/dependency-cruiser.js
@@ -30,13 +30,13 @@ module.exports = {
       }
     },
     {
-      name: 'src-no-app-payload-types',
+      name: 'src-no-payload-types',
       severity: 'error',
       from: {
         path: '^src/'
       },
       to: {
-        path: '^app/payload-types'
+        path: 'payload-types'
       }
     },
     {
@@ -50,23 +50,23 @@ module.exports = {
       }
     },
     {
-      name: 'forge-only-imports-shared',
+      name: 'forge-no-writer-dependency',
       severity: 'error',
       from: {
         path: '^src/forge/'
       },
       to: {
-        path: '^src/(writer|ai)/'
+        path: '^src/writer/'
       }
     },
     {
-      name: 'writer-only-imports-shared',
+      name: 'writer-no-forge-dependency',
       severity: 'error',
       from: {
         path: '^src/writer/'
       },
       to: {
-        path: '^src/(forge|ai)/'
+        path: '^src/forge/'
       }
     },
     {


### PR DESCRIPTION
### Motivation

- Ensure the dependency-cruiser rule graph aligns with the ESLint boundary configuration and the repo's Architecture Boundaries.  
- Treat the AI layer as a first-class layer in boundary rules so domain layers can depend on AI while AI does not depend on domains.  
- Make the payload-types restriction consistent across tooling to prevent accidental imports of host-generated types.

### Description

- Updated `.eslintrc.cjs` to include `src/ai` in the shared restricted patterns and added a new `aiRestrictedPatterns` plus an override for `src/ai` files to enforce import restrictions.  
- Expanded `sharedRestrictedPatterns` to explicitly block imports from domain folders and AI where appropriate.  
- Updated `dependency-cruiser.js` to rename and broaden the payload-types rule to `src-no-payload-types` and match the ESLint pattern (`payload-types`).  
- Adjusted dependency-cruiser domain rules to explicitly forbid Forge↔Writer cross-imports while allowing domain → AI imports and included AI in the shared-isolation rule.

### Testing

- Ran `npm run build`, which failed due to a missing environment dependency (`@payloadcms/next`) so the project build could not be validated in this environment.  
- No additional automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ff4545c4832d90f04ea07cf74627)