### PR TITLE
Add GraphEditorStatusBar showing validation, issues, and uncommitted change count

### DIFF
--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx
@@ -45,6 +45,7 @@ import { ConditionalNode } from '@/forge/components/ForgeWorkspace/components/Gr
 import { GraphLeftToolbar } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphLeftToolbar';
 import { GraphLayoutControls } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphLayoutControls';
 import { GraphEditorToolbar } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphEditorToolbar';
+import { GraphEditorStatusBar } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphEditorStatusBar';
 import { useDraftVisualIndicators } from '@/forge/components/ForgeWorkspace/components/GraphEditors/shared/hooks/useDraftVisualIndicators';
 import { useShallow } from 'zustand/shallow';
 import type { FlagSchema } from '@/forge/types/flags';
@@ -415,6 +416,14 @@ function ForgeNarrativeGraphEditorContent({
   useForgeGraphEditorActions();
   
   const actions = useForgeEditorActions();
+  const { validation, deltas } = useForgeWorkspaceStore(
+    useShallow((state) => ({
+      validation: state.validation,
+      deltas: state.deltas,
+    }))
+  );
+
+  const uncommittedChangeCount = deltas.length;
 
   return (
     <div 
@@ -426,7 +435,7 @@ function ForgeNarrativeGraphEditorContent({
     >
         {/* Toolbar with breadcrumbs and view toggles */}
         <div className={cn(
-          "flex items-center justify-between gap-2 px-3 py-2 border-t-1 bg-df-editor-bg flex-shrink-0 transition-colors",
+          "flex items-center gap-3 px-3 py-2 border-t-1 bg-df-editor-bg flex-shrink-0 transition-colors",
           isFocused ? "border-t-[var(--color-df-info)]" : "border-t-df-control-border"
         )}>
           <div className="flex items-center gap-2">
@@ -435,7 +444,12 @@ function ForgeNarrativeGraphEditorContent({
               <Focus size={14} style={{ color: 'var(--color-df-info)' }} />
             )}
           </div>
-          <div className="flex items-center gap-2">
+          <GraphEditorStatusBar
+            validation={validation}
+            uncommittedChangeCount={uncommittedChangeCount}
+            className="flex-1"
+          />
+          <div className="ml-auto flex items-center gap-2">
             <GraphEditorToolbar 
               scope="narrative" 
               onCreateNew={async () => {

--- a/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphEditorStatusBar.tsx
+++ b/src/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphEditorStatusBar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import * as React from "react";
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronUp, XCircle } from "lucide-react";
+
+import { cn } from "@/shared/lib/utils";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/shared/ui/collapsible";
+import type { GraphValidationResult } from "@/forge/lib/graph-validation";
+
+type GraphEditorStatusBarProps = {
+  validation: GraphValidationResult | null;
+  uncommittedChangeCount: number;
+  className?: string;
+};
+
+type ValidationStatus = "valid" | "warning" | "error";
+
+const STATUS_ICONS: Record<ValidationStatus, typeof CheckCircle2> = {
+  valid: CheckCircle2,
+  warning: AlertTriangle,
+  error: XCircle,
+};
+
+const STATUS_ICON_CLASSES: Record<ValidationStatus, string> = {
+  valid: "text-emerald-400",
+  warning: "text-yellow-400",
+  error: "text-red-400",
+};
+
+export function GraphEditorStatusBar({
+  validation,
+  uncommittedChangeCount,
+  className,
+}: GraphEditorStatusBarProps) {
+  const errorCount = validation?.errors.length ?? 0;
+  const warningCount = validation?.warnings.length ?? 0;
+  const hasIssues = errorCount + warningCount > 0;
+
+  const status: ValidationStatus = errorCount > 0 ? "error" : warningCount > 0 ? "warning" : "valid";
+  const StatusIcon = STATUS_ICONS[status];
+
+  const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!hasIssues && open) {
+      setOpen(false);
+    }
+  }, [hasIssues, open]);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className={cn("relative", className)}>
+      <div className="flex w-full items-center justify-center gap-2 text-xs text-df-text-secondary">
+        <StatusIcon className={cn("h-4 w-4", STATUS_ICON_CLASSES[status])} />
+        <span className="font-semibold text-df-text-primary">Validation</span>
+        <span className="text-red-400">Errors: {errorCount}</span>
+        <span className="text-yellow-400">Warnings: {warningCount}</span>
+        <span className="text-df-text-muted">Changes: {uncommittedChangeCount}</span>
+        {hasIssues && (
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="ml-1 inline-flex items-center gap-1 rounded border border-df-control-border px-2 py-0.5 text-[11px] text-df-text-secondary transition hover:text-df-text-primary"
+              aria-label={open ? "Collapse validation issues" : "Expand validation issues"}
+            >
+              {open ? "Hide" : "Show"} issues
+              {open ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+            </button>
+          </CollapsibleTrigger>
+        )}
+      </div>
+      {hasIssues && (
+        <CollapsibleContent className="absolute left-0 top-full z-20 mt-2 w-[360px] rounded-md border border-df-control-border bg-df-editor-bg p-3 shadow-lg">
+          {errorCount > 0 && (
+            <div className="mb-3">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-red-400">Errors</p>
+              <ul className="mt-2 space-y-1 text-xs text-df-text-secondary">
+                {validation?.errors.map((issue, index) => (
+                  <li key={`error-${issue.type}-${index}`} className="flex gap-2">
+                    <span className="mt-0.5 h-2 w-2 rounded-full bg-red-400" />
+                    <span>{issue.message}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {warningCount > 0 && (
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-yellow-400">Warnings</p>
+              <ul className="mt-2 space-y-1 text-xs text-df-text-secondary">
+                {validation?.warnings.map((issue, index) => (
+                  <li key={`warning-${issue.type}-${index}`} className="flex gap-2">
+                    <span className="mt-0.5 h-2 w-2 rounded-full bg-yellow-400" />
+                    <span>{issue.message}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </CollapsibleContent>
+      )}
+    </Collapsible>
+  );
+}


### PR DESCRIPTION
### Motivation
- Surface graph validation state and draft change counts in the graph editor toolbar so authors see errors/warnings and pending edits at-a-glance.
- Provide a quick click-to-expand errors/warnings list following existing UI patterns (`Collapsible`) so users can inspect issues without opening separate panels.

### Description
- Added a new component `src/forge/components/ForgeWorkspace/components/GraphEditors/shared/GraphEditorStatusBar.tsx` that renders a validation icon (valid/warn/error), error and warning counts, uncommitted change count, and a collapsible issues list using the shared `Collapsible` UI.
- Integrated the status bar into the narrative editor toolbar in `src/forge/components/ForgeWorkspace/components/GraphEditors/ForgeNarrativeGraphEditor/ForgeNarrativeGraphEditor.tsx` placing it between breadcrumbs and action buttons and wired it to workspace store state.
- The status bar reads `validation` and `deltas` from the workspace store (via `useForgeWorkspaceStore` + `useShallow`) to compute `errorCount`, `warningCount`, and `uncommittedChangeCount` and uses `lucide-react` icons and existing CSS utility classes for styling.
- Click-to-expand issue list is implemented with `Collapsible`, showing separate lists for errors and warnings and automatically collapsing when there are no issues.

### Testing
- Attempted a full build with `npm run build`; the build fails due to missing optional/host dependencies (errors: missing `sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, etc.), so the new component compiles locally in the repo context but the Next.js production build could not complete because external packages required by the demo app are not installed.
- No new unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766dbfe378832da437da7416c79aef)