### PR TITLE
Add "New from preset" and "Duplicate template" actions to Video Studio

### DIFF
--- a/src/video/workspace/VideoTemplateWorkspace.tsx
+++ b/src/video/workspace/VideoTemplateWorkspace.tsx
@@ -37,6 +37,7 @@ interface VideoTemplateWorkspaceProps {
   onUpdateLayerOpacity?: (layerId: string, opacity: number) => void;
   onUpdateTemplateMetadata?: (metadata: Partial<Pick<VideoTemplate, 'name' | 'width' | 'height' | 'frameRate'>>) => void;
   onTogglePlayback?: () => void;
+  onSaveTemplate?: () => void;
 }
 
 export function VideoTemplateWorkspace({
@@ -53,6 +54,7 @@ export function VideoTemplateWorkspace({
   onAddScene,
   onAddLayer,
   onTogglePlayback,
+  onSaveTemplate,
 }: VideoTemplateWorkspaceProps) {
   const resolvedScenes = scenes ?? template?.scenes;
   const activeScene =
@@ -142,7 +144,12 @@ export function VideoTemplateWorkspace({
           <Button size="sm" variant="secondary" disabled={!adapterReady}>
             Load
           </Button>
-          <Button size="sm" variant="secondary" disabled={!adapterReady || !template}>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={!adapterReady || !template}
+            onClick={onSaveTemplate}
+          >
             Save
           </Button>
         </div>


### PR DESCRIPTION
### Motivation
- Provide users a convenient way to create new templates from existing presets and duplicate the current template, and let them explicitly save template copies from the UI.

### Description
- Added `syncTemplateSummary`, `cloneTemplate`, and `saveTemplate` helpers in `VideoStudio` to clone templates (new `id`s and `name`) and keep the template list in sync.
- Added handlers `handleCreateFromPreset`, `handleDuplicateTemplate`, and `handleSaveTemplate` and wired them into the studio UI and workspace lifecycle so cloning operations call `saveTemplate`.
- Reworked template list entries to include a per-template `New from preset` button and added a `Duplicate template` button in the Templates header in `app/(video)/video/VideoStudio.tsx`.
- Exposed an `onSaveTemplate` prop on `VideoTemplateWorkspace` and wired the header `Save` button to invoke it in `src/video/workspace/VideoTemplateWorkspace.tsx`.

### Testing
- Ran `npm run build`, which failed due to missing environment/dependency issues (`sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, `tailwind-merge`), so a full production build could not be completed.
- Started the dev server with `npm run dev` and executed an automated Playwright script to navigate to `/video` and capture a screenshot, which produced an artifact but the page compilation reported missing modules at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697589710a38832d9324ee75edb021d0)