### PR TITLE
Use `TemplateInputKey` for video template inputs and tighten binding resolution

### DIFF
--- a/src/video/templates/compile/compile-composition.ts
+++ b/src/video/templates/compile/compile-composition.ts
@@ -13,7 +13,7 @@ export type CompileCompositionOptions = {
 };
 
 const resolveInputBindings = (
-  bindings: Record<string, string> | undefined,
+  bindings: Record<string, TemplateInputKey> | undefined,
   frameInputs: Record<TemplateInputKey, unknown>,
 ): Record<string, unknown> | undefined => {
   if (!bindings) {
@@ -21,7 +21,7 @@ const resolveInputBindings = (
   }
 
   const resolvedEntries = Object.entries(bindings)
-    .map(([key, binding]) => [key, frameInputs[binding as TemplateInputKey]] as const)
+    .map(([key, binding]) => [key, frameInputs[binding]] as const)
     .filter(([, value]) => value !== undefined);
 
   if (resolvedEntries.length === 0) {
@@ -32,9 +32,9 @@ const resolveInputBindings = (
 };
 
 const mergeResolvedInputs = (
-  templateInputs: Record<string, string> | undefined,
-  sceneInputs: Record<string, string> | undefined,
-  layerInputs: Record<string, string> | undefined,
+  templateInputs: Record<string, TemplateInputKey> | undefined,
+  sceneInputs: Record<string, TemplateInputKey> | undefined,
+  layerInputs: Record<string, TemplateInputKey> | undefined,
   frameInputs: Record<TemplateInputKey, unknown>,
 ): Record<string, unknown> | undefined => {
   const resolvedTemplateInputs = resolveInputBindings(templateInputs, frameInputs);
@@ -59,8 +59,8 @@ const buildCompositionLayer = (
   sceneStartMs: number,
   sceneDurationMs: number,
   frameInputs: Record<TemplateInputKey, unknown>,
-  templateInputs: Record<string, string> | undefined,
-  sceneInputs: Record<string, string> | undefined,
+  templateInputs: Record<string, TemplateInputKey> | undefined,
+  sceneInputs: Record<string, TemplateInputKey> | undefined,
   frameId: string,
   sceneId: string,
 ): VideoCompositionLayer => {

--- a/src/video/templates/types/video-layer.ts
+++ b/src/video/templates/types/video-layer.ts
@@ -1,8 +1,10 @@
+import type { TemplateInputKey } from '@/shared/types/bindings';
+
 export interface VideoLayer {
   id: string;
   name?: string;
   startMs: number;
   durationMs?: number;
   opacity?: number;
-  inputs?: Record<string, string>;
+  inputs?: Record<string, TemplateInputKey>;
 }

--- a/src/video/templates/types/video-scene.ts
+++ b/src/video/templates/types/video-scene.ts
@@ -1,3 +1,4 @@
+import type { TemplateInputKey } from '@/shared/types/bindings';
 import type { VideoLayer } from './video-layer';
 
 export interface VideoScene {
@@ -5,5 +6,5 @@ export interface VideoScene {
   name?: string;
   durationMs: number;
   layers: VideoLayer[];
-  inputs?: Record<string, string>;
+  inputs?: Record<string, TemplateInputKey>;
 }

--- a/src/video/templates/types/video-template.ts
+++ b/src/video/templates/types/video-template.ts
@@ -1,3 +1,4 @@
+import type { TemplateInputKey } from '@/shared/types/bindings';
 import type { VideoScene } from './video-scene';
 
 export interface VideoTemplate {
@@ -7,5 +8,5 @@ export interface VideoTemplate {
   height: number;
   frameRate: number;
   scenes: VideoScene[];
-  inputs?: Record<string, string>;
+  inputs?: Record<string, TemplateInputKey>;
 }

--- a/src/video/workspace/components/LayerInspector.tsx
+++ b/src/video/workspace/components/LayerInspector.tsx
@@ -2,13 +2,23 @@ import * as React from 'react';
 import type { VideoLayer } from '@/video/templates/types/video-layer';
 import { Badge } from '@/shared/ui/badge';
 import { Card, CardContent, CardHeader } from '@/shared/ui/card';
+import { TEMPLATE_INPUT_KEY, type TemplateInputKey } from '@/shared/types/bindings';
 
 interface LayerInspectorProps {
   layer?: VideoLayer | null;
 }
 
+const TEMPLATE_INPUT_KEYS = new Set<TemplateInputKey>(Object.values(TEMPLATE_INPUT_KEY));
+
 export function LayerInspector({ layer }: LayerInspectorProps) {
   const hasBinding = layer !== undefined;
+  const bindingEntries = React.useMemo(() => {
+    if (!layer?.inputs) {
+      return [];
+    }
+
+    return Object.entries(layer.inputs).filter(([, bindingKey]) => TEMPLATE_INPUT_KEYS.has(bindingKey));
+  }, [layer?.inputs]);
 
   return (
     <Card className="h-full border-[var(--video-workspace-border)] bg-[var(--video-workspace-panel)]">
@@ -50,8 +60,20 @@ export function LayerInspector({ layer }: LayerInspectorProps) {
             <div>
               <div className="text-[10px] uppercase tracking-wide text-[var(--video-workspace-text-muted)]">Inputs</div>
               <div className="text-[var(--video-workspace-text)]">
-                {layer.inputs ? `${Object.keys(layer.inputs).length} bound` : 'No bindings'}
+                {bindingEntries.length > 0 ? `${bindingEntries.length} bound` : 'No bindings'}
               </div>
+              {bindingEntries.length > 0 ? (
+                <div className="mt-2 space-y-1 text-[var(--video-workspace-text-muted)]">
+                  {bindingEntries.map(([inputName, bindingKey]) => (
+                    <div key={inputName} className="flex items-center justify-between">
+                      <span className="truncate">{inputName}</span>
+                      <span className="ml-2 rounded bg-[var(--video-workspace-muted)] px-2 py-1 text-[10px]">
+                        {bindingKey}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
             </div>
           </div>
         ) : (


### PR DESCRIPTION
### Motivation

- Strengthen type-safety for video template input bindings by using the canonical `TemplateInputKey` type instead of free-form `string` values.  
- Ensure compile/resolve helpers accept typed binding keys so template binding resolution is safe and deterministic.  
- Restrict the VideoTemplateWorkspace UI to only surface binding keys from the shared `TEMPLATE_INPUT_KEY` constants for clearer UX and to avoid showing arbitrary keys.

### Description

- Updated types so `inputs` on video template, scene, and layer use `Record<string, TemplateInputKey>` instead of `Record<string, string>` in `src/video/templates/types/video-template.ts`, `src/video/templates/types/video-scene.ts`, and `src/video/templates/types/video-layer.ts`.  
- Tightened compilation helpers in `src/video/templates/compile/compile-composition.ts` to accept `Record<string, TemplateInputKey>` for template/scene/layer bindings and to index `frameInputs` with typed keys (removed cast).  
- Enhanced `LayerInspector` (`src/video/workspace/components/LayerInspector.tsx`) to filter displayed bindings to only the shared `TEMPLATE_INPUT_KEY` values and render binding details in the inspector UI.  
- Adjusted imports where necessary to reference `TemplateInputKey` from `src/shared/types/bindings.ts`.

### Testing

- Ran the production build with `npm run build`, which failed in this environment due to missing tooling/dependencies (`sass`) and optional external packages (e.g. `@ai-sdk/openai`, `@copilotkit/react-core`); failures are unrelated to the typed binding changes and are environment/dependency issues.  
- No project unit tests were executed in this session beyond the build attempt.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697538011e18832d8bdae83ee9de946e)