### PR TITLE
Add video template presets (Dialogue Only & Dialogue + Portrait) and expose via workspace adapter

### DIFF
--- a/app/lib/video/payload-video-template-adapter.ts
+++ b/app/lib/video/payload-video-template-adapter.ts
@@ -8,6 +8,7 @@ import type {
 } from '@magicborn/dialogue-forge/video/workspace/video-template-workspace-contracts';
 import { PAYLOAD_COLLECTIONS } from '@/app/payload-collections/enums';
 import { makePayloadMediaResolver } from '@/app/lib/video/payload-media-resolver';
+import { VIDEO_TEMPLATE_PRESET_BY_ID, VIDEO_TEMPLATE_PRESETS } from '@/video/templates/presets';
 
 interface PayloadVideoTemplateDoc {
   id: number;
@@ -67,10 +68,20 @@ export function makePayloadVideoTemplateAdapter(opts?: {
         where: where as any,
         limit: 200,
       });
-      return result.docs.map((doc) => mapTemplateSummary(doc as PayloadVideoTemplateDoc));
+      return [
+        ...VIDEO_TEMPLATE_PRESETS.map((preset) => ({
+          id: preset.id,
+          name: preset.name,
+        })),
+        ...result.docs.map((doc) => mapTemplateSummary(doc as PayloadVideoTemplateDoc)),
+      ];
     },
 
     async loadTemplate(templateId: string): Promise<VideoTemplate | null> {
+      const preset = VIDEO_TEMPLATE_PRESET_BY_ID[templateId];
+      if (preset) {
+        return preset;
+      }
       const parsedId = getTemplateId(templateId);
       if (!parsedId) {
         return null;

--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -13,3 +13,4 @@ export * from './templates/compile/compile-composition';
 export * from './workspace/VideoTemplateWorkspace';
 export * from './workspace/video-template-workspace-actions';
 export * from './workspace/video-template-workspace-contracts';
+export * from './templates/presets';

--- a/src/video/templates/presets/index.ts
+++ b/src/video/templates/presets/index.ts
@@ -1,0 +1,97 @@
+import { TEMPLATE_INPUT_KEY } from '@/shared/types/bindings';
+import type { VideoTemplate } from '../types/video-template';
+
+export const VIDEO_TEMPLATE_PRESETS: VideoTemplate[] = [
+  {
+    id: 'preset-dialogue-only',
+    name: 'Dialogue Only',
+    width: 1920,
+    height: 1080,
+    frameRate: 30,
+    inputs: {
+      speaker: TEMPLATE_INPUT_KEY.NODE_SPEAKER,
+      dialogue: TEMPLATE_INPUT_KEY.NODE_DIALOGUE,
+    },
+    scenes: [
+      {
+        id: 'scene-dialogue-only',
+        name: 'Dialogue Scene',
+        durationMs: 4000,
+        inputs: {
+          background: TEMPLATE_INPUT_KEY.NODE_BACKGROUND,
+        },
+        layers: [
+          {
+            id: 'layer-background',
+            name: 'Background',
+            startMs: 0,
+            inputs: {
+              background: TEMPLATE_INPUT_KEY.NODE_BACKGROUND,
+            },
+          },
+          {
+            id: 'layer-dialogue',
+            name: 'Dialogue',
+            startMs: 0,
+            inputs: {
+              dialogue: TEMPLATE_INPUT_KEY.NODE_DIALOGUE,
+              speaker: TEMPLATE_INPUT_KEY.NODE_SPEAKER,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'preset-dialogue-portrait',
+    name: 'Dialogue + Portrait Placeholder',
+    width: 1920,
+    height: 1080,
+    frameRate: 30,
+    inputs: {
+      speaker: TEMPLATE_INPUT_KEY.NODE_SPEAKER,
+      dialogue: TEMPLATE_INPUT_KEY.NODE_DIALOGUE,
+    },
+    scenes: [
+      {
+        id: 'scene-dialogue-portrait',
+        name: 'Dialogue Scene',
+        durationMs: 4000,
+        inputs: {
+          background: TEMPLATE_INPUT_KEY.NODE_BACKGROUND,
+        },
+        layers: [
+          {
+            id: 'layer-background',
+            name: 'Background',
+            startMs: 0,
+            inputs: {
+              background: TEMPLATE_INPUT_KEY.NODE_BACKGROUND,
+            },
+          },
+          {
+            id: 'layer-portrait',
+            name: 'Portrait Placeholder',
+            startMs: 0,
+            inputs: {
+              image: TEMPLATE_INPUT_KEY.NODE_IMAGE,
+            },
+          },
+          {
+            id: 'layer-dialogue',
+            name: 'Dialogue',
+            startMs: 0,
+            inputs: {
+              dialogue: TEMPLATE_INPUT_KEY.NODE_DIALOGUE,
+              speaker: TEMPLATE_INPUT_KEY.NODE_SPEAKER,
+            },
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const VIDEO_TEMPLATE_PRESET_BY_ID = Object.fromEntries(
+  VIDEO_TEMPLATE_PRESETS.map((preset) => [preset.id, preset]),
+);


### PR DESCRIPTION
### Motivation
- Provide a minimal set of reusable video templates for common dialogue layouts so the workspace can compile compositions without requiring ad-hoc template JSON.
- Ensure presets use canonical binding keys so `compileCompositionFromFrames`/`compileTemplate` can resolve inputs deterministically.
- Surface built-in presets in the Forge workspace adapter/template picker so users can select them alongside stored templates.

### Description
- Added `src/video/templates/presets/index.ts` with two presets (`preset-dialogue-only`, `preset-dialogue-portrait`) that reference `TEMPLATE_INPUT_KEY` values (no string literals) and define `VideoTemplate.inputs`, scene `inputs`, and layer `inputs` for binding resolution.
- Exported the preset collection from the video package by updating `src/video/index.ts` to `export * from './templates/presets';`.
- Updated the Payload-backed adapter in `app/lib/video/payload-video-template-adapter.ts` to include `VIDEO_TEMPLATE_PRESETS` in the `listTemplates()` response and to short-circuit `loadTemplate()` to return a preset when the requested `templateId` matches a built-in preset id.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69753571c794832db80eda5442dc5a3e)