### PR TITLE
Define workspace contracts and make workspace/editor validator configurable

### DIFF
--- a/docs/architecture/workspace-editor-architecture.md
+++ b/docs/architecture/workspace-editor-architecture.md
@@ -38,6 +38,24 @@ The workspace architecture consists of four main layers:
 
 **Example**: See `src/forge/components/ForgeWorkspace/store/forge-workspace-store.tsx`
 
+### 1.5 Workspace Contracts (Host ↔ Workspace Boundary)
+
+**Purpose**: Define the stable, typed interface between a workspace and the host app. Contracts describe what the workspace expects from its host (adapters, data loaders, callbacks) without importing host-specific types.
+
+**Location**: `src/{domain}/workspace/{domain}-workspace-contracts.ts` (or another domain-appropriate contracts file).
+
+**Characteristics**:
+- Pure TypeScript interfaces/types (no runtime dependencies).
+- Imported by the workspace UI and adapters to keep the boundary explicit.
+- Must not import host app types (keep library independence intact).
+
+**Example**: See `src/video/workspace/video-template-workspace-contracts.ts` for a concrete adapter contract used by the Video workspace.
+
+**How to Use**:
+1. Define the contract in a `*-workspace-contracts.ts` file (interfaces, types, constants).
+2. Use the contract types in the workspace component props and adapter implementations.
+3. Keep the contract stable—breaking changes should be intentional and versioned.
+
 ### 2. Editor Session Store (Per-Instance UI State)
 
 **Purpose**: Manages ephemeral UI state specific to a single editor instance.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "postinstall": "node scripts/patch-undici.js",
     "sync": "./sync-to-repo.sh",
     "arch:sync": "node scripts/sync-architecture-docs.js",
+    "validate:workspace": "node scripts/workspace-validator.js",
     "pack": "npm pack --dry-run",
     "vendor:opencode:install": "cd vendor/opencode && bun install",
     "vendor:opencode:dev": "cd vendor/opencode/packages/console/app && bun run dev",

