### PR TITLE
Add optional media/presentation fields to Forge nodes and expose inputs in node inspectors

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNodeFields.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { ForgeGraphDoc } from '@/forge/types/forge-graph';
+import { ForgeGraphDoc, ForgeNode, ForgeNodePresentation } from '@/forge/types/forge-graph';
 import { ForgeCharacter } from '@/forge/types/characters';
 import { CharacterSelector } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/shared/CharacterSelector';
 import { User } from 'lucide-react';
 import { NextNodeSelector } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/NodeEditor/NextNodeSelector';
-import { ForgeNode } from '@/forge/types/forge-graph';
 
 interface CharacterNodeFieldsProps {
   node: ForgeNode;
@@ -15,6 +14,12 @@ interface CharacterNodeFieldsProps {
 }
 
 export function CharacterNodeFields({ node, graph, characters, onUpdate, onFocusNode }: CharacterNodeFieldsProps) {
+  const updatePresentation = (updates: Partial<ForgeNodePresentation>) => {
+    const nextPresentation = { ...node.presentation, ...updates };
+    const hasValue = Object.values(nextPresentation).some((value) => value);
+    onUpdate({ presentation: hasValue ? nextPresentation : undefined });
+  };
+
   return (
     <>
       <div>
@@ -48,6 +53,32 @@ export function CharacterNodeFields({ node, graph, characters, onUpdate, onFocus
             onChange={(event) => onUpdate({ speaker: event.target.value })}
             className="flex-1 bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-npc-accent)] outline-none"
             placeholder="Custom speaker name (optional)"
+          />
+        </div>
+      </div>
+      <div className="mt-4 space-y-2">
+        <label className="text-[10px] text-[var(--color-df-text-secondary)] uppercase">Media</label>
+        <div className="grid grid-cols-1 gap-2">
+          <input
+            type="text"
+            value={node.presentation?.imageId || ''}
+            onChange={(event) => updatePresentation({ imageId: event.target.value || undefined })}
+            className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-npc-accent)] outline-none"
+            placeholder="Image ID (optional)"
+          />
+          <input
+            type="text"
+            value={node.presentation?.backgroundId || ''}
+            onChange={(event) => updatePresentation({ backgroundId: event.target.value || undefined })}
+            className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-npc-accent)] outline-none"
+            placeholder="Background ID (optional)"
+          />
+          <input
+            type="text"
+            value={node.presentation?.portraitId || ''}
+            onChange={(event) => updatePresentation({ portraitId: event.target.value || undefined })}
+            className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-npc-accent)] outline-none"
+            placeholder="Portrait ID (optional)"
           />
         </div>
       </div>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNodeFields.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNodeFields.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ForgeGraphDoc, ForgeChoice, ForgeNode } from '@/forge/types/forge-graph';
+import { ForgeGraphDoc, ForgeChoice, ForgeNode, ForgeNodePresentation } from '@/forge/types/forge-graph';
 import { FlagSchema } from '@/forge/types/flags';
 import { ForgeCharacter } from '@/forge/types/characters';
 import { CharacterSelector } from '../shared/CharacterSelector';
@@ -44,6 +44,11 @@ export function PlayerNodeFields({
   setChoiceInputs,
 }: PlayerNodeFieldsProps) {
   const actions = useForgeEditorActions();
+  const updatePresentation = (updates: Partial<ForgeNodePresentation>) => {
+    const nextPresentation = { ...node.presentation, ...updates };
+    const hasValue = Object.values(nextPresentation).some((value) => value);
+    onUpdate({ presentation: hasValue ? nextPresentation : undefined });
+  };
 
   const handleAddChoice = () => {
     if (!node.id) return;
@@ -103,6 +108,32 @@ export function PlayerNodeFields({
             onChange={(event) => onUpdate({ speaker: event.target.value })}
             className="flex-1 bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-player-accent)] outline-none"
             placeholder="Custom speaker name (optional)"
+          />
+        </div>
+      </div>
+      <div className="mt-4 space-y-2">
+        <label className="text-[10px] text-[var(--color-df-text-secondary)] uppercase">Media</label>
+        <div className="grid grid-cols-1 gap-2">
+          <input
+            type="text"
+            value={node.presentation?.imageId || ''}
+            onChange={(event) => updatePresentation({ imageId: event.target.value || undefined })}
+            className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-player-accent)] outline-none"
+            placeholder="Image ID (optional)"
+          />
+          <input
+            type="text"
+            value={node.presentation?.backgroundId || ''}
+            onChange={(event) => updatePresentation({ backgroundId: event.target.value || undefined })}
+            className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-player-accent)] outline-none"
+            placeholder="Background ID (optional)"
+          />
+          <input
+            type="text"
+            value={node.presentation?.portraitId || ''}
+            onChange={(event) => updatePresentation({ portraitId: event.target.value || undefined })}
+            className="w-full bg-card border border-border rounded px-2 py-1 text-sm text-foreground focus:border-[var(--node-player-accent)] outline-none"
+            placeholder="Portrait ID (optional)"
           />
         </div>
       </div>

--- a/src/forge/types/forge-graph.ts
+++ b/src/forge/types/forge-graph.ts
@@ -126,6 +126,12 @@ export type ForgeStoryletCall = {
   returnGraphId?: number;
 };
 
+export type ForgeNodePresentation = {
+  imageId?: string;
+  backgroundId?: string;
+  portraitId?: string;
+};
+
 export type ForgeNode = {
   // shared
   id?: string;
@@ -154,6 +160,9 @@ export type ForgeNode = {
 
   // optional semantics for deterministic "book path"
   defaultNextNodeId?: string; // optional: explicitly mark default path
+
+  // optional media fields for presentation
+  presentation?: ForgeNodePresentation;
 };
 
 export type ForgeReactFlowEdge = Edge & {

--- a/src/forge/types/index.ts
+++ b/src/forge/types/index.ts
@@ -16,6 +16,7 @@ export type {
   ForgeChoice,
   ForgeStoryletCall,
   ForgeNode,
+  ForgeNodePresentation,
   ForgeNodeType,
   ForgeGraphKind,
   ForgeEdgeKind,


### PR DESCRIPTION
### Motivation
- Add optional media metadata to node data so nodes can reference presentation assets (images, backgrounds, portraits) without changing existing flows. 
- Surface simple placeholder inputs in node inspectors so authors can set those media IDs from the UI.

### Description
- Introduced `ForgeNodePresentation` (`imageId?`, `backgroundId?`, `portraitId?`) and added an optional `presentation?: ForgeNodePresentation` to `ForgeNode` in `src/forge/types/forge-graph.ts` and exported it from `src/forge/types/index.ts`.
- Added placeholder text inputs and an `updatePresentation` helper to `CharacterNodeFields` and `PlayerNodeFields` (`src/forge/components/.../CharacterNode/CharacterNodeFields.tsx` and `.../PlayerNode/PlayerNodeFields.tsx`) to edit these optional fields and clear `presentation` when all values are empty.
- Kept fields optional and local to node data and did not modify any Yarn export/conversion code, so exports remain unchanged.

### Testing
- Ran `npm run build` which failed due to missing optional workspace dependencies (errors about `sass`, `@copilotkit/react-core`, etc.).
- Started the dev server with `npm run dev` which launched, and an automated browser script attempted `/forge` and produced a screenshot, but loading `/forge` hit compile-time missing-module errors resulting in a 500 response during the visit.
- No unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697539ed69d4832dab7ed9af496300e4)