### PR TITLE
Add CopilotKit video workspace actions and wire into VideoStudio

### DIFF
--- a/app/(video)/video/copilot/actions.ts
+++ b/app/(video)/video/copilot/actions.ts
@@ -1,0 +1,170 @@
+import type { FrontendAction } from '@copilotkit/react-core';
+import type { Parameter } from '@copilotkit/shared';
+
+export const VIDEO_WORKSPACE_ACTION = {
+  ADD_SCENE: 'video.workspace.addScene',
+  DELETE_LAYER: 'video.workspace.deleteLayer',
+  SET_DURATION: 'video.workspace.setDuration',
+  RENAME_TEMPLATE: 'video.workspace.renameTemplate',
+  LOAD_PRESET: 'video.workspace.loadPreset',
+  EXPORT: 'video.workspace.export',
+} as const;
+
+export type VideoWorkspaceActionName = (typeof VIDEO_WORKSPACE_ACTION)[keyof typeof VIDEO_WORKSPACE_ACTION];
+
+export type VideoWorkspaceDurationTarget = 'scene' | 'layer';
+
+export interface VideoWorkspaceActionHandlers {
+  addScene: (options?: { durationMs?: number }) => void;
+  deleteLayer: (layerId: string) => void;
+  setDuration: (payload: { durationMs: number; target?: VideoWorkspaceDurationTarget; id?: string }) => void;
+  renameTemplate: (name: string) => void;
+  loadPreset: (presetId: string) => void;
+  exportVideo: () => void | Promise<void>;
+}
+
+export function createVideoWorkspaceActions(
+  handlers: VideoWorkspaceActionHandlers
+): [
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+] {
+  const addSceneAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.ADD_SCENE,
+    description: 'Add a new scene to the current video template, optionally with a custom duration in milliseconds.',
+    parameters: [
+      {
+        name: 'durationMs',
+        type: 'number',
+        description: 'Optional duration for the new scene in milliseconds.',
+        required: false,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const durationMs = typeof args.durationMs === 'number' ? args.durationMs : undefined;
+      handlers.addScene({ durationMs });
+      return { success: true, durationMs };
+    },
+  };
+
+  const deleteLayerAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.DELETE_LAYER,
+    description: 'Delete a layer from the current template using the layer ID.',
+    parameters: [
+      {
+        name: 'layerId',
+        type: 'string',
+        description: 'The ID of the layer to delete.',
+        required: true,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const layerId = args.layerId as string;
+      if (!layerId) {
+        throw new Error('layerId is required');
+      }
+      handlers.deleteLayer(layerId);
+      return { success: true, layerId };
+    },
+  };
+
+  const setDurationAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.SET_DURATION,
+    description: 'Set the duration (in milliseconds) for a scene or layer in the active template.',
+    parameters: [
+      {
+        name: 'durationMs',
+        type: 'number',
+        description: 'The duration to set in milliseconds.',
+        required: true,
+      },
+      {
+        name: 'target',
+        type: 'string',
+        description: 'Target type to update: "scene" or "layer". Defaults to "scene".',
+        required: false,
+      },
+      {
+        name: 'id',
+        type: 'string',
+        description: 'Optional scene or layer ID. Uses the active selection if omitted.',
+        required: false,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const durationMs = args.durationMs as number;
+      if (!durationMs || Number.isNaN(durationMs)) {
+        throw new Error('durationMs is required');
+      }
+      const target = (args.target as VideoWorkspaceDurationTarget) ?? 'scene';
+      const id = args.id as string | undefined;
+      handlers.setDuration({ durationMs, target, id });
+      return { success: true, durationMs, target, id };
+    },
+  };
+
+  const renameTemplateAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.RENAME_TEMPLATE,
+    description: 'Rename the currently selected video template.',
+    parameters: [
+      {
+        name: 'name',
+        type: 'string',
+        description: 'The new template name.',
+        required: true,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const name = args.name as string;
+      if (!name) {
+        throw new Error('name is required');
+      }
+      handlers.renameTemplate(name);
+      return { success: true, name };
+    },
+  };
+
+  const loadPresetAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.LOAD_PRESET,
+    description: 'Load a preset video template by its preset ID.',
+    parameters: [
+      {
+        name: 'presetId',
+        type: 'string',
+        description: 'The preset template ID to load.',
+        required: true,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const presetId = args.presetId as string;
+      if (!presetId) {
+        throw new Error('presetId is required');
+      }
+      handlers.loadPreset(presetId);
+      return { success: true, presetId };
+    },
+  };
+
+  const exportAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.EXPORT,
+    description: 'Export the current composition using the configured render settings.',
+    parameters: [],
+    handler: async () => {
+      await handlers.exportVideo();
+      return { success: true };
+    },
+  };
+
+  return [
+    addSceneAction,
+    deleteLayerAction,
+    setDurationAction,
+    renameTemplateAction,
+    loadPresetAction,
+    exportAction,
+  ];
+}

--- a/app/(video)/video/copilot/useVideoWorkspaceActions.ts
+++ b/app/(video)/video/copilot/useVideoWorkspaceActions.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { useCopilotAction } from '@copilotkit/react-core';
+import { createVideoWorkspaceActions } from './actions';
+import type { VideoWorkspaceActionHandlers } from './actions';
+
+export function useVideoWorkspaceActions(handlers: VideoWorkspaceActionHandlers) {
+  const actions = useMemo(() => createVideoWorkspaceActions(handlers), [handlers]);
+
+  const [
+    addSceneAction,
+    deleteLayerAction,
+    setDurationAction,
+    renameTemplateAction,
+    loadPresetAction,
+    exportAction,
+  ] = actions;
+
+  useCopilotAction(addSceneAction);
+  useCopilotAction(deleteLayerAction);
+  useCopilotAction(setDurationAction);
+  useCopilotAction(renameTemplateAction);
+  useCopilotAction(loadPresetAction);
+  useCopilotAction(exportAction);
+}


### PR DESCRIPTION
### Motivation

- Expose video-studio operations (add scene, delete layer, set duration, rename template, load preset, export) as CopilotKit actions so the assistant can control the Video Studio.
- Ensure actions target the Video Studio container handlers (app/(video)/video) rather than internal `src/**` logic.
- Provide human-readable descriptions and parameter schemas to improve CopilotKit UX when invoking actions.

### Description

- Added a video workspace action registry at `app/(video)/video/copilot/actions.ts` that defines action names, parameters, descriptions, and handlers for: add scene, delete layer, set duration (scene or layer), rename template, load preset, and export.
- Added a `useVideoWorkspaceActions` hook at `app/(video)/video/copilot/useVideoWorkspaceActions.ts` that registers the actions with CopilotKit via `useCopilotAction`.
- Wired actions into the Video Studio by wrapping the UI with `CopilotKitProvider` and instantiating `VideoStudioCopilotActions` in `app/(video)/video/VideoStudio.tsx`, mapping each Copilot action to existing Video Studio handler functions (added/adjusted handler signatures where needed, e.g. `addScene(options?: { durationMs?: number })`).
- All new actions call the Video Studio container handlers (the workspace-level handlers in `app/(video)/video/VideoStudio.tsx`) and include human-friendly descriptions for each action and parameter for better CopilotKit UX.

### Testing

- Ran `npm run build` to verify integration; build failed in this environment due to missing external dependencies (`sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, etc.), so full build verification could not complete here.
- No additional automated tests were executed in this environment; the changes are limited to the app-level video workspace and action registration and should be testable once the project dependencies are available and `npm run build` succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697578450fc8832d8e19547116821c09)