### PR TITLE
Add forge workspace draft slice with validation

### DIFF
--- a/src/forge/components/ForgeWorkspace/store/forge-workspace-store.tsx
+++ b/src/forge/components/ForgeWorkspace/store/forge-workspace-store.tsx
@@ -19,6 +19,7 @@ import { createGraphSlice } from "@/forge/components/ForgeWorkspace/store/slices
 import { createGameStateSlice } from "@/forge/components/ForgeWorkspace/store/slices/gameState.slice"
 import { createViewStateSlice } from "@/forge/components/ForgeWorkspace/store/slices/viewState.slice"
 import { createProjectSlice } from "@/forge/components/ForgeWorkspace/store/slices/project.slice"
+import { createForgeDraftSlice } from "@/forge/components/ForgeWorkspace/store/slices/draft.slice"
 import type { ForgeDataAdapter } from "@/forge/adapters/forge-data-adapter"
 import type { VideoTemplateWorkspaceAdapter } from "@/video/workspace/video-template-workspace-contracts"
 import type { VideoTemplateOverrides } from "@/video/templates/types/video-template-overrides"
@@ -33,6 +34,14 @@ export interface ForgeWorkspaceState {
   activeNarrativeGraphId: ReturnType<typeof createGraphSlice>["activeNarrativeGraphId"]
   activeStoryletGraphId: ReturnType<typeof createGraphSlice>["activeStoryletGraphId"]
   breadcrumbHistoryByScope: ReturnType<typeof createGraphSlice>["breadcrumbHistoryByScope"]
+
+  // Draft slice
+  committedGraph: ReturnType<typeof createForgeDraftSlice>["committedGraph"]
+  draftGraph: ReturnType<typeof createForgeDraftSlice>["draftGraph"]
+  deltas: ReturnType<typeof createForgeDraftSlice>["deltas"]
+  validation: ReturnType<typeof createForgeDraftSlice>["validation"]
+  hasUncommittedChanges: ReturnType<typeof createForgeDraftSlice>["hasUncommittedChanges"]
+  lastCommittedAt: ReturnType<typeof createForgeDraftSlice>["lastCommittedAt"]
   
   // Game state slice
   activeFlagSchema: ReturnType<typeof createGameStateSlice>["activeFlagSchema"]
@@ -79,6 +88,14 @@ export interface ForgeWorkspaceState {
     popBreadcrumb: ReturnType<typeof createGraphSlice>["popBreadcrumb"]
     clearBreadcrumbs: ReturnType<typeof createGraphSlice>["clearBreadcrumbs"]
     navigateToBreadcrumb: ReturnType<typeof createGraphSlice>["navigateToBreadcrumb"]
+
+    // Draft actions
+    applyDelta: ReturnType<typeof createForgeDraftSlice>["applyDelta"]
+    commitDraft: ReturnType<typeof createForgeDraftSlice>["commitDraft"]
+    discardDraft: ReturnType<typeof createForgeDraftSlice>["discardDraft"]
+    resetDraft: ReturnType<typeof createForgeDraftSlice>["resetDraft"]
+    getDraftGraph: ReturnType<typeof createForgeDraftSlice>["getDraftGraph"]
+    getCommittedGraph: ReturnType<typeof createForgeDraftSlice>["getCommittedGraph"]
     
     // Game state actions
     setActiveFlagSchema: ReturnType<typeof createGameStateSlice>["setActiveFlagSchema"]
@@ -192,6 +209,8 @@ export function createForgeWorkspaceStore(
         const finalResolver = resolveGraph ?? graphResolver
         
         const graphSlice = createGraphSlice(set, get, narrativeGraphId, storyletGraphId, finalResolver)
+        const initialDraftGraph = initialNarrativeGraph ?? initialStoryletGraph ?? null
+        const draftSlice = createForgeDraftSlice(set, get, initialDraftGraph)
         
         // If initial graphs provided, add them to cache
         if (initialNarrativeGraph) {
@@ -255,6 +274,7 @@ export function createForgeWorkspaceStore(
 
         return {
           ...graphSlice,
+          ...draftSlice,
           ...gameStateSlice,
           ...viewStateSlice,
           ...projectSlice,
@@ -273,6 +293,14 @@ export function createForgeWorkspaceStore(
             popBreadcrumb: graphSlice.popBreadcrumb,
             clearBreadcrumbs: graphSlice.clearBreadcrumbs,
             navigateToBreadcrumb: graphSlice.navigateToBreadcrumb,
+
+            // Draft actions
+            applyDelta: draftSlice.applyDelta,
+            commitDraft: draftSlice.commitDraft,
+            discardDraft: draftSlice.discardDraft,
+            resetDraft: draftSlice.resetDraft,
+            getDraftGraph: draftSlice.getDraftGraph,
+            getCommittedGraph: draftSlice.getCommittedGraph,
             
             // Game state actions
             setActiveFlagSchema: gameStateSlice.setActiveFlagSchema,

--- a/src/forge/components/ForgeWorkspace/store/slices/draft.slice.ts
+++ b/src/forge/components/ForgeWorkspace/store/slices/draft.slice.ts
@@ -1,0 +1,22 @@
+import type { StateCreator } from "zustand"
+
+import type { ForgeGraphDoc } from "@/forge/types"
+import { validateNarrativeGraph, type GraphValidationResult } from "@/forge/lib/graph-validation"
+import { calculateDelta } from "@/shared/lib/draft/draft-helpers"
+import { createDraftSlice, type DraftSlice } from "@/shared/store/draft-slice"
+import type { ForgeWorkspaceState } from "../forge-workspace-store"
+
+export type ForgeDraftDelta = ReturnType<typeof calculateDelta>
+
+export type ForgeDraftSlice = DraftSlice<ForgeGraphDoc, ForgeDraftDelta, GraphValidationResult>
+
+export function createForgeDraftSlice(
+  set: Parameters<StateCreator<ForgeWorkspaceState, [], [], ForgeWorkspaceState>>[0],
+  get: Parameters<StateCreator<ForgeWorkspaceState, [], [], ForgeWorkspaceState>>[1],
+  initialGraph?: ForgeGraphDoc | null
+): ForgeDraftSlice {
+  return createDraftSlice<ForgeDraftSlice, ForgeGraphDoc, ForgeDraftDelta, GraphValidationResult>(set, get, {
+    initialGraph: initialGraph ?? null,
+    validateDraft: (draft) => validateNarrativeGraph(draft),
+  })
+}


### PR DESCRIPTION
### Motivation
- Provide per-graph draft management for Forge graphs using the shared draft utilities to track deltas and draft/committed state.  
- Run structural validation on draft graphs and persist the `GraphValidationResult` so UI/components can react to errors and warnings.

### Description
- Added `src/forge/components/ForgeWorkspace/store/slices/draft.slice.ts` which wraps the shared `createDraftSlice` for `ForgeGraphDoc` and wires `validateNarrativeGraph` to produce `GraphValidationResult`.  
- Introduced `createForgeDraftSlice` and exported types `ForgeDraftDelta` and `ForgeDraftSlice` to type the slice.  
- Updated `src/forge/components/ForgeWorkspace/store/forge-workspace-store.tsx` to create and include the draft slice in the workspace store, merge its state into the root store, and expose draft actions/selectors (`applyDelta`, `commitDraft`, `discardDraft`, `resetDraft`, `getDraftGraph`, `getCommittedGraph`).  
- The store initializes the draft slice with an initial graph when provided and merges the draft state alongside graph, gameState, viewState and project slices.

### Testing
- Ran `npm run build` to validate integration, which produced a Turbopack build failure due to missing optional/runtime dependencies (e.g. `sass`, `@copilotkit/react-core`, `@ai-sdk/openai`) and unrelated module resolution errors, so a full build could not complete in this environment.  
- No unit tests were added or executed for the new slice in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697662c5a4c0832d96933502af9e7387)