### PR TITLE
Add draft visual indicators for graph nodes and edges

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
@@ -45,6 +45,7 @@ import { ConditionalNode } from '@/forge/components/ForgeWorkspace/components/Gr
 import { GraphLeftToolbar } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphLeftToolbar';
 import { GraphLayoutControls } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphLayoutControls';
 import { GraphEditorToolbar } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphEditorToolbar';
+import { useDraftVisualIndicators } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/hooks/useDraftVisualIndicators';
 import { useShallow } from 'zustand/shallow';
 import type { FlagSchema } from '@/forge/types/flags';
 import type { ForgeCharacter } from '@/forge/types/characters';
@@ -203,6 +204,8 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
     shell.effectiveGraph
   );
 
+  const { addedNodeIds, modifiedNodeIds, addedEdgeIds, modifiedEdgeIds } = useDraftVisualIndicators();
+
   // Consume focus requests from workspace
   React.useEffect(() => {
     if (pendingFocus && graph && String(graph.id) === pendingFocus.graphId) {
@@ -237,6 +240,8 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
       const nodeType = (flowNode?.type as ForgeNodeType | undefined) ?? (flowNode?.data as ForgeNode | undefined)?.type;
       const isStartNode = node.id === startId;
       const isEndNode = shell.effectiveGraph.endNodeIds.some((e) => e.nodeId === node.id);
+      const isDraftAdded = addedNodeIds.has(node.id);
+      const isDraftUpdated = modifiedNodeIds.has(node.id);
       const nodeData = (flowNode?.data ?? {}) as ForgeNode;
 
       return {
@@ -250,6 +255,8 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
             isInPath,
             isStartNode,
             isEndNode,
+            isDraftAdded,
+            isDraftUpdated,
           },
           flagSchema,
           characters,
@@ -266,6 +273,8 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
     flagSchema,
     resolvedGameStateFlags,
     layoutDirection,
+    addedNodeIds,
+    modifiedNodeIds,
     nodeDepths,
     showPathHighlight,
     shell.effectiveGraph.endNodeIds,
@@ -298,6 +307,8 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
 
       const isInPath = edgesToSelectedNode.has(edge.id);
       const isDimmed = hasSelection && !isInPath;
+      const isDraftAdded = addedEdgeIds.has(edge.id);
+      const isDraftUpdated = modifiedEdgeIds.has(edge.id);
 
       return {
         ...edge,
@@ -306,11 +317,15 @@ function ForgeNarrativeGraphEditorInternal(props: ForgeNarrativeGraphEditorProps
           isInPathToSelected: isInPath,
           isBackEdge,
           isDimmed,
+          isDraftAdded,
+          isDraftUpdated,
           sourceNode: sourceFlowNode,
         },
       };
     });
   }, [
+    addedEdgeIds,
+    modifiedEdgeIds,
     edgesToSelectedNode,
     flowById,
     layoutDirection,

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeStoryletGraphEditor/ForgeStoryletGraphEditor.tsx
@@ -47,6 +47,7 @@ import { GraphEditorToolbar } from '@/forge/components/ForgeWorkspace/components
 import { Network, Focus, FileText, Play } from 'lucide-react';
 import { ToggleGroup, ToggleGroupItem } from '@/shared/ui/toggle-group';
 import { cn } from '@/shared/lib/utils';
+import { useDraftVisualIndicators } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/hooks/useDraftVisualIndicators';
 
 // EdgeDropMenu components
 import { CharacterEdgeDropMenu } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterEdgeDropMenu';
@@ -293,6 +294,8 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
     shell.effectiveGraph
   );
 