--- a/scripts/workspace-validator.js
+++ b/scripts/workspace-validator.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_WORKSPACE_REQUIRED_FILES = [
+  'workspace-state.ts',
+  'actions.ts',
+  'contracts.ts'
+];
+
+const DEFAULT_EDITOR_REQUIRED_FILES = [
+  'Editor.tsx',
+  path.join('shell', 'store.ts'),
+  path.join('shell', 'actions.ts'),
+  path.join('shell', 'events.ts')
+];
+
+const DEFAULT_EDITOR_REQUIRED_DIRS = [
+  path.join('inspector')
+];
+
+const getArgValue = (args, flag) => {
+  const exactIndex = args.indexOf(flag);
+  if (exactIndex !== -1 && args[exactIndex + 1]) {
+    return args[exactIndex + 1];
+  }
+
+  const prefix = `${flag}=`;
+  const match = args.find((arg) => arg.startsWith(prefix));
+  return match ? match.slice(prefix.length) : null;
+};
+
+const getListArgValue = (args, flag) => {
+  const value = getArgValue(args, flag);
+  if (!value) {
+    return null;
+  }
+
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+};
+
+const loadConfig = (configPath) => {
+  if (!configPath) {
+    return null;
+  }
+
+  const resolvedPath = path.resolve(configPath);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Config file not found: ${resolvedPath}`);
+  }
+
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  return JSON.parse(raw);
+};
+
+const ensurePosixRelative = (filePath) => filePath.split(path.sep).join('/');
+
+const listDirectoryEntries = (dirPath) => {
+  if (!fs.existsSync(dirPath)) {
+    return [];
+  }
+
+  return fs.readdirSync(dirPath);
+};
+
+const collectMissingFiles = (basePath, files) =>
+  files.filter((file) => !fs.existsSync(path.join(basePath, file)));
+
+const collectMissingDirectories = (basePath, directories) =>
+  directories.filter((dir) => {
+    const fullPath = path.join(basePath, dir);
+    return !fs.existsSync(fullPath) || listDirectoryEntries(fullPath).length === 0;
+  });
+
+const validateRequiredFiles = (label, basePath, requiredFiles, requiredDirs) => {
+  const missingFiles = collectMissingFiles(basePath, requiredFiles);
+  const missingDirs = collectMissingDirectories(basePath, requiredDirs);
+  const missing = [
+    ...missingFiles.map((file) => ensurePosixRelative(path.join(basePath, file))),
+    ...missingDirs.map((dir) => `${ensurePosixRelative(path.join(basePath, dir))}/*`)
+  ];
+
+  if (missing.length === 0) {
+    console.log(`✅ ${label} requirements satisfied: ${basePath}`);
+    return [];
+  }
+
+  console.log(`❌ ${label} is missing required files:`);
+  missing.forEach((file) => {
+    console.log(`  - ${file}`);
+  });
+  return missing;
+};
+
+const args = process.argv.slice(2);
+const workspaceDir = getArgValue(args, '--workspace') || getArgValue(args, '-w');
+const editorDir = getArgValue(args, '--editor') || getArgValue(args, '-e');
+const configPath = getArgValue(args, '--config');
+
+if (!workspaceDir && !editorDir) {
+  console.error('❌ Provide --workspace <path> or --editor <path> to validate.');
+  process.exit(1);
+}
+
+let config = null;
+
+try {
+  config = loadConfig(configPath);
+} catch (error) {
+  console.error(`❌ ${error.message}`);
+  process.exit(1);
+}
+
+const workspacePath = workspaceDir ? path.resolve(workspaceDir) : null;
+const editorPath = editorDir
+  ? path.resolve(editorDir)
+  : workspacePath
+    ? path.join(workspacePath, 'editor')
+    : null;
+
+const workspaceFilesOverride = getListArgValue(args, '--workspace-files');
+const workspaceDirsOverride = getListArgValue(args, '--workspace-dirs');
+const editorFilesOverride = getListArgValue(args, '--editor-files');
+const editorDirsOverride = getListArgValue(args, '--editor-dirs');
+
+const workspaceFiles =
+  workspaceFilesOverride ??
+  config?.workspace?.files ??
+  DEFAULT_WORKSPACE_REQUIRED_FILES;
+const workspaceDirs = workspaceDirsOverride ?? config?.workspace?.dirs ?? [];
+const editorFiles =
+  editorFilesOverride ?? config?.editor?.files ?? DEFAULT_EDITOR_REQUIRED_FILES;
+const editorDirs =
+  editorDirsOverride ?? config?.editor?.dirs ?? DEFAULT_EDITOR_REQUIRED_DIRS;
+
+const missing = [];
+
+if (workspacePath) {
+  missing.push(
+    ...validateRequiredFiles(
+      'Workspace',
+      workspacePath,
+      workspaceFiles,
+      workspaceDirs
+    )
+  );
+}
+
+if (editorPath) {
+  missing.push(
+    ...validateRequiredFiles(
+      'Editor',
+      editorPath,
+      editorFiles,
+      editorDirs
+    )
+  );
+}
+
+if (missing.length > 0) {
+  console.log('\n📋 Missing workspace/editor requirements detected.');
+  process.exit(1);
+}
+
+console.log('\n🎉 Workspace/editor validation passed.');


### PR DESCRIPTION
### Motivation

- Document and standardize how workspaces expose stable, typed boundaries to the host by introducing the concept of workspace contracts. 
- Make the workspace/editor validator flexible so teams can adapt required files and directories to different repo layouts instead of a fixed hard-coded list.

### Description

- Add `scripts/workspace-validator.js`, a Node CLI that validates required files/dirs for a workspace or editor and treats required entries as configurable via a JSON `--config` file or CLI overrides (`--workspace-files`, `--workspace-dirs`, `--editor-files`, `--editor-dirs`).
- Provide sensible defaults (`DEFAULT_WORKSPACE_REQUIRED_FILES` and `DEFAULT_EDITOR_REQUIRED_FILES`) and ensure directory checks also fail when a required directory is empty.
- Update `docs/architecture/workspace-editor-architecture.md` with a new "Workspace Contracts" section describing purpose, location, characteristics, and usage guidance for `*-workspace-contracts.ts` files.
- Expose the validator via the npm script `validate:workspace` in `package.json`.

### Testing

- Ran `npm run build` to validate the repository build, which failed with: `Error: Cannot find package '@payloadcms/next' imported from next.config.mjs`, indicating the sandbox lacks some repository dependencies (build failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69740232aac0832dbc608d19df01e4e2)