### PR TITLE
Sanitize runtime presentation and directives during Yarn export

### DIFF
--- a/src/forge/lib/yarn-converter/__tests__/runtime-export.test.ts
+++ b/src/forge/lib/yarn-converter/__tests__/runtime-export.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { prepareGraphForYarnExport } from '../utils/runtime-export';
+import { createMockForgeFlowNode, createMockForgeGraphDoc } from './helpers';
+import { FORGE_NODE_TYPE } from '@/forge/types/forge-graph';
+import { RUNTIME_DIRECTIVE_TYPE } from '@/forge/runtime/engine/constants';
+
+describe('prepareGraphForYarnExport', () => {
+  it('strips runtime-only presentation/directives while preserving dialogue flow', () => {
+    const characterNode = createMockForgeFlowNode('char1', FORGE_NODE_TYPE.CHARACTER, {
+      content: 'Hello there.',
+      defaultNextNodeId: 'player1',
+      presentation: {
+        imageId: 'image_1',
+        backgroundId: 'background_1',
+      },
+      runtimeDirectives: [
+        {
+          type: RUNTIME_DIRECTIVE_TYPE.SCENE,
+          refId: 'scene_1',
+        },
+      ],
+    });
+
+    const playerNode = createMockForgeFlowNode('player1', FORGE_NODE_TYPE.PLAYER, {
+      choices: [
+        {
+          id: 'choice_1',
+          text: 'Continue',
+          nextNodeId: 'char2',
+        },
+      ],
+      presentation: {
+        portraitId: 'portrait_1',
+      },
+      runtimeDirectives: [
+        {
+          type: RUNTIME_DIRECTIVE_TYPE.MEDIA,
+          refId: 'media_1',
+        },
+      ],
+    });
+
+    const followupNode = createMockForgeFlowNode('char2', FORGE_NODE_TYPE.CHARACTER, {
+      content: 'Next line.',
+    });
+
+    const graph = createMockForgeGraphDoc('Runtime export test', [
+      characterNode,
+      playerNode,
+      followupNode,
+    ]);
+
+    graph.flow.edges = [
+      { id: 'edge_1', source: 'char1', target: 'player1' },
+      { id: 'edge_2', source: 'player1', target: 'char2' },
+    ];
+
+    const result = prepareGraphForYarnExport(graph);
+
+    const exportedCharacter = result.nodes.find(node => node.id === 'char1');
+    const exportedPlayer = result.nodes.find(node => node.id === 'player1');
+
+    expect(exportedCharacter?.data?.presentation).toBeUndefined();
+    expect(exportedCharacter?.data?.runtimeDirectives).toBeUndefined();
+    expect(exportedPlayer?.data?.presentation).toBeUndefined();
+    expect(exportedPlayer?.data?.runtimeDirectives).toBeUndefined();
+    expect(exportedCharacter?.data?.defaultNextNodeId).toBe('player1');
+    expect(exportedPlayer?.data?.choices?.[0]?.nextNodeId).toBe('char2');
+    expect(result.edges).toHaveLength(2);
+    expect(result.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'char1', target: 'player1' }),
+        expect.objectContaining({ source: 'player1', target: 'char2' }),
+      ])
+    );
+  });
+});

--- a/src/forge/lib/yarn-converter/utils/runtime-export.ts
+++ b/src/forge/lib/yarn-converter/utils/runtime-export.ts
@@ -24,6 +24,7 @@ const sanitizeRuntimeLinks = (
 
   const data = { ...node.data };
   data.runtimeDirectives = undefined;
+  data.presentation = undefined;
 
   if (data.defaultNextNodeId && runtimeNodeIds.has(data.defaultNextNodeId)) {
     data.defaultNextNodeId = undefined;


### PR DESCRIPTION
### Motivation
- Prevent runtime-only media and directive metadata from being included in Yarn exports while keeping dialogue/choice flow intact.
- Add a focused unit test to guard against regressions where runtime-only fields might be leaked or break node/edge relationships.

### Description
- Update `prepareGraphForYarnExport` in `src/forge/lib/yarn-converter/utils/runtime-export.ts` to also clear `presentation` from node `data` in `sanitizeRuntimeLinks` (in addition to `runtimeDirectives`).
- Add a Vitest unit test at `src/forge/lib/yarn-converter/__tests__/runtime-export.test.ts` that asserts `presentation` and `runtimeDirectives` are removed while `defaultNextNodeId`, `choices` nextNodeId`, and edges are preserved.

### Testing
- Ran `npm run build` to validate the change, which failed in this environment due to missing optional dependencies (`sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, etc.) and not because of the export changes.
- Added the unit test file (Vitest) but the test suite was not executed here due to the environment build failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697547da2f1c832da516b7ea6a20c794)