### PR TITLE
Add video layer kinds and Remotion component mapping

### DIFF
--- a/src/video/templates/compile/compile-composition.ts
+++ b/src/video/templates/compile/compile-composition.ts
@@ -1,7 +1,7 @@
 import type { Frame } from '@/forge/runtime/types';
 import type { TemplateInputKey } from '@/shared/types/bindings';
 import type { VideoComposition, VideoCompositionLayer, VideoCompositionScene } from '@/video/templates/types/video-composition';
-import type { VideoLayer } from '@/video/templates/types/video-layer';
+import { VIDEO_LAYER_KIND_TO_COMPONENT, type VideoLayer } from '@/video/templates/types/video-layer';
 import type { VideoScene } from '@/video/templates/types/video-scene';
 import type { VideoTemplate } from '@/video/templates/types/video-template';
 import { framesToTemplateInputs, type FrameTemplateInputs } from './frames-to-template-inputs';
@@ -71,6 +71,8 @@ const buildCompositionLayer = (
   return {
     id: `${frameId}:${sceneId}:${layer.id}`,
     sceneId,
+    kind: layer.kind,
+    component: VIDEO_LAYER_KIND_TO_COMPONENT[layer.kind],
     startMs: sceneStartMs + layer.startMs,
     endMs: sceneStartMs + Math.max(0, durationMs),
     opacity: layer.opacity,

--- a/src/video/templates/compile/compile-template.test.ts
+++ b/src/video/templates/compile/compile-template.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { TEMPLATE_INPUT_KEY } from '../../../shared/types/bindings';
+import { VIDEO_LAYER_COMPONENT, VIDEO_LAYER_KIND } from '../types/video-layer';
 import type { VideoTemplate } from '../types/video-template';
 import { compileTemplate } from './compile-template';
 
@@ -27,6 +28,7 @@ describe('compileTemplate', () => {
           layers: [
             {
               id: 'layer-b',
+              kind: VIDEO_LAYER_KIND.PORTRAIT,
               startMs: 500,
               durationMs: 1000,
               inputs: {
@@ -35,6 +37,7 @@ describe('compileTemplate', () => {
             },
             {
               id: 'layer-a',
+              kind: VIDEO_LAYER_KIND.PORTRAIT,
               startMs: 500,
               durationMs: 1000,
               inputs: {
@@ -55,6 +58,7 @@ describe('compileTemplate', () => {
 
     const scene = composition.scenes[0];
     expect(scene.layers.map((layer) => layer.id)).toEqual(['layer-a', 'layer-b']);
+    expect(scene.layers[0].component).toBe(VIDEO_LAYER_COMPONENT.PORTRAIT);
 
     const resolvedInputs = scene.layers[0].resolvedInputs;
     expect(resolvedInputs).toEqual({

--- a/src/video/templates/compile/stitch-scenes.ts
+++ b/src/video/templates/compile/stitch-scenes.ts
@@ -1,4 +1,5 @@
 import type { VideoCompositionScene } from '../types/video-composition';
+import { VIDEO_LAYER_KIND_TO_COMPONENT } from '../types/video-layer';
 import type { NormalizedVideoTemplate } from './normalize-timeline';
 
 export interface StitchedScenes {
@@ -21,6 +22,8 @@ export const stitchScenes = (template: NormalizedVideoTemplate): StitchedScenes 
       layers: scene.layers.map((layer) => ({
         id: layer.id,
         sceneId: scene.id,
+        kind: layer.kind,
+        component: VIDEO_LAYER_KIND_TO_COMPONENT[layer.kind],
         startMs: sceneStartMs + layer.startMs,
         endMs: sceneStartMs + layer.startMs + layer.durationMs,
         opacity: layer.opacity,

--- a/src/video/templates/presets/index.ts
+++ b/src/video/templates/presets/index.ts
@@ -1,4 +1,5 @@
 import { TEMPLATE_INPUT_KEY } from '@/shared/types/bindings';
+import { VIDEO_LAYER_KIND } from '../types/video-layer';
 import type { VideoTemplate } from '../types/video-template';
 
 export const VIDEO_TEMPLATE_PRESETS: VideoTemplate[] = [
@@ -24,6 +25,7 @@ export const VIDEO_TEMPLATE_PRESETS: VideoTemplate[] = [
           {
             id: 'layer-background',
             name: 'Background',
+            kind: VIDEO_LAYER_KIND.BACKGROUND,
             startMs: 0,
             inputs: {
               background: TEMPLATE_INPUT_KEY.NODE_BACKGROUND,
@@ -32,6 +34,7 @@ export const VIDEO_TEMPLATE_PRESETS: VideoTemplate[] = [
           {
             id: 'layer-dialogue',
             name: 'Dialogue',
+            kind: VIDEO_LAYER_KIND.DIALOGUE_CARD,
             startMs: 0,
             inputs: {
               dialogue: TEMPLATE_INPUT_KEY.NODE_DIALOGUE,
@@ -64,6 +67,7 @@ export const VIDEO_TEMPLATE_PRESETS: VideoTemplate[] = [
           {
             id: 'layer-background',
             name: 'Background',
+            kind: VIDEO_LAYER_KIND.BACKGROUND,
             startMs: 0,
             inputs: {
               background: TEMPLATE_INPUT_KEY.NODE_BACKGROUND,
@@ -72,6 +76,7 @@ export const VIDEO_TEMPLATE_PRESETS: VideoTemplate[] = [
           {
             id: 'layer-portrait',
             name: 'Portrait Placeholder',
+            kind: VIDEO_LAYER_KIND.PORTRAIT,
             startMs: 0,
             inputs: {
               image: TEMPLATE_INPUT_KEY.NODE_IMAGE,
@@ -80,6 +85,67 @@ export const VIDEO_TEMPLATE_PRESETS: VideoTemplate[] = [
           {
             id: 'layer-dialogue',
             name: 'Dialogue',
+            kind: VIDEO_LAYER_KIND.DIALOGUE_CARD,
+            startMs: 0,
+            inputs: {
+              dialogue: TEMPLATE_INPUT_KEY.NODE_DIALOGUE,
+              speaker: TEMPLATE_INPUT_KEY.NODE_SPEAKER,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'preset-dialogue-lower-third',
+    name: 'Dialogue + Lower Third',
+    width: 1920,
+    height: 1080,
+    frameRate: 30,
+    inputs: {
+      speaker: TEMPLATE_INPUT_KEY.NODE_SPEAKER,
+      dialogue: TEMPLATE_INPUT_KEY.NODE_DIALOGUE,
+    },
+    scenes: [
+      {
+        id: 'scene-dialogue-lower-third',
+        name: 'Dialogue Scene',
+        durationMs: 5000,
+        inputs: {
+          background: TEMPLATE_INPUT_KEY.NODE_BACKGROUND,
+        },
+        layers: [
+          {
+            id: 'layer-background',
+            name: 'Background',
+            kind: VIDEO_LAYER_KIND.BACKGROUND,
+            startMs: 0,
+            inputs: {
+              background: TEMPLATE_INPUT_KEY.NODE_BACKGROUND,
+            },
+          },
+          {
+            id: 'layer-portrait',
+            name: 'Portrait',
+            kind: VIDEO_LAYER_KIND.PORTRAIT,
+            startMs: 0,
+            inputs: {
+              image: TEMPLATE_INPUT_KEY.NODE_IMAGE,
+            },
+          },
+          {
+            id: 'layer-lower-third',
+            name: 'Lower Third',
+            kind: VIDEO_LAYER_KIND.LOWER_THIRD,
+            startMs: 200,
+            inputs: {
+              speaker: TEMPLATE_INPUT_KEY.NODE_SPEAKER,
+            },
+          },
+          {
+            id: 'layer-dialogue',
+            name: 'Dialogue Card',
+            kind: VIDEO_LAYER_KIND.DIALOGUE_CARD,
             startMs: 0,
             inputs: {
               dialogue: TEMPLATE_INPUT_KEY.NODE_DIALOGUE,

--- a/src/video/templates/types/video-composition.ts
+++ b/src/video/templates/types/video-composition.ts
@@ -1,6 +1,10 @@
+import type { VideoLayerComponent, VideoLayerKind } from './video-layer';
+
 export interface VideoCompositionLayer {
   id: string;
   sceneId: string;
+  kind: VideoLayerKind;
+  component: VideoLayerComponent;
   startMs: number;
   endMs: number;
   opacity?: number;

--- a/src/video/templates/types/video-layer.ts
+++ b/src/video/templates/types/video-layer.ts
@@ -1,8 +1,34 @@
 import type { TemplateInputKey } from '@/shared/types/bindings';
 
+export const VIDEO_LAYER_KIND = {
+  BACKGROUND: 'background',
+  DIALOGUE_CARD: 'dialogue_card',
+  PORTRAIT: 'portrait',
+  LOWER_THIRD: 'lower_third',
+} as const;
+
+export type VideoLayerKind = typeof VIDEO_LAYER_KIND[keyof typeof VIDEO_LAYER_KIND];
+
+export const VIDEO_LAYER_COMPONENT = {
+  BACKGROUND: 'BackgroundImage',
+  DIALOGUE_CARD: 'DialogueCard',
+  PORTRAIT: 'Portrait',
+  LOWER_THIRD: 'LowerThird',
+} as const;
+
+export type VideoLayerComponent = typeof VIDEO_LAYER_COMPONENT[keyof typeof VIDEO_LAYER_COMPONENT];
+
+export const VIDEO_LAYER_KIND_TO_COMPONENT: Record<VideoLayerKind, VideoLayerComponent> = {
+  [VIDEO_LAYER_KIND.BACKGROUND]: VIDEO_LAYER_COMPONENT.BACKGROUND,
+  [VIDEO_LAYER_KIND.DIALOGUE_CARD]: VIDEO_LAYER_COMPONENT.DIALOGUE_CARD,
+  [VIDEO_LAYER_KIND.PORTRAIT]: VIDEO_LAYER_COMPONENT.PORTRAIT,
+  [VIDEO_LAYER_KIND.LOWER_THIRD]: VIDEO_LAYER_COMPONENT.LOWER_THIRD,
+};
+
 export interface VideoLayer {
   id: string;
   name?: string;
+  kind: VideoLayerKind;
   startMs: number;
   durationMs?: number;
   opacity?: number;


### PR DESCRIPTION
### Motivation
- Introduce first-class layer kinds to map template layers to Remotion renderers so compositions can carry renderer metadata. 
- Use exported constants for all new type values to follow the repository rule that forbids string literals. 
- Provide presets that demonstrate the common layer kinds (background, dialogue card, portrait, lower-third) so templates can be authored with renderer intent.

### Description
- Add `VIDEO_LAYER_KIND`, `VIDEO_LAYER_COMPONENT`, and `VIDEO_LAYER_KIND_TO_COMPONENT` constants and types, and require a `kind: VideoLayerKind` on `VideoLayer` in `src/video/templates/types/video-layer.ts`.
- Extend `VideoCompositionLayer` with `kind` and `component` fields in `src/video/templates/types/video-composition.ts` so compiled compositions include renderer metadata.
- Populate `kind` and `component` during compilation in `stitch-scenes.ts` and `compile-composition.ts` by mapping `layer.kind` to the Remotion component via `VIDEO_LAYER_KIND_TO_COMPONENT`.
- Update `src/video/templates/presets/index.ts` to set `kind` on preset layers and add a `preset-dialogue-lower-third` demonstrating background, portrait, dialogue card, and lower-third layers, and update `src/video/templates/compile/compile-template.test.ts` to assert the resulting `component`.

### Testing
- Updated unit test `src/video/templates/compile/compile-template.test.ts` to include `kind` on template layers and to assert the compiled `component`; the test file was modified but the test suite was not executed in this environment. 
- Ran `npm run build` to validate the change compiles in-context, but the Next.js build failed due to missing optional dependencies in the environment (e.g., `sass`, `@copilotkit/*`, `@ai-sdk/openai`), so a full build/test pass could not be completed here. 
- The code changes are self-contained and type-checked locally against TypeScript definitions in the repo; please run the full test suite (`npm test`) and a production build (`npm run build`) in a development environment with the project dependencies installed to verify everything passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69757a39c34c832d9cbd27af41c657b6)