### PR TITLE
Add Graphviz DOT-to-SVG conversion script

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "arch:sync": "node scripts/sync-architecture-docs.js",
     "validate:workspace": "node scripts/workspace-validator.js",
     "pack": "npm pack --dry-run",
+    "arch:deps:svg": "node scripts/graphviz-dot-to-svg.js",
     "vendor:opencode:install": "cd vendor/opencode && bun install",
     "vendor:opencode:dev": "cd vendor/opencode/packages/console/app && bun run dev",
     "vendor:opencode:build": "cd vendor/opencode/packages/console/app && bun run build",

--- a/scripts/graphviz-dot-to-svg.js
+++ b/scripts/graphviz-dot-to-svg.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const getArgValue = (args, flag) => {
+  const exactIndex = args.indexOf(flag);
+  if (exactIndex !== -1 && args[exactIndex + 1]) {
+    return args[exactIndex + 1];
+  }
+
+  const prefix = `${flag}=`;
+  const match = args.find((arg) => arg.startsWith(prefix));
+  return match ? match.slice(prefix.length) : null;
+};
+
+const ensureDirectory = (directoryPath) => {
+  if (!fs.existsSync(directoryPath)) {
+    fs.mkdirSync(directoryPath, { recursive: true });
+  }
+};
+
+const verifyGraphviz = () => {
+  const result = spawnSync('dot', ['-V'], { encoding: 'utf8' });
+  if (result.error) {
+    console.error('❌ Graphviz "dot" command not found. Install Graphviz to generate SVGs.');
+    process.exit(1);
+  }
+};
+
+const convertDotToSvg = (inputPath, outputPath) => {
+  const result = spawnSync('dot', ['-Tsvg', inputPath, '-o', outputPath], { encoding: 'utf8' });
+  if (result.status !== 0) {
+    console.error(`❌ Failed to convert ${inputPath}: ${result.stderr || result.stdout}`);
+    process.exit(1);
+  }
+};
+
+const args = process.argv.slice(2);
+const outputDir =
+  getArgValue(args, '--output') || getArgValue(args, '-o') || path.join('docs', 'architecture', 'reports', 'deps');
+const inputDir = getArgValue(args, '--input') || getArgValue(args, '-i') || outputDir;
+
+verifyGraphviz();
+ensureDirectory(outputDir);
+
+if (!fs.existsSync(inputDir)) {
+  console.error(`❌ Input directory not found: ${inputDir}`);
+  process.exit(1);
+}
+
+const dotFiles = fs
+  .readdirSync(inputDir)
+  .filter((entry) => entry.endsWith('.dot'))
+  .map((entry) => path.join(inputDir, entry));
+
+if (dotFiles.length === 0) {
+  console.warn(`⚠️  No .dot files found in ${inputDir}`);
+  process.exit(0);
+}
+
+console.log(`🧭 Converting ${dotFiles.length} DOT file(s) to SVG...`);
+
+dotFiles.forEach((dotFile) => {
+  const svgName = `${path.basename(dotFile, '.dot')}.svg`;
+  const outputPath = path.join(outputDir, svgName);
+
+  convertDotToSvg(dotFile, outputPath);
+  console.log(`✅ ${path.basename(dotFile)} → ${path.relative(process.cwd(), outputPath)}`);
+});


### PR DESCRIPTION
### Motivation
- Provide a simple tool to convert dependency-cruiser/other DOT graphs into SVGs for inclusion in the architecture docs directory at `docs/architecture/reports/deps`.
- Make graph exportable from CI or local workflows via an npm script so generated visuals can be committed or published alongside other architecture reports.

### Description
- Add a CLI script `scripts/graphviz-dot-to-svg.js` that verifies Graphviz is installed, scans an input directory for `.dot` files, and converts each to `.svg` using `dot -Tsvg` with configurable `--input`/`--output` paths.
- Add an npm script `arch:deps:svg` to `package.json` to run the converter via `node scripts/graphviz-dot-to-svg.js`.
- Create `docs/architecture/reports/deps/` and add a `.gitkeep` so the reports directory is tracked in the repo.

### Testing
- Ran `npm run build` as an automated verification step which failed due to a missing environment package (`@payloadcms/next`), unrelated to the added script and indicative of the local build environment rather than the new functionality.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697408bb23fc832da849d68a0919e088)