### PR TITLE
Add video template input types, validate overrides, and return binding maps from compilation

### DIFF
--- a/src/video/index.ts
+++ b/src/video/index.ts
@@ -2,6 +2,8 @@ export * from './templates/types/video-composition';
 export * from './templates/types/video-layer';
 export * from './templates/types/video-scene';
 export * from './templates/types/video-template';
+export * from './templates/types/video-template-input-bindings';
+export * from './templates/types/video-template-input-overrides';
 export * from './templates/types/video-template-overrides';
 export * from './templates/compile/compile-template';
 export * from './templates/compile/normalize-timeline';

--- a/src/video/templates/compile/compile-composition.ts
+++ b/src/video/templates/compile/compile-composition.ts
@@ -1,6 +1,7 @@
 import type { Frame } from '@/forge/runtime/types';
 import type { TemplateInputKey } from '@/shared/types/bindings';
 import type { VideoComposition, VideoCompositionLayer, VideoCompositionScene } from '@/video/templates/types/video-composition';
+import type { VideoTemplateInputBindings } from '@/video/templates/types/video-template-input-bindings';
 import { VIDEO_LAYER_KIND_TO_COMPONENT, type VideoLayer } from '@/video/templates/types/video-layer';
 import type { VideoScene } from '@/video/templates/types/video-scene';
 import type { VideoTemplate } from '@/video/templates/types/video-template';