+  const { addedNodeIds, modifiedNodeIds, addedEdgeIds, modifiedEdgeIds } = useDraftVisualIndicators();
+
   // Consume focus requests from workspace
   React.useEffect(() => {
     if (pendingFocus && graph && String(graph.id) === pendingFocus.graphId) {
@@ -331,6 +334,8 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
 
       const isStartNode = n.id === startId;
       const isEndNode = shell.endNodeIds.has(n.id);
+      const isDraftAdded = addedNodeIds.has(n.id);
+      const isDraftUpdated = modifiedNodeIds.has(n.id);
 
       const baseNodeData = (flowNode?.data ?? {}) as ForgeNode;
 
@@ -345,6 +350,8 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
             isInPath: inPath,
             isStartNode,
             isEndNode,
+            isDraftAdded,
+            isDraftUpdated,
           },
 
           // Read-only context
@@ -363,6 +370,8 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
     flagSchema,
     resolvedGameStateFlags,
     layoutDirection,
+    addedNodeIds,
+    modifiedNodeIds,
     nodeDepths,
     showPathHighlight,
     shell.effectiveGraph.startNodeId,
@@ -399,6 +408,8 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
 
       const isInPath = edgesToSelectedNode.has(e.id);
       const isDimmed = hasSelection && !isInPath;
+      const isDraftAdded = addedEdgeIds.has(e.id);
+      const isDraftUpdated = modifiedEdgeIds.has(e.id);
 
       const stroke = edgeStrokeColor(e as any, sourceType);
 
@@ -431,12 +442,24 @@ function ForgeStoryletGraphEditorInternal(props: ForgeStoryletGraphEditorProps) 
           isInPathToSelected: isInPath,
           isBackEdge,
           isDimmed,
+          isDraftAdded,
+          isDraftUpdated,
           insertElementTypes,
           sourceNode: sourceFlowNode,
         },
       } as any;
     });
