### PR TITLE
Use draft deltas for forge graph editor updates

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
@@ -170,6 +170,15 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
     }))
   );
 
+  const { committedGraph, draftGraph, applyDelta, resetDraft } = useForgeWorkspaceStore(
+    useShallow((s) => ({
+      committedGraph: s.committedGraph,
+      draftGraph: s.draftGraph,
+      applyDelta: s.actions.applyDelta,
+      resetDraft: s.actions.resetDraft,
+    }))
+  );
+
   const reactFlow = useReactFlow();
 
   // Editor focus tracking - click-only, no hover preview
@@ -250,10 +259,17 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
     });
   }, [graph, selectedProjectId]);
 
+  React.useEffect(() => {
+    if (!committedGraph || committedGraph.id !== effectiveGraph.id) {
+      resetDraft(effectiveGraph);
+    }
+  }, [committedGraph, effectiveGraph, resetDraft]);
+
   // Shell is still the only "graph mutation" boundary.
   const shell = useForgeFlowEditorShell({
-    graph: effectiveGraph,
-    onChange,
+    committedGraph: committedGraph ?? effectiveGraph,
+    draftGraph: draftGraph ?? effectiveGraph,
+    applyDelta,
     reactFlow,
     sessionStore,
   });

--- a/src/shared/types/draft.ts
+++ b/src/shared/types/draft.ts
@@ -1,4 +1,4 @@
-import type { ForgePage } from '@/shared/types/narrative';
+import type { ForgePage, PageType } from '@/shared/types/narrative';
 
 export const DRAFT_PAGE_OPERATION_KIND = {
   CREATE: 'CREATE',
@@ -13,6 +13,22 @@ export type DraftPageOperation<TPage = ForgePage> = {
   kind: DraftPageOperationKind;
   page: TPage;
   previous?: TPage | null;
+};
+
+export type DraftDeltaIds = {
+  added: string[];
+  updated: string[];
+  removed: string[];
+};
+
+export type DraftPendingPageCreation = {
+  nodeId: string;
+  pageType: PageType;
+  title: string;
+  order: number;
+  projectId: number;
+  parentNodeId?: string | null;
+  parentPageId?: number | null;
 };
 
 export type DraftCollectionDelta<TItem> = {
@@ -35,6 +51,9 @@ export type DraftDelta<TNode = unknown, TEdge = unknown, TViewport = unknown, TM
   edges: DraftCollectionDelta<TEdge>;
   viewport?: TViewport | null;
   meta?: Partial<TMeta>;
+  nodeIds?: DraftDeltaIds;
+  edgeIds?: DraftDeltaIds;
+  pendingPageCreations?: DraftPendingPageCreation[];
   pendingPageOperations?: TPageOp[];
 };
 


### PR DESCRIPTION
### Motivation
- Move the React Flow editor to treat the draft graph as the source-of-truth so edits are staged in the draft system rather than mutating the committed graph directly. 
- Replace ad-hoc graph mutations with canonical draft delta operations to keep UI state and persisted/draft state consistent. 
- Capture page-creation intent from newly added narrative nodes (ACT/CHAPTER/PAGE) without immediately writing to the DB, and surface these as draft pending operations. 
- Ensure the draft validation pipeline runs after each staged delta so editor state stays validated as users edit.

### Description
- Switched the editor shell to accept `committedGraph`, `draftGraph`, and `applyDelta` and made the draft graph (`draftGraph`) the React Flow source of truth via `effectiveGraph` and UI state mapping. 
- Replaced direct `onChange`/write calls with `applyDelta(calculateDelta(committed, nextDraft))` by introducing `applyDraftUpdate(nextDraft)` which computes `calculateDelta(committedGraphForDelta, nextDraft)` and calls `applyDelta`. 
- Extended draft delta types and helpers by adding `DraftDeltaIds`, `DraftPendingPageCreation`, `nodeIds`, `edgeIds`, and `pendingPageCreations`, and updated `calculateDelta`/`mergeDeltas` to populate those fields. 
- Implemented logic to detect added/updated/removed node and edge IDs and to build `pendingPageCreations` for narrative node additions (inferring parent relationships and page type) without creating DB entries immediately. 
- Wired narrative and storylet editors to the workspace draft slice (`committedGraph`, `draftGraph`, `applyDelta`, `resetDraft`) and synchronized editor shell initialization to reset draft when a new committed graph is loaded. 
- Kept direct ReactFlow node updates (for low-latency field edits) but ensured corresponding draft deltas are produced for persisted changes and layout/collision/position updates are staged through the draft mechanism.

### Testing
- Ran `npm run build` to exercise type checks and a production build path; the build started but failed due to missing optional environment dependencies (`sass`, `@ai-sdk/openai`, `@copilotkit/react-core`) in this environment, so full bundling/tests could not complete. 
- Verified by static code inspection that `applyDelta` is invoked in all graph mutation paths (node create/patch/delete, edge create/delete, layout, drag-stop position sync). 
- Confirmed the draft slice validation hook (`validateDraft`) will run when `applyDelta` updates the draft (the draft slice computes `nextValidation` after applying deltas). 
- No unit tests were added in this change; integration/build could be validated in CI where optional dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976651cfc44832d9c04d907e9ab2b88)