@@ -14,7 +15,7 @@ export type CompileCompositionOptions = {
 };
 
 const resolveInputBindings = (
-  bindings: Record<string, TemplateInputKey> | undefined,
+  bindings: VideoTemplateInputBindings | undefined,
   frameInputs: Record<TemplateInputKey, unknown>,
 ): Record<string, unknown> | undefined => {
   if (!bindings) {
@@ -33,9 +34,9 @@ const resolveInputBindings = (
 };
 
 const mergeResolvedInputs = (
-  templateInputs: Record<string, TemplateInputKey> | undefined,
-  sceneInputs: Record<string, TemplateInputKey> | undefined,
-  layerInputs: Record<string, TemplateInputKey> | undefined,
+  templateInputs: VideoTemplateInputBindings | undefined,
+  sceneInputs: VideoTemplateInputBindings | undefined,
+  layerInputs: VideoTemplateInputBindings | undefined,
   frameInputs: Record<TemplateInputKey, unknown>,
 ): Record<string, unknown> | undefined => {
   const resolvedTemplateInputs = resolveInputBindings(templateInputs, frameInputs);
@@ -60,8 +61,8 @@ const buildCompositionLayer = (
   sceneStartMs: number,
   sceneDurationMs: number,
   frameInputs: Record<TemplateInputKey, unknown>,
-  templateInputs: Record<string, TemplateInputKey> | undefined,
-  sceneInputs: Record<string, TemplateInputKey> | undefined,
+  templateInputs: VideoTemplateInputBindings | undefined,
+  sceneInputs: VideoTemplateInputBindings | undefined,
   frameId: string,
   sceneId: string,
 ): VideoCompositionLayer => {

--- a/src/video/templates/compile/compile-template-overrides.ts
+++ b/src/video/templates/compile/compile-template-overrides.ts
@@ -1,5 +1,7 @@
 import type { Frame } from '@/forge/runtime/types';
+import { TEMPLATE_INPUT_KEY, type TemplateInputKey } from '@/shared/types/bindings';
 import type { VideoComposition } from '@/video/templates/types/video-composition';
+import type { VideoTemplateInputOverrides } from '@/video/templates/types/video-template-input-overrides';
 import type { VideoTemplate } from '@/video/templates/types/video-template';
 import type { VideoTemplateOverrides } from '@/video/templates/types/video-template-overrides';
 import type { FrameTemplateInputs } from './frames-to-template-inputs';
@@ -14,13 +16,53 @@ export interface VideoTemplateCompilePayload {
 
 export interface VideoTemplateCompileResult {
   composition: VideoComposition;
-  resolvedBindings: FrameTemplateInputs[];
+  bindingMap: FrameTemplateInputs[];
 }
+
+const templateInputKeys = new Set(Object.values(TEMPLATE_INPUT_KEY));
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const validateInputOverrides = (overrides: VideoTemplateInputOverrides, context: string): void => {
+  const invalidKeys = Object.keys(overrides).filter((key) => !templateInputKeys.has(key as TemplateInputKey));
+
+  if (invalidKeys.length > 0) {
+    throw new Error(`Invalid template input override keys in ${context}: ${invalidKeys.sort().join(', ')}`);
+  }
+};
+
+const validateOverrides = (overrides: VideoTemplateOverrides | undefined): void => {
+  if (!overrides) {
+    return;
+  }
+
+  if (overrides.inputs !== undefined) {
+    if (!isRecord(overrides.inputs)) {
+      throw new Error('Invalid template input overrides: inputs must be an object.');
+    }
+    validateInputOverrides(overrides.inputs, 'template inputs');
+  }
+
+  if (overrides.frameInputs !== undefined) {
+    if (!isRecord(overrides.frameInputs)) {
+      throw new Error('Invalid template input overrides: frameInputs must be an object.');
+    }
+
+    Object.entries(overrides.frameInputs).forEach(([frameId, frameOverrides]) => {
+      if (!isRecord(frameOverrides)) {
+        throw new Error(`Invalid template input overrides for frame "${frameId}": expected an object.`);
+      }
+      validateInputOverrides(frameOverrides, `frame "${frameId}"`);
+    });
+  }
+};
 
 const mergeInputs = (
   baseInputs: Record<string, unknown>,
-  templateOverrides: Partial<Record<string, unknown>> | undefined,
-  frameOverrides: Partial<Record<string, unknown>> | undefined,
+  templateOverrides: VideoTemplateInputOverrides | undefined,
+  frameOverrides: VideoTemplateInputOverrides | undefined,
 ): Record<string, unknown> => {
   if (!templateOverrides && !frameOverrides) {
     return baseInputs;
@@ -55,15 +97,16 @@ export const compileTemplateWithOverrides = (
   template: VideoTemplate,
   payload: VideoTemplateCompilePayload,
 ): VideoTemplateCompileResult => {
+  validateOverrides(payload.overrides);
   const baseFrameInputs = framesToTemplateInputs(payload.frames);
-  const resolvedBindings = applyOverrides(baseFrameInputs, payload.overrides);
+  const bindingMap = applyOverrides(baseFrameInputs, payload.overrides);
   const composition = compileCompositionFromFrames(template, payload.frames, {
     ...(payload.options ?? {}),
-    frameInputs: resolvedBindings,
+    frameInputs: bindingMap,
   });
 
   return {
     composition,
-    resolvedBindings,
+    bindingMap,
   };
 };

--- a/src/video/templates/compile/compile-template.test.ts
+++ b/src/video/templates/compile/compile-template.test.ts
@@ -49,7 +49,7 @@ describe('compileTemplate', () => {
       ],
     };
 
-    const composition = compileTemplate(template, {
+    const { composition } = compileTemplate(template, {
       [TEMPLATE_INPUT_KEY.NODE_BACKGROUND]: 'bg.png',
       [TEMPLATE_INPUT_KEY.NODE_DIALOGUE]: 'hello',
       [TEMPLATE_INPUT_KEY.NODE_IMAGE]: 'actor.png',

--- a/src/video/templates/compile/compile-template.ts
+++ b/src/video/templates/compile/compile-template.ts
@@ -1,9 +1,12 @@
 import type { TemplateInputKey } from '../../../shared/types/bindings';
 import type { VideoComposition, VideoCompositionLayer } from '../types/video-composition';
+import type { VideoTemplateInputBindings } from '../types/video-template-input-bindings';
 import type { VideoTemplate } from '../types/video-template';
 import { normalizeTimeline } from './normalize-timeline';
 import { resolveBindings, type TemplateInputs } from './resolve-bindings';
 import { stitchScenes } from './stitch-scenes';
+
+export type TemplateInputBindingMap = Record<TemplateInputKey, unknown>;
 
 const mergeResolvedInputs = (
   ...resolvedInputsList: Array<Record<string, unknown> | undefined>
@@ -26,6 +29,17 @@ const collectMissing = (collector: Set<TemplateInputKey>, missing: TemplateInput
   missing.forEach((key) => collector.add(key));
 };
 
+const collectBindings = (
+  collector: Set<TemplateInputKey>,
+  bindings: VideoTemplateInputBindings | undefined,
+): void => {
+  if (!bindings) {
+    return;
+  }
+
+  Object.values(bindings).forEach((key) => collector.add(key));
+};
+
 const applyResolvedInputs = (
   layer: VideoCompositionLayer,
   templateInputs: Record<string, unknown> | undefined,
@@ -44,14 +58,24 @@ const applyResolvedInputs = (
   };
 };
 
-export const compileTemplate = (template: VideoTemplate, inputs: TemplateInputs = {}): VideoComposition => {
+export interface VideoTemplateCompileResult {
+  composition: VideoComposition;
+  bindingMap: TemplateInputBindingMap;
+}
+
+export const compileTemplate = (
+  template: VideoTemplate,
+  inputs: TemplateInputs = {},
+): VideoTemplateCompileResult => {
   const normalizedTemplate = normalizeTimeline(template);
   const stitched = stitchScenes(normalizedTemplate);
 
   const missingBindings = new Set<TemplateInputKey>();
+  const usedBindings = new Set<TemplateInputKey>();
 
   const templateBindings = resolveBindings(template.inputs, inputs);
   collectMissing(missingBindings, templateBindings.missing);
+  collectBindings(usedBindings, template.inputs);
 
   const sceneById = new Map(normalizedTemplate.scenes.map((scene) => [scene.id, scene]));
 
@@ -63,11 +87,13 @@ export const compileTemplate = (template: VideoTemplate, inputs: TemplateInputs 
 
     const sceneBindings = resolveBindings(templateScene.inputs, inputs);
     collectMissing(missingBindings, sceneBindings.missing);
+    collectBindings(usedBindings, templateScene.inputs);
 
     const layers = scene.layers.map((layer) => {
       const templateLayer = templateScene.layers.find((candidate) => candidate.id === layer.id);
       const layerBindings = resolveBindings(templateLayer?.inputs, inputs);
       collectMissing(missingBindings, layerBindings.missing);
+      collectBindings(usedBindings, templateLayer?.inputs);
 
       return applyResolvedInputs(
         layer,
@@ -88,13 +114,21 @@ export const compileTemplate = (template: VideoTemplate, inputs: TemplateInputs 
     throw new Error(`Missing template inputs: ${missingList}`);
   }
 
+  const bindingMap = [...usedBindings].sort().reduce<TemplateInputBindingMap>((accumulator, key) => {
+    accumulator[key] = inputs[key];
+    return accumulator;
+  }, {});
+
   return {
-    id: template.id,
-    templateId: template.id,
-    width: template.width,
-    height: template.height,
-    frameRate: template.frameRate,
-    durationMs: stitched.durationMs,
-    scenes,
+    composition: {
+      id: template.id,
+      templateId: template.id,
+      width: template.width,
+      height: template.height,
+      frameRate: template.frameRate,
+      durationMs: stitched.durationMs,
+      scenes,
+    },
+    bindingMap,
   };
 };

--- a/src/video/templates/compile/resolve-bindings.ts
+++ b/src/video/templates/compile/resolve-bindings.ts
@@ -1,4 +1,5 @@
 import type { TemplateInputKey } from '../../../shared/types/bindings';
+import type { VideoTemplateInputBindings } from '../types/video-template-input-bindings';
 
 export type TemplateInputs = Partial<Record<TemplateInputKey, unknown>>;
 
@@ -7,12 +8,12 @@ export interface ResolvedBindings {
   missing: TemplateInputKey[];
 }
 
-const sortTemplateInputs = (bindings: Record<string, TemplateInputKey>): [string, TemplateInputKey][] => {
+const sortTemplateInputs = (bindings: VideoTemplateInputBindings): [string, TemplateInputKey][] => {
   return Object.entries(bindings).sort(([left], [right]) => left.localeCompare(right));
 };
 
 export const resolveBindings = (
-  bindings: Record<string, TemplateInputKey> | undefined,
+  bindings: VideoTemplateInputBindings | undefined,
   inputs: TemplateInputs,
 ): ResolvedBindings => {
   if (!bindings) {

--- a/src/video/templates/types/video-layer.ts
+++ b/src/video/templates/types/video-layer.ts
@@ -1,4 +1,4 @@
-import type { TemplateInputKey } from '@/shared/types/bindings';
+import type { VideoTemplateInputBindings } from './video-template-input-bindings';
 
 export const VIDEO_LAYER_KIND = {
   BACKGROUND: 'background',
@@ -32,5 +32,5 @@ export interface VideoLayer {
   startMs: number;
   durationMs?: number;
   opacity?: number;
-  inputs?: Record<string, TemplateInputKey>;
+  inputs?: VideoTemplateInputBindings;
 }

--- a/src/video/templates/types/video-scene.ts
+++ b/src/video/templates/types/video-scene.ts
@@ -1,10 +1,10 @@
-import type { TemplateInputKey } from '@/shared/types/bindings';
 import type { VideoLayer } from './video-layer';
+import type { VideoTemplateInputBindings } from './video-template-input-bindings';
 
 export interface VideoScene {
   id: string;
   name?: string;
   durationMs: number;
   layers: VideoLayer[];
-  inputs?: Record<string, TemplateInputKey>;
+  inputs?: VideoTemplateInputBindings;
 }

--- a/src/video/templates/types/video-template-input-bindings.ts
+++ b/src/video/templates/types/video-template-input-bindings.ts
@@ -1,0 +1,3 @@
+import type { TemplateInputKey } from '@/shared/types/bindings';
+
+export type VideoTemplateInputBindings = Record<string, TemplateInputKey>;

--- a/src/video/templates/types/video-template-input-overrides.ts
+++ b/src/video/templates/types/video-template-input-overrides.ts
@@ -1,0 +1,3 @@
+import type { TemplateInputKey } from '@/shared/types/bindings';
+
+export type VideoTemplateInputOverrides = Partial<Record<TemplateInputKey, unknown>>;

--- a/src/video/templates/types/video-template-overrides.ts
+++ b/src/video/templates/types/video-template-overrides.ts
@@ -1,6 +1,6 @@
-import type { TemplateInputKey } from '@/shared/types/bindings';
+import type { VideoTemplateInputOverrides } from './video-template-input-overrides';
 
 export interface VideoTemplateOverrides {
-  inputs?: Partial<Record<TemplateInputKey, unknown>>;
-  frameInputs?: Record<string, Partial<Record<TemplateInputKey, unknown>>>;
+  inputs?: VideoTemplateInputOverrides;
+  frameInputs?: Record<string, VideoTemplateInputOverrides>;
 }

--- a/src/video/templates/types/video-template.ts
+++ b/src/video/templates/types/video-template.ts
@@ -1,5 +1,5 @@
-import type { TemplateInputKey } from '@/shared/types/bindings';
 import type { VideoScene } from './video-scene';
+import type { VideoTemplateInputBindings } from './video-template-input-bindings';
 
 export interface VideoTemplate {
   id: string;
@@ -8,5 +8,5 @@ export interface VideoTemplate {
   height: number;
   frameRate: number;
   scenes: VideoScene[];
-  inputs?: Record<string, TemplateInputKey>;
+  inputs?: VideoTemplateInputBindings;
 }


### PR DESCRIPTION
### Motivation
- Introduce explicit types for template input bindings and overrides so scenes and layers can reference template inputs by key with type safety.
- Validate override payloads early to prevent invalid keys from being applied to compositions.
- Ensure compile utilities apply overrides consistently and return both a resolved `VideoComposition` and a binding map of used template inputs.

### Description
- Add `VideoTemplateInputBindings` and `VideoTemplateInputOverrides` types and export them from `src/video/index.ts`.
- Replace ad-hoc `Record<string, TemplateInputKey>` occurrences with `VideoTemplateInputBindings` across `VideoTemplate`, `VideoScene`, and `VideoLayer` definitions.
- Add input validation in `compile-template-overrides.ts` to assert `inputs` and `frameInputs` shapes and to reject invalid template input keys.
- Make `compileTemplate` return a `VideoTemplateCompileResult` containing `composition` and `bindingMap` (mapping used `TemplateInputKey` to supplied values), and propagate that change through `compile-template-overrides.ts`.
- Update `resolve-bindings.ts` and `compile-composition.ts` to use the new binding types and keep deterministic ordering/merging behavior.
- Update unit test usage in `compile-template.test.ts` to unwrap `composition` from the new result shape.

### Testing
- Ran `npm run build` to validate the workspace build, which failed due to unrelated environment issues (missing optional deps such as `sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, and a `zustand` export mismatch), so no full build/test pass was possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697587a1b3f4832d9d3bdf7d5c89caef)