### PR TITLE
Add runtimeDirectives to Forge nodes, show placeholders in Node Editor, and strip runtime data for Yarn export

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/NodeEditor/NodeEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/NodeEditor/NodeEditor.tsx
@@ -10,6 +10,7 @@ import { NodeEditorHeader } from './NodeEditorHeader';
 import { NodeEditorIdField } from './NodeEditorIdField';
 import { NodeEditorFields } from './NodeEditorFields';
 import { NodeEditorSetFlagsField } from './NodeEditorSetFlagsField';
+import { NodeEditorRuntimeDirectivesField } from './NodeEditorRuntimeDirectivesField';
 
 interface NodeEditorProps {
   node: ForgeNode;
@@ -95,6 +96,7 @@ export function NodeEditor({
             onUpdateStoryletCall={handleStoryletCallUpdate}
           />
           <NodeEditorSetFlagsField node={node} flagSchema={flagSchema} onUpdate={onUpdate} />
+          <NodeEditorRuntimeDirectivesField node={node} />
         </div>
       </aside>
     </>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/NodeEditor/NodeEditorRuntimeDirectivesField.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/NodeEditor/NodeEditorRuntimeDirectivesField.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { ForgeNode } from '@/forge/types/forge-graph';
+import { Label } from '@/shared/ui/label';
+
+interface NodeEditorRuntimeDirectivesFieldProps {
+  node: ForgeNode;
+}
+
+const directivePlaceholders = [
+  { label: 'Scene', description: 'Placeholder' },
+  { label: 'Media', description: 'Placeholder' },
+  { label: 'Camera', description: 'Placeholder' },
+  { label: 'Overlay', description: 'Placeholder' },
+];
+
+export function NodeEditorRuntimeDirectivesField({ node }: NodeEditorRuntimeDirectivesFieldProps) {
+  const directiveCount = node.runtimeDirectives?.length ?? 0;
+
+  return (
+    <div>
+      <Label className="text-[10px] text-gray-500 uppercase">Runtime Directives</Label>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Placeholder slots for runtime-only scene/media/camera/overlay directives.
+      </p>
+      <div className="mt-2 grid grid-cols-2 gap-2">
+        {directivePlaceholders.map(item => (
+          <div
+            key={item.label}
+            className="rounded border border-df-node-border bg-[#12121a] px-2 py-1 text-[11px] text-muted-foreground"
+          >
+            <span className="font-medium text-foreground">{item.label}</span>
+            <span className="ml-2 text-[10px] text-muted-foreground">{item.description}</span>
+          </div>
+        ))}
+      </div>
+      <p className="mt-2 text-[10px] text-muted-foreground">
+        {directiveCount > 0
+          ? `${directiveCount} directive${directiveCount === 1 ? '' : 's'} configured.`
+          : 'No runtime directives configured.'}
+      </p>
+    </div>
+  );
+}

--- a/src/forge/lib/yarn-converter/utils/runtime-export.ts
+++ b/src/forge/lib/yarn-converter/utils/runtime-export.ts
@@ -23,6 +23,7 @@ const sanitizeRuntimeLinks = (
   }
 
   const data = { ...node.data };
+  data.runtimeDirectives = undefined;
 
   if (data.defaultNextNodeId && runtimeNodeIds.has(data.defaultNextNodeId)) {
     data.defaultNextNodeId = undefined;

--- a/src/forge/runtime/engine/types.ts
+++ b/src/forge/runtime/engine/types.ts
@@ -1,11 +1,16 @@
 import type { ForgeFlagValue, ForgeGameState } from '@/forge/types/forge-game-state';
-import type { ForgeChoice, ForgeCondition, ForgeGraphDoc, ForgeNode } from '@/forge/types/forge-graph';
+import type {
+  ForgeChoice,
+  ForgeCondition,
+  ForgeGraphDoc,
+  ForgeNode,
+  ForgeRuntimeDirective,
+} from '@/forge/types/forge-graph';
 import type {
   ExecutionMode,
   ExecutionStatus,
   FrameKind,
   RuntimeDirectiveApplyMode,
-  RuntimeDirectiveType,
 } from './constants';
 
 export type { RuntimeDirectiveApplyMode };
@@ -22,13 +27,7 @@ export type RuntimeChoice = {
   mutations?: FlagMutation[];
 };
 
-export type RuntimeDirective = {
-  type: RuntimeDirectiveType;
-  refId?: string;
-  payload?: Record<string, unknown>;
-  applyMode?: RuntimeDirectiveApplyMode;
-  priority?: number;
-};
+export type RuntimeDirective = ForgeRuntimeDirective;
 
 export type ResolvedRuntimeDirective = RuntimeDirective & {
   resolved?: unknown;

--- a/src/forge/types/forge-graph.ts
+++ b/src/forge/types/forge-graph.ts
@@ -1,5 +1,6 @@
 import type { Node, Edge, Viewport } from 'reactflow';
 import { CONDITION_OPERATOR, type ConditionOperator } from '@/forge/types/constants';
+import type { RuntimeDirectiveApplyMode, RuntimeDirectiveType } from '@/forge/runtime/engine/constants';
 
 /**
  * Forge graph kind constants
@@ -76,6 +77,14 @@ export const CONDITION_VALUE_TYPE = {
 } as const;
 
 export type ConditionValueType = typeof CONDITION_VALUE_TYPE[keyof typeof CONDITION_VALUE_TYPE];
+
+export type ForgeRuntimeDirective = {
+  type: RuntimeDirectiveType;
+  refId?: string;
+  payload?: Record<string, unknown>;
+  applyMode?: RuntimeDirectiveApplyMode;
+  priority?: number;
+};
 
 /**
  * Condition for evaluating flags
@@ -163,6 +172,9 @@ export type ForgeNode = {
 
   // optional media fields for presentation
   presentation?: ForgeNodePresentation;
+
+  // runtime-only directives for scene/media/camera/overlay/etc.
+  runtimeDirectives?: ForgeRuntimeDirective[];
 };
 
 export type ForgeReactFlowEdge = Edge & {

--- a/src/forge/types/index.ts
+++ b/src/forge/types/index.ts
@@ -17,6 +17,7 @@ export type {
   ForgeStoryletCall,
   ForgeNode,
   ForgeNodePresentation,
+  ForgeRuntimeDirective,
   ForgeNodeType,
   ForgeGraphKind,
   ForgeEdgeKind,


### PR DESCRIPTION
### Motivation
- Support attaching runtime-only presentation directives (scene/media/camera/overlay/etc.) to Forge nodes so the runtime can consume them directly. 
- Surface a lightweight, non-blocking UI in node editors to show and count configured directives as authoring affordance. 
- Ensure Yarn export continues to ignore runtime-only data so exported Yarn remains runtime-agnostic.

### Description
- Added `ForgeRuntimeDirective` type and exposed `runtimeDirectives?: ForgeRuntimeDirective[]` on `ForgeNode` in `src/forge/types/forge-graph.ts` and re-exported it from `src/forge/types/index.ts`.
- Reused the new `ForgeRuntimeDirective` in the runtime engine types by changing `RuntimeDirective` to alias `ForgeRuntimeDirective` in `src/forge/runtime/engine/types.ts`.
- Added a simple UI component `NodeEditorRuntimeDirectivesField.tsx` and included it in the editor sidebar at `NodeEditor.tsx` to show placeholder slots and a configured count (non-editable placeholder UI).
- Ensured Yarn export strips runtime-only data by clearing `data.runtimeDirectives` in the Yarn export preparation step in `src/forge/lib/yarn-converter/utils/runtime-export.ts` while preserving existing runtime-only node filtering logic.

### Testing
- Ran `npm run build`; the build failed in this environment due to missing external development dependencies (`sass`, `@ai-sdk/openai`, and `@copilotkit/react-core`) unrelated to the changes, so no full production build artifact was produced.
- Started the dev server with `npm run dev` which booted and served the app; a Playwright-based smoke screenshot of `/forge` was captured to validate the Node Editor renders (the app compilation showed unrelated missing module warnings during iterative dev compile).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69753c15a37c832d8502c21c9836b77c)