### PR TITLE
Move manual playback fixture into runtime tests and stop seeding it into Demo Project

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -22,6 +22,25 @@ A convenience export is exposed via `src/forge/runtime/execute-graph-to-frames.t
 ## How It Looks
 Runtime playback inside Forge uses the `GamePlayer` component, which provides a stage-like container for dialogue simulation during authoring.
 
+## Manual Runtime Verification Checklist
+Use the **Manual Playback Fixture** graph to confirm the dialogue UI and Remotion preview stay in sync. The fixture lives in `src/forge/runtime/__tests__/fixtures/manual-playback-graph.ts` so it can be reused in tests and as a manual QA reference.
+
+### Setup
+1. Start the app locally (`npm run dev`) and open `/forge`.
+2. In your Demo Project (or any project), create a new narrative graph named **Manual Playback Fixture**.
+3. Use `src/forge/runtime/__tests__/fixtures/manual-playback-graph.ts` as the reference for the node content, choices, and wiring.
+4. Switch to the **Play** tab.
+5. In the template dropdown, pick the **Dialogue Only** video template preset (starter template).
+
+### Checklist (manual)
+- ✅ **Initial frame renders**: The dialogue panel shows the Guide speaker and the intro line from the fixture.
+- ✅ **Choices render**: Two choices appear in the choice list.
+- ✅ **Dialogue updates on choice**: Clicking either choice updates the dialogue text to the outro line.
+- ✅ **Remotion Player updates**: The Remotion preview updates to reflect the newly selected line (speaker + dialogue).
+- ✅ **Completion state**: The choices panel transitions to “Dialogue complete.” after the outro line.
+
+If any step fails, re-check the fixture data and verify that the video template preset is selected so that the Remotion Player can compile frames.
+
 ## When to Edit Runtime Code
 - **New runtime behaviors** (scene/media directives, frame rendering, runtime tuning) → edit the engine in `src/forge/runtime/engine/`.
 - **Playback UI** (what users see during test runs) → edit `GamePlayer` or related UI in `src/forge/components/ForgeWorkspace/components/GamePlayer/`.

--- a/src/forge/runtime/__tests__/fixtures/manual-playback-graph.ts
+++ b/src/forge/runtime/__tests__/fixtures/manual-playback-graph.ts
@@ -1,0 +1,91 @@
+import {
+  FORGE_EDGE_KIND,
+  FORGE_GRAPH_KIND,
+  FORGE_NODE_TYPE,
+  type ForgeGraphDoc,
+} from '@/forge/types/forge-graph';
+
+const now = '2024-01-01T00:00:00.000Z';
+
+export const MANUAL_PLAYBACK_GRAPH_FIXTURE: ForgeGraphDoc = {
+  id: 0,
+  project: 0,
+  kind: FORGE_GRAPH_KIND.NARRATIVE,
+  title: 'Manual Playback Fixture',
+  startNodeId: 'node-intro',
+  endNodeIds: [{ nodeId: 'node-outro', exitKey: 'complete' }],
+  flow: {
+    nodes: [
+      {
+        id: 'node-intro',
+        type: FORGE_NODE_TYPE.CHARACTER,
+        position: { x: 0, y: 0 },
+        data: {
+          id: 'node-intro',
+          type: FORGE_NODE_TYPE.CHARACTER,
+          speaker: 'Guide',
+          content: 'Welcome to Forge. Pick a path to continue.',
+        },
+      },
+      {
+        id: 'node-choice',
+        type: FORGE_NODE_TYPE.PLAYER,
+        position: { x: 320, y: 0 },
+        data: {
+          id: 'node-choice',
+          type: FORGE_NODE_TYPE.PLAYER,
+          speaker: 'Player',
+          choices: [
+            {
+              id: 'choice-continue',
+              text: 'Show me the demo flow',
+              nextNodeId: 'node-outro',
+            },
+            {
+              id: 'choice-skip',
+              text: 'Skip ahead',
+              nextNodeId: 'node-outro',
+            },
+          ],
+        },
+      },
+      {
+        id: 'node-outro',
+        type: FORGE_NODE_TYPE.CHARACTER,
+        position: { x: 640, y: -40 },
+        data: {
+          id: 'node-outro',
+          type: FORGE_NODE_TYPE.CHARACTER,
+          speaker: 'Guide',
+          content: 'Great! The choice should update both the dialogue and the video preview.',
+        },
+      },
+    ],
+    edges: [
+      {
+        id: 'edge-intro-choice',
+        source: 'node-intro',
+        target: 'node-choice',
+        kind: FORGE_EDGE_KIND.FLOW,
+      },
+      {
+        id: 'edge-choice-outro-1',
+        source: 'node-choice',
+        target: 'node-outro',
+        kind: FORGE_EDGE_KIND.CHOICE,
+        label: 'Show me the demo flow',
+      },
+      {
+        id: 'edge-choice-outro-2',
+        source: 'node-choice',
+        target: 'node-outro',
+        kind: FORGE_EDGE_KIND.CHOICE,
+        label: 'Skip ahead',
+      },
+    ],
+    viewport: { x: 0, y: 0, zoom: 1 },
+  },
+  compiledYarn: null,
+  updatedAt: now,
+  createdAt: now,
+};


### PR DESCRIPTION
### Motivation
- The seeded demo fixture was intentionally forbidden; the change removes automatic seeding and keeps a QA-facing how-to/checklist instead. 
- Provide a stable, reusable manual playback graph that lives with runtime tests for QA reference and potential test reuse. 
- Keep the runtime documentation aligned with the new location and workflow for the manual verification checklist.

### Description
- Remove the seeded fixture and related seeding logic so the Demo Project is created without any graphs (`app/seeds/graph-seeds.ts` now only creates the Demo Project). 
- Add a manual playback graph fixture for QA under runtime test fixtures at `src/forge/runtime/__tests__/fixtures/manual-playback-graph.ts`. 
- Update the runtime documentation checklist to reference the test fixture and describe how to create/use the Manual Playback Fixture in the UI (`docs/runtime.md`). 
- Ensure the fixture is suitable for manual verification and reuse in automated tests without being auto-seeded into the demo project.

### Testing
- No automated tests were run for this change, as it only moves a fixture and updates documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697548f1eef4832d96d4077cffcd94b1)