### PR TITLE
Add generic draft slice for graph drafts

### DIFF
--- a/src/shared/store/draft-slice.ts
+++ b/src/shared/store/draft-slice.ts
@@ -1,0 +1,137 @@
+import type { StateCreator } from 'zustand';
+
+import { applyDeltaToGraph, calculateDelta } from '@/shared/lib/draft/draft-helpers';
+
+export type DraftSliceState<TGraph, TDelta, TValidation> = {
+  committedGraph: TGraph | null;
+  draftGraph: TGraph | null;
+  deltas: TDelta[];
+  validation: TValidation | null;
+  hasUncommittedChanges: boolean;
+  lastCommittedAt: Date | null;
+};
+
+export type DraftSliceActions<TGraph, TDelta> = {
+  applyDelta: (delta: TDelta) => void;
+  commitDraft: () => Promise<void>;
+  discardDraft: () => Promise<void>;
+  resetDraft: (nextCommitted?: TGraph | null) => void;
+  getDraftGraph: () => TGraph | null;
+  getCommittedGraph: () => TGraph | null;
+};
+
+export type DraftSliceConfig<TGraph, TDelta, TValidation> = {
+  initialGraph?: TGraph | null;
+  calculateDelta?: (committed: TGraph, draft: TGraph) => TDelta;
+  applyDeltaToGraph?: (graph: TGraph, delta: TDelta) => TGraph;
+  validateDraft?: (draft: TGraph) => TValidation | null;
+  onCommitDraft?: (draft: TGraph, deltas: TDelta[], committed: TGraph) => Promise<TGraph | void> | TGraph | void;
+  onDiscardDraft?: (draft: TGraph, committed: TGraph, deltas: TDelta[]) => Promise<TGraph | void> | TGraph | void;
+};
+
+export type DraftSlice<TGraph, TDelta, TValidation> = DraftSliceState<TGraph, TDelta, TValidation> &
+  DraftSliceActions<TGraph, TDelta>;
+
+export const createDraftSlice = <
+  TState extends DraftSlice<TGraph, TDelta, TValidation>,
+  TGraph,
+  TDelta = ReturnType<typeof calculateDelta>,
+  TValidation = unknown,
+>(
+  set: Parameters<StateCreator<TState, [], [], TState>>[0],
+  get: Parameters<StateCreator<TState, [], [], TState>>[1],
+  config: DraftSliceConfig<TGraph, TDelta, TValidation> = {}
+): DraftSlice<TGraph, TDelta, TValidation> => {
+  const defaultCalculateDelta = calculateDelta as unknown as (committed: TGraph, draft: TGraph) => TDelta;
+  const defaultApplyDeltaToGraph = applyDeltaToGraph as unknown as (graph: TGraph, delta: TDelta) => TGraph;
+  const calculateDeltaFn = config.calculateDelta ?? defaultCalculateDelta;
+  const applyDeltaToGraphFn = config.applyDeltaToGraph ?? defaultApplyDeltaToGraph;
+
+  const initialGraph = config.initialGraph ?? null;
+  const initialValidation = initialGraph ? (config.validateDraft?.(initialGraph) ?? null) : null;
+
+  return {
+    committedGraph: initialGraph,
+    draftGraph: initialGraph,
+    deltas: [],
+    validation: initialValidation,
+    hasUncommittedChanges: false,
+    lastCommittedAt: null,
+
+    applyDelta: (delta: TDelta) => {
+      set((state) => {
+        if (!state.draftGraph || !state.committedGraph) {
+          return state;
+        }
+
+        const nextDraft = applyDeltaToGraphFn(state.draftGraph, delta);
+        const nextDelta = calculateDeltaFn(state.committedGraph, nextDraft);
+        const nextValidation = config.validateDraft?.(nextDraft) ?? state.validation;
+
+        return {
+          draftGraph: nextDraft,
+          deltas: [...state.deltas, nextDelta],
+          validation: nextValidation,
+          hasUncommittedChanges: true,
+        };
+      });
+    },
+
+    commitDraft: async () => {
+      const { draftGraph, committedGraph, deltas } = get();
+      if (!draftGraph || !committedGraph) {
+        return;
+      }
+
+      const result = await config.onCommitDraft?.(draftGraph, deltas, committedGraph);
+      const nextCommitted = (result ?? draftGraph) as TGraph;
+      const nextValidation = config.validateDraft?.(nextCommitted) ?? null;
+
+      set({
+        committedGraph: nextCommitted,
+        draftGraph: nextCommitted,
+        deltas: [],
+        validation: nextValidation,
+        hasUncommittedChanges: false,
+        lastCommittedAt: new Date(),
+      });
+    },
+
+    discardDraft: async () => {
+      const { draftGraph, committedGraph, deltas } = get();
+      if (!draftGraph || !committedGraph) {
+        return;
+      }
+
+      const result = await config.onDiscardDraft?.(draftGraph, committedGraph, deltas);
+      const nextGraph = (result ?? committedGraph) as TGraph;
+      const nextValidation = config.validateDraft?.(nextGraph) ?? null;
+
+      set({
+        committedGraph: nextGraph,
+        draftGraph: nextGraph,
+        deltas: [],
+        validation: nextValidation,
+        hasUncommittedChanges: false,
+      });
+    },
+
+    resetDraft: (nextCommitted?: TGraph | null) => {
+      set((state) => {
+        const committed = nextCommitted ?? state.committedGraph ?? null;
+        const nextValidation = committed ? (config.validateDraft?.(committed) ?? null) : null;
+
+        return {
+          committedGraph: committed,
+          draftGraph: committed,
+          deltas: [],
+          validation: nextValidation,
+          hasUncommittedChanges: false,
+        };
+      });
+    },
+
+    getDraftGraph: () => get().draftGraph,
+    getCommittedGraph: () => get().committedGraph,
+  };
+};


### PR DESCRIPTION
### Motivation
- Provide a reusable, domain-agnostic draft store for graphs that keeps committed/draft state, deltas and validation in one place. 
- Ensure consistent draft updates by reusing the existing `calculateDelta` / `applyDeltaToGraph` helpers and allow domain-specific commit/discard behavior via injected callbacks.

### Description
- Add `src/shared/store/draft-slice.ts` which exports `createDraftSlice` and typed slice shapes for `committedGraph`, `draftGraph`, `deltas`, `validation`, `hasUncommittedChanges` and `lastCommittedAt`.
- Implement actions `applyDelta`, `commitDraft`, `discardDraft`, `resetDraft`, `getDraftGraph` and `getCommittedGraph` and wire `calculateDelta` + `applyDeltaToGraph` for update/delta computation.
- Make behavior pluggable via `DraftSliceConfig` with optional `calculateDelta`, `applyDeltaToGraph`, `validateDraft`, `onCommitDraft` and `onDiscardDraft` callbacks so Forge/Writer/Video can bind their own adapters.
- Use safe defaults that coerce the shared `draft-helpers` implementations into the generic types while preserving typed overrides.

### Testing
- Ran the build with `npm run build`; the build failed due to unrelated missing optional dependencies in the demo app (errors reported for missing `sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, etc.), so package build could not complete end-to-end.
- No unit tests were added or executed for the new slice in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766162d120832da941ae68841b808f)