### PR TITLE
Move OpenRouter adapter to app layer and update references

### DIFF
--- a/app/lib/ai/ai-adapter.ts
+++ b/app/lib/ai/ai-adapter.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { createOpenRouterAdapter } from '@/ai/aiadapter/openrouter/openrouter-adapter';
+import { createOpenRouterAdapter } from '@/app/lib/ai/aiadapter/openrouter/openrouter-adapter';
 import { getOpenRouterConfig } from '@/ai/aiadapter/openrouter/config';
 import type {
   AiAdapter,

--- a/app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts
+++ b/app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts
@@ -14,7 +14,7 @@ import type {
   AiResponse,
   AiStreamResponse,
 } from '@/ai/aiadapter/types';
-import { getOpenRouterConfig, type OpenRouterConfig } from './config';
+import { getOpenRouterConfig, type OpenRouterConfig } from '@/ai/aiadapter/openrouter/config';
 
 const OPENROUTER_MODEL_MODE = {
   FAST: 'fast',

--- a/docs/architecture/dependency-cruiser.json
+++ b/docs/architecture/dependency-cruiser.json
@@ -28,7 +28,7 @@
         }
       ],
       "dependents": [
-        "src/ai/aiadapter/openrouter/openrouter-adapter.ts"
+        "app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts"
       ],
       "orphan": false,
       "valid": true
@@ -45,16 +45,16 @@
       "dependencies": [],
       "dependents": [
         "src/ai/aiadapter/openrouter/config.ts",
-        "src/ai/aiadapter/openrouter/openrouter-adapter.ts"
+        "app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts"
       ],
       "orphan": false,
       "valid": true
     },
     {
-      "source": "src/ai/aiadapter/openrouter/openrouter-adapter.ts",
+      "source": "app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts",
       "dependencies": [
         {
-          "module": "./config",
+          "module": "@/ai/aiadapter/openrouter/config",
           "moduleSystem": "es6",
           "dynamic": false,
           "exoticallyRequired": false,
@@ -150,7 +150,7 @@
       ],
       "dependencies": [],
       "dependents": [
-        "src/ai/aiadapter/openrouter/openrouter-adapter.ts"
+        "app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts"
       ],
       "orphan": false,
       "valid": true
@@ -166,7 +166,7 @@
       ],
       "dependencies": [],
       "dependents": [
-        "src/ai/aiadapter/openrouter/openrouter-adapter.ts"
+        "app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts"
       ],
       "orphan": false,
       "valid": true
@@ -182,7 +182,7 @@
       ],
       "dependencies": [],
       "dependents": [
-        "src/ai/aiadapter/openrouter/openrouter-adapter.ts"
+        "app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts"
       ],
       "orphan": false,
       "valid": true

--- a/docs/architecture/graphs/dependency-cruiser.d2
+++ b/docs/architecture/graphs/dependency-cruiser.d2
@@ -3,7 +3,7 @@
 "src"."ai"."adapters"."types"."ai-data-adapter.ts": {class: module; link: "src/ai/adapters/types/ai-data-adapter.ts"}
 "src"."ai"."aiadapter"."openrouter"."config.ts": {class: module; link: "src/ai/aiadapter/openrouter/config.ts"}
 "server-only": {class: module; link: "server-only"}
-"src"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts": {class: module; link: "src/ai/aiadapter/openrouter/openrouter-adapter.ts"}
+"app"."lib"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts": {class: module; link: "app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts"}
 "@"."ai"."aiadapter"."types": {class: module; link: "@/ai/aiadapter/types"}
 "@ai-sdk"."openai": {class: module; link: "@ai-sdk/openai"}
 "ai": {class: module; link: "ai"}
@@ -1278,11 +1278,11 @@
 # dependencies
 
 "src"."ai"."aiadapter"."openrouter"."config.ts" -> "server-only"
-"src"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "src"."ai"."aiadapter"."openrouter"."config.ts"
-"src"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "@"."ai"."aiadapter"."types"
-"src"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "@ai-sdk"."openai"
-"src"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "ai"
-"src"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "server-only"
+"app"."lib"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "src"."ai"."aiadapter"."openrouter"."config.ts"
+"app"."lib"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "@"."ai"."aiadapter"."types"
+"app"."lib"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "@ai-sdk"."openai"
+"app"."lib"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "ai"
+"app"."lib"."ai"."aiadapter"."openrouter"."openrouter-adapter.ts" -> "server-only"
 "src"."ai"."components"."AiWorkspace"."AiWorkspace.tsx" -> "src"."ai"."components"."AiWorkspace"."components"."AiWorkspaceConfig.tsx"
 "src"."ai"."components"."AiWorkspace"."AiWorkspace.tsx" -> "src"."ai"."components"."AiWorkspace"."components"."AiWorkspaceHistory.tsx"
 "src"."ai"."components"."AiWorkspace"."AiWorkspace.tsx" -> "src"."ai"."components"."AiWorkspace"."components"."AiWorkspaceRequest.tsx"

--- a/docs/architecture/graphs/madge.json
+++ b/docs/architecture/graphs/madge.json
@@ -2,7 +2,7 @@
   "../components/ThemeSwitcher.tsx": [],
   "ai/adapters/types/ai-data-adapter.ts": [],
   "ai/aiadapter/openrouter/config.ts": [],
-  "ai/aiadapter/openrouter/openrouter-adapter.ts": [
+  "app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts": [
     "ai/aiadapter/openrouter/config.ts",
     "ai/aiadapter/types.ts"
   ],


### PR DESCRIPTION
### Motivation
- The OpenRouter AI adapter belongs in the app layer so the adapter implementation lives with server-side application code while still being able to import shared `src` pieces.
- Keep dependency graphs and import paths consistent with the physical relocation of the file.

### Description
- Moved `src/ai/aiadapter/openrouter/openrouter-adapter.ts` into `app/lib/ai/aiadapter/openrouter/openrouter-adapter.ts` and updated the code location accordingly.
- Updated the app AI adapter import to `import { createOpenRouterAdapter } from '@/app/lib/ai/aiadapter/openrouter/openrouter-adapter'` in `app/lib/ai/ai-adapter.ts`.
- Adjusted the moved adapter's internal import to reference the config at `@/ai/aiadapter/openrouter/config`.
- Updated architecture artifacts under `docs/architecture/` (`madge.json`, `dependency-cruiser.d2`, `dependency-cruiser.json`) to reflect the new adapter path.

### Testing
- Ran `npm run build`; the build failed due to an unrelated missing package error: `Cannot find package '@payloadcms/next' imported from next.config.mjs`, so no successful full build was completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974047a70c8832db71d3a7c05dac78f)