-  }, [edgesToSelectedNode, layoutDirection, showBackEdges, showPathHighlight, shell, nodeById, flowById]);
+  }, [
+    addedEdgeIds,
+    modifiedEdgeIds,
+    edgesToSelectedNode,
+    layoutDirection,
+    showBackEdges,
+    showPathHighlight,
+    shell,
+    nodeById,
+    flowById,
+  ]);
 
   return (
     <ForgeEditorActionsProvider actions={actions}>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Edges/ForgeEdge.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Edges/ForgeEdge.tsx
@@ -93,6 +93,8 @@ export const ForgeEdge = React.memo(function ForgeEdge({
   const isSelected = selected || hovered;
   const isDimmed = data?.isDimmed ?? false;
   const isInPath = data?.isInPathToSelected ?? false;
+  const draftData = data as { isDraftAdded?: boolean; isDraftUpdated?: boolean } | undefined;
+  const isDraft = draftData?.isDraftAdded || draftData?.isDraftUpdated;
   
   // Determine stroke color - use vibrant green on hover/selected
   const strokeColor = isDimmed 
@@ -102,13 +104,15 @@ export const ForgeEdge = React.memo(function ForgeEdge({
       : isBackEdge 
         ? 'var(--color-df-edge-loop)' 
         : edgeColor;
+
+  const draftStrokeColor = isDraft ? 'var(--color-df-warning)' : strokeColor;
   
   const strokeWidth = isSelected || isInPath ? 4 : 3;
   const opacity = isDimmed ? 0.4 : (isSelected || isInPath ? 1 : 0.9);
   
   // Add glow effect when hovered or in path (only if not dimmed)
-  const glowColor = isBackEdge ? 'var(--color-df-edge-loop)' : edgeColor;
-  const filter = (hovered || isInPath) && !isDimmed 
+  const glowColor = isDraft ? 'var(--color-df-warning)' : (isBackEdge ? 'var(--color-df-edge-loop)' : edgeColor);
+  const filter = (hovered || isInPath || isDraft) && !isDimmed 
     ? `drop-shadow(0 0 8px ${glowColor})`
     : !isDimmed
     ? `drop-shadow(0 0 2px ${glowColor})`
@@ -130,7 +134,7 @@ export const ForgeEdge = React.memo(function ForgeEdge({
   const insertElementTypes = menuData?.insertElementTypes;
   const hasContextMenu = !!insertElementTypes && insertElementTypes.length > 0;
   const edgeStyle = useMemo(() => ({
-    stroke: strokeColor,
+    stroke: draftStrokeColor,
     strokeWidth,
     opacity,
     cursor: 'pointer',
@@ -138,7 +142,7 @@ export const ForgeEdge = React.memo(function ForgeEdge({
     filter,
     // Dashed line for back edges
     strokeDasharray: isBackEdge ? '8 4' : undefined,
-  }), [strokeColor, strokeWidth, opacity, filter, isBackEdge]);
+  }), [draftStrokeColor, strokeWidth, opacity, filter, isBackEdge]);
 
   const edgeContent = (
     <>
@@ -184,7 +188,9 @@ export const ForgeEdge = React.memo(function ForgeEdge({
     return (
       <g
         data-choice-index={dataChoiceIndex ?? undefined}
-        className={isChoiceHandle ? `forge-choice-edge${isDimmed ? ' is-dimmed' : ''}${isBackEdge ? ' is-loop' : ''}` : undefined}
+        className={isChoiceHandle
+          ? `forge-choice-edge${isDimmed ? ' is-dimmed' : ''}${isBackEdge ? ' is-loop' : ''}${isDraft ? ' is-draft' : ''}`
+          : `forge-edge${isDraft ? ' is-draft' : ''}`}
       >
         {edgeContent}
       </g>
@@ -204,7 +210,9 @@ export const ForgeEdge = React.memo(function ForgeEdge({
             e.stopPropagation();
           }}
           data-choice-index={dataChoiceIndex ?? undefined}
-          className={isChoiceHandle ? `forge-choice-edge${isDimmed ? ' is-dimmed' : ''}${isBackEdge ? ' is-loop' : ''}` : undefined}
+          className={isChoiceHandle
+            ? `forge-choice-edge${isDimmed ? ' is-dimmed' : ''}${isBackEdge ? ' is-loop' : ''}${isDraft ? ' is-draft' : ''}`
+            : `forge-edge${isDraft ? ' is-draft' : ''}`}
         >
           {edgeContent}
         </g>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ActNode/ActNode.tsx
@@ -15,7 +15,7 @@ import { StandardNodeContextMenuItems } from '../shared/StandardNodeContextMenuI
 
 export const ActNode = React.memo(function ActNode({ data, selected, id }: NodeProps<ShellNodeData>) {
   const { node, ui = {} } = data;
-  const { isDimmed = false, isInPath = false, isStartNode = false } = ui;
+  const { isDimmed = false, isInPath = false, isStartNode = false, isDraftAdded, isDraftUpdated } = ui;
   
   const title = node.label || id;
   const summary = node.content;
@@ -44,6 +44,7 @@ export const ActNode = React.memo(function ActNode({ data, selected, id }: NodeP
           data-selected={selected ? 'true' : 'false'}
           data-in-path={isInPath ? 'true' : 'false'}
           data-dimmed={isDimmed ? 'true' : 'false'}
+          data-draft={isDraftAdded ? 'added' : isDraftUpdated ? 'modified' : undefined}
           data-start="false"
           data-end="false"
           className="forge-node min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm transition-all duration-200 border-node bg-node text-node"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ChapterNode/ChapterNode.tsx
@@ -15,7 +15,7 @@ import { StandardNodeContextMenuItems } from '../shared/StandardNodeContextMenuI
 
 export const ChapterNode = React.memo(function ChapterNode({ data, selected, id }: NodeProps<ShellNodeData>) {
   const { node, ui = {} } = data;
-  const { isDimmed = false, isInPath = false, isStartNode = false } = ui;
+  const { isDimmed = false, isInPath = false, isStartNode = false, isDraftAdded, isDraftUpdated } = ui;
   
   const title = node.label || id;
   const summary = node.content;
@@ -44,6 +44,7 @@ export const ChapterNode = React.memo(function ChapterNode({ data, selected, id 
           data-selected={selected ? 'true' : 'false'}
           data-in-path={isInPath ? 'true' : 'false'}
           data-dimmed={isDimmed ? 'true' : 'false'}
+          data-draft={isDraftAdded ? 'added' : isDraftUpdated ? 'modified' : undefined}
           data-start="false"
           data-end="false"
           className="forge-node min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm transition-all duration-200 border-node bg-node text-node"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/CharacterNode/CharacterNode.tsx
@@ -56,7 +56,7 @@ export const CharacterNode = React.memo(function CharacterNode({ data, selected 
     layoutDirection = 'TB',
   } = data;
 
-  const { isDimmed, isInPath, isStartNode, isEndNode } = ui;
+  const { isDimmed, isInPath, isStartNode, isEndNode, isDraftAdded, isDraftUpdated } = ui;
   const setFlags = useMemo(() => node.setFlags ?? [], [node.setFlags]);
 
 
@@ -119,6 +119,7 @@ export const CharacterNode = React.memo(function CharacterNode({ data, selected 
           data-selected={selected ? 'true' : 'false'}
           data-in-path={isInPath ? 'true' : 'false'}
           data-dimmed={isDimmed ? 'true' : 'false'}
+          data-draft={isDraftAdded ? 'added' : isDraftUpdated ? 'modified' : undefined}
           data-start={isStartNode ? 'true' : 'false'}
           data-end={isEndNode ? 'true' : 'false'}
           className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[320px] max-w-[450px] relative overflow-hidden"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/ConditionalNode/ConditionalNode.tsx
@@ -29,13 +29,15 @@ interface ConditionalNodeData {
     isInPath?: boolean;
     isStartNode?: boolean;
     isEndNode?: boolean;
+    isDraftAdded?: boolean;
+    isDraftUpdated?: boolean;
   };
   layoutDirection?: LayoutDirection;
 }
 
 export const ConditionalNode = React.memo(function ConditionalNode({ data, selected }: NodeProps<ConditionalNodeData>) {
   const { node, flagSchema, characters = {}, ui = {}, layoutDirection = 'TB' } = data;
-  const { isDimmed, isInPath, isStartNode, isEndNode } = ui;
+  const { isDimmed, isInPath, isStartNode, isEndNode, isDraftAdded, isDraftUpdated } = ui;
   const blocks = useMemo(() => node.conditionalBlocks ?? [], [node.conditionalBlocks]);
   const setFlags = useMemo(() => node.setFlags ?? [], [node.setFlags]);
 
@@ -116,6 +118,7 @@ export const ConditionalNode = React.memo(function ConditionalNode({ data, selec
           data-selected={selected ? 'true' : 'false'}
           data-in-path={isInPath ? 'true' : 'false'}
           data-dimmed={isDimmed ? 'true' : 'false'}
+          data-draft={isDraftAdded ? 'added' : isDraftUpdated ? 'modified' : undefined}
           data-start={isStartNode ? 'true' : 'false'}
           data-end={isEndNode ? 'true' : 'false'}
           className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[320px] max-w-[450px] relative overflow-hidden"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/DetourNode/DetourNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/DetourNode/DetourNode.tsx
@@ -21,6 +21,8 @@ interface DetourNodeData {
     isInPath?: boolean;
     isStartNode?: boolean;
     isEndNode?: boolean;
+    isDraftAdded?: boolean;
+    isDraftUpdated?: boolean;
   };
   layoutDirection?: LayoutDirection;
 }
@@ -31,7 +33,7 @@ export const DetourNode = React.memo(function DetourNode({ data, selected }: Nod
     ui = {},
     layoutDirection = 'TB' 
   } = data;
-  const { isDimmed, isInPath, isStartNode, isEndNode } = ui;
+  const { isDimmed, isInPath, isStartNode, isEndNode, isDraftAdded, isDraftUpdated } = ui;
   
   const id = node.id || '';
   const title = node.label;
@@ -69,6 +71,7 @@ export const DetourNode = React.memo(function DetourNode({ data, selected }: Nod
           data-selected={selected ? 'true' : 'false'}
           data-in-path={isInPath ? 'true' : 'false'}
           data-dimmed={isDimmed ? 'true' : 'false'}
+          data-draft={isDraftAdded ? 'added' : isDraftUpdated ? 'modified' : undefined}
           data-start={isStartNode ? 'true' : 'false'}
           data-end={isEndNode ? 'true' : 'false'}
           className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[280px] max-w-[350px] relative overflow-hidden"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PageNode/PageNode.tsx
@@ -15,7 +15,7 @@ import { StandardNodeContextMenuItems } from '@/forge/components/ForgeWorkspace/
 
 export const PageNode = React.memo(function PageNode({ data, selected, id }: NodeProps<ShellNodeData>) {
   const { node, ui = {} } = data;
-  const { isDimmed = false, isInPath = false, isStartNode = false } = ui;
+  const { isDimmed = false, isInPath = false, isStartNode = false, isDraftAdded, isDraftUpdated } = ui;
   
   const title = node.label || id;
   const summary = node.content;
@@ -53,6 +53,7 @@ export const PageNode = React.memo(function PageNode({ data, selected, id }: Nod
           data-selected={selected ? 'true' : 'false'}
           data-in-path={isInPath ? 'true' : 'false'}
           data-dimmed={isDimmed ? 'true' : 'false'}
+          data-draft={isDraftAdded ? 'added' : isDraftUpdated ? 'modified' : undefined}
           data-start="false"
           data-end="false"
           className="forge-node min-w-[220px] max-w-[320px] rounded-lg border-2 shadow-sm transition-all duration-200 border-node bg-node text-node"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/ChoiceEdge.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/ChoiceEdge.tsx
@@ -18,6 +18,8 @@ interface ChoiceEdgeData {
   choiceIndex?: number;
   isDimmed?: boolean;
   isInPathToSelected?: boolean;
+  isDraftAdded?: boolean;
+  isDraftUpdated?: boolean;
   sourceNode?: ForgeReactFlowNode;
 }
 
@@ -89,6 +91,7 @@ export const ChoiceEdge = React.memo(function ChoiceEdge({
   const colorVar = isBackEdge ? 'var(--color-df-edge-loop)' : 'var(--edge-color)';
   const isSelected = selected || hovered;
   const isDimmed = edgeData?.isDimmed ?? false;
+  const isDraft = edgeData?.isDraftAdded || edgeData?.isDraftUpdated;
   
   // Make edge thicker and more opaque when hovered or selected
   // Dim edges not in path when highlighting is on
@@ -96,10 +99,10 @@ export const ChoiceEdge = React.memo(function ChoiceEdge({
   const opacity = isDimmed ? 0.15 : (isSelected ? 1 : 0.7);
   
   // Use dimmed color when dimmed
-  const strokeColor = isDimmed ? 'var(--color-df-edge-dimmed)' : colorVar;
+  const strokeColor = isDraft ? 'var(--color-df-warning)' : (isDimmed ? 'var(--color-df-edge-dimmed)' : colorVar);
   
   // Add glow effect when hovered (only if not dimmed)
-  const filter = hovered && !isDimmed ? `drop-shadow(0 0 4px ${colorVar})` : undefined;
+  const filter = (hovered || isDraft) && !isDimmed ? `drop-shadow(0 0 4px ${strokeColor})` : undefined;
 
   // For pulse animation
   const pulseColor = colorVar;
@@ -115,6 +118,7 @@ export const ChoiceEdge = React.memo(function ChoiceEdge({
   const insertNodeTypes = edgeData?.insertElementTypes;
   const hasContextMenu = !!insertNodeTypes && insertNodeTypes.length > 0;
   const edgeStyle = useMemo<React.CSSProperties>(() => ({
+    stroke: strokeColor,
     strokeWidth,
     opacity,
     cursor: 'pointer',
@@ -123,7 +127,7 @@ export const ChoiceEdge = React.memo(function ChoiceEdge({
     filter,
     // Dashed line for back edges
     strokeDasharray: isBackEdge ? '8 4' : undefined,
-  }), [strokeWidth, opacity, filter, isBackEdge]);
+  }), [strokeColor, strokeWidth, opacity, filter, isBackEdge]);
 
   const edgeContent = (
     <>
@@ -183,7 +187,7 @@ export const ChoiceEdge = React.memo(function ChoiceEdge({
     return (
       <g
         data-choice-index={dataChoiceIndex}
-        className={`forge-choice-edge${isDimmed ? ' is-dimmed' : ''}${isBackEdge ? ' is-loop' : ''}`}
+        className={`forge-choice-edge${isDimmed ? ' is-dimmed' : ''}${isBackEdge ? ' is-loop' : ''}${isDraft ? ' is-draft' : ''}`}
       >
         {edgeContent}
       </g>
@@ -203,7 +207,7 @@ export const ChoiceEdge = React.memo(function ChoiceEdge({
             e.stopPropagation();
           }}
           data-choice-index={dataChoiceIndex}
-          className={`forge-choice-edge${isDimmed ? ' is-dimmed' : ''}${isBackEdge ? ' is-loop' : ''}`}
+          className={`forge-choice-edge${isDimmed ? ' is-dimmed' : ''}${isBackEdge ? ' is-loop' : ''}${isDraft ? ' is-draft' : ''}`}
         >
           {edgeContent}
         </g>

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/PlayerNode/PlayerNode.tsx
@@ -25,13 +25,15 @@ interface PlayerNodeData {
     isInPath?: boolean;
     isStartNode?: boolean;
     isEndNode?: boolean;
+    isDraftAdded?: boolean;
+    isDraftUpdated?: boolean;
   };
   layoutDirection?: LayoutDirection;
 }
 
 export const PlayerNode = React.memo(function PlayerNode({ data, selected }: NodeProps<PlayerNodeData>) {
   const { node, flagSchema, characters = {}, ui = {}, layoutDirection = 'TB' } = data;
-  const { isDimmed, isInPath, isStartNode, isEndNode } = ui;
+  const { isDimmed, isInPath, isStartNode, isEndNode, isDraftAdded, isDraftUpdated } = ui;
   const choices = useMemo(() => node.choices ?? [], [node.choices]);
   const choiceHandleStyle = useMemo(() => ({
     top: '50%',
@@ -125,6 +127,7 @@ export const PlayerNode = React.memo(function PlayerNode({ data, selected }: Nod
           data-selected={selected ? 'true' : 'false'}
           data-in-path={isInPath ? 'true' : 'false'}
           data-dimmed={isDimmed ? 'true' : 'false'}
+          data-draft={isDraftAdded ? 'added' : isDraftUpdated ? 'modified' : undefined}
           data-start={isStartNode ? 'true' : 'false'}
           data-end={isEndNode ? 'true' : 'false'}
           className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[320px] max-w-[450px] relative overflow-hidden"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletNode.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/Nodes/components/StoryletNode/StoryletNode.tsx
@@ -26,13 +26,15 @@ interface StoryletNodeData {
     isInPath?: boolean;
     isStartNode?: boolean;
     isEndNode?: boolean;
+    isDraftAdded?: boolean;
+    isDraftUpdated?: boolean;
   };
   layoutDirection?: LayoutDirection;
 }
 
 export const StoryletNode = React.memo(function StoryletNode({ data, selected }: NodeProps<StoryletNodeData>) {
   const { node, flagSchema, ui = {}, layoutDirection = 'TB' } = data;
-  const { isDimmed, isInPath, isStartNode, isEndNode } = ui;
+  const { isDimmed, isInPath, isStartNode, isEndNode, isDraftAdded, isDraftUpdated } = ui;
   const setFlags = useMemo(() => node.setFlags ?? [], [node.setFlags]);
 
   const actions = useForgeEditorActions();
@@ -84,6 +86,7 @@ export const StoryletNode = React.memo(function StoryletNode({ data, selected }:
           data-selected={selected ? 'true' : 'false'}
           data-in-path={isInPath ? 'true' : 'false'}
           data-dimmed={isDimmed ? 'true' : 'false'}
+          data-draft={isDraftAdded ? 'added' : isDraftUpdated ? 'modified' : undefined}
           data-start={isStartNode ? 'true' : 'false'}
           data-end={isEndNode ? 'true' : 'false'}
           className="forge-node rounded-lg border-2 transition-all duration-300 border-node bg-node text-node min-w-[320px] max-w-[450px] relative overflow-hidden"

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/hooks/useDraftVisualIndicators.ts
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/hooks/useDraftVisualIndicators.ts
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { useShallow } from 'zustand/shallow';
+
+import { useForgeWorkspaceStore } from '@/forge/components/ForgeWorkspace/store/forge-workspace-store';
+import { calculateDelta } from '@/shared/lib/draft/draft-helpers';
+import type { ForgeGraphDoc } from '@/forge/types/forge-graph';
+
+type DraftDelta = ReturnType<typeof calculateDelta>;
+
+type DraftVisualIndicators = {
+  addedNodeIds: Set<string>;
+  modifiedNodeIds: Set<string>;
+  addedEdgeIds: Set<string>;
+  modifiedEdgeIds: Set<string>;
+};
+
+const buildDraftDelta = (
+  committedGraph: ForgeGraphDoc | null,
+  draftGraph: ForgeGraphDoc | null,
+  deltas: DraftDelta[]
+): DraftDelta | null => {
+  if (deltas.length > 0) {
+    return deltas[deltas.length - 1] ?? null;
+  }
+
+  if (!committedGraph || !draftGraph) {
+    return null;
+  }
+
+  return calculateDelta(committedGraph, draftGraph);
+};
+
+export const useDraftVisualIndicators = (): DraftVisualIndicators => {
+  const { committedGraph, draftGraph, deltas } = useForgeWorkspaceStore(
+    useShallow((state) => ({
+      committedGraph: state.committedGraph,
+      draftGraph: state.draftGraph,
+      deltas: state.deltas,
+    }))
+  );
+
+  const delta = React.useMemo(
+    () => buildDraftDelta(committedGraph, draftGraph, deltas),
+    [committedGraph, draftGraph, deltas]
+  );
+
+  const addedNodeIds = React.useMemo(() => new Set(delta?.nodeIds?.added ?? []), [delta]);
+  const modifiedNodeIds = React.useMemo(() => new Set(delta?.nodeIds?.updated ?? []), [delta]);
+  const addedEdgeIds = React.useMemo(() => new Set(delta?.edgeIds?.added ?? []), [delta]);
+  const modifiedEdgeIds = React.useMemo(() => new Set(delta?.edgeIds?.updated ?? []), [delta]);
+
+  return {
+    addedNodeIds,
+    modifiedNodeIds,
+    addedEdgeIds,
+    modifiedEdgeIds,
+  };
+};

--- a/src/forge/lib/graph-editor/hooks/useForgeFlowEditorShell.ts
+++ b/src/forge/lib/graph-editor/hooks/useForgeFlowEditorShell.ts
@@ -43,6 +43,8 @@ export type ShellNodeData = {
     isInPath?: boolean;
     isStartNode?: boolean;
     isEndNode?: boolean;
+    isDraftAdded?: boolean;
+    isDraftUpdated?: boolean;
   };
 
 };

--- a/src/forge/styles/nodes.css
+++ b/src/forge/styles/nodes.css
@@ -166,6 +166,12 @@
   box-shadow: var(--node-selected-shadow);
 }
 
+.dialogue-graph-editor .forge-node[data-draft="added"],
+.dialogue-graph-editor .forge-node[data-draft="modified"] {
+  outline: 2px solid var(--color-df-warning);
+  outline-offset: 2px;
+}
+
 .dialogue-graph-editor .forge-node[data-start="true"],
 .dialogue-graph-editor .forge-node[data-end="true"] {
   box-shadow: var(--node-start-shadow);

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -89,3 +89,13 @@
   stroke: var(--color-df-edge-loop);
   fill: var(--color-df-edge-loop);
 }
+
+.dialogue-graph-editor .forge-edge.is-draft .react-flow__edge-path,
+.dialogue-graph-editor .forge-choice-edge.is-draft .react-flow__edge-path {
+  stroke: var(--color-df-warning);
+}
+
+.dialogue-graph-editor .forge-choice-edge.is-draft .forge-choice-arrow {
+  stroke: var(--color-df-warning);
+  fill: var(--color-df-warning);
+}


### PR DESCRIPTION
### Motivation

- Surface draft delta state in the graph editor so recently added/modified nodes and edges are visually obvious when editing a draft.

### Description

- Add `useDraftVisualIndicators` hook at `src/forge/components/ForgeWorkspace/components/GraphEditors/shared/hooks/useDraftVisualIndicators.ts` to derive added/updated node and edge ID sets from workspace deltas or calculated delta.
- Propagate draft flags into the editor shell and graph editor pipelines by adding `isDraftAdded`/`isDraftUpdated` to `ShellNodeData.ui` and annotating nodes/edges in both storylet and narrative editors so components receive draft state.
- Update node components to emit a `data-draft` attribute (`added` | `modified`) (changed: Act, Chapter, Page, Detour, Character, Conditional, Player, Storylet) and add CSS to show a yellow outline for draft nodes in `src/forge/styles/nodes.css`.
- Update edge renderers (`ForgeEdge` and `ChoiceEdge`) to detect draft state and apply draft stroke color/glow and a CSS class (`is-draft`); add CSS rules in `src/styles/graph.css` to color draft edges.

### Testing

- Attempted an automated full build with `npm run build`; the build failed in this environment due to missing project dependencies and unrelated environment issues (missing `sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, and an export mismatch for `useShallow`), so UI verification could not be completed here.  No unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697669428f74832da0fe1cb334f0ed6f)