### PR TITLE
Add project gating and empty state to Video Studio

### DIFF
--- a/src/video/workspace/VideoTemplateWorkspace.tsx
+++ b/src/video/workspace/VideoTemplateWorkspace.tsx
@@ -38,6 +38,7 @@ interface VideoTemplateWorkspaceProps {
   onUpdateTemplateMetadata?: (metadata: Partial<Pick<VideoTemplate, 'name' | 'width' | 'height' | 'frameRate'>>) => void;
   onTogglePlayback?: () => void;
   onSaveTemplate?: () => void;
+  saveDisabled?: boolean;
 }
 
 export function VideoTemplateWorkspace({
@@ -55,6 +56,7 @@ export function VideoTemplateWorkspace({
   onAddLayer,
   onTogglePlayback,
   onSaveTemplate,
+  saveDisabled,
 }: VideoTemplateWorkspaceProps) {
   const resolvedScenes = scenes ?? template?.scenes;
   const activeScene =
@@ -147,7 +149,7 @@ export function VideoTemplateWorkspace({
           <Button
             size="sm"
             variant="secondary"
-            disabled={!adapterReady || !template}
+            disabled={!adapterReady || !template || saveDisabled}
             onClick={onSaveTemplate}
           >
             Save


### PR DESCRIPTION
### Motivation
- Enforce that a host project is selected before allowing users to save or export video templates in the Video Studio.
- Surface a clear empty state when no project is selected, matching the existing Writer app behavior and preventing confusing failures when adapter persistence is unbound.

### Description
- Added `ProjectSwitcher` to the Video Studio UI and wired a `selectedProjectId` state to the page (`app/(video)/video/VideoStudio.tsx`).
- Re-created the payload video template adapter with the selected `projectId` and reset workspace state when the project changes so templates are scoped and state does not leak across projects.
- Gated template listing/loading on project selection and render/export actions, showing a visible empty-state card when no project is selected instead of the workspace UI.
- Added a `saveDisabled` prop to `VideoTemplateWorkspace` and updated the workspace to disable the Save button when no project (or adapter) is bound (`src/video/workspace/VideoTemplateWorkspace.tsx`).

### Testing
- Ran `npm run build`, which failed in this environment due to missing optional/local dev dependencies (`sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, `tailwind-merge`) so the full production build could not complete.
- Started the dev server with `npm run dev` and executed a Playwright script to visit `/video` and capture the empty-state screenshot, which validated the UI gating and produced an artifact (`artifacts/video-empty-state.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69758ace89ac832d9fa9c81d28284d28)