### PR TITLE
Handle pending page creation on draft commit

### DIFF
--- a/src/forge/components/ForgeWorkspace/store/slices/draft.slice.ts
+++ b/src/forge/components/ForgeWorkspace/store/slices/draft.slice.ts
@@ -3,6 +3,9 @@ import type { StateCreator } from "zustand"
 import type { ForgeGraphDoc } from "@/forge/types"
 import { validateNarrativeGraph, type GraphValidationResult } from "@/forge/lib/graph-validation"
 import { calculateDelta } from "@/shared/lib/draft/draft-helpers"
+import type { DraftPendingPageCreation } from "@/shared/types/draft"
+import type { ForgeNode } from "@/forge/types/forge-graph"
+import { PAGE_TYPE, type ForgePage } from "@/forge/types/narrative"
 import { createDraftSlice, type DraftSlice } from "@/shared/store/draft-slice"
 import type { ForgeWorkspaceState } from "../forge-workspace-store"
 
@@ -15,8 +18,83 @@ export function createForgeDraftSlice(
   get: Parameters<StateCreator<ForgeWorkspaceState, [], [], ForgeWorkspaceState>>[1],
   initialGraph?: ForgeGraphDoc | null
 ): ForgeDraftSlice {
+  const resolvePendingPageCreations = (deltas: ForgeDraftDelta[]): DraftPendingPageCreation[] => {
+    const latestDelta = deltas[deltas.length - 1]
+    return latestDelta?.pendingPageCreations ?? []
+  }
+
+  const patchGraphWithPageIds = (
+    graph: ForgeGraphDoc,
+    createdPages: Map<string, ForgePage>
+  ): ForgeGraphDoc => {
+    if (!createdPages.size) {
+      return graph
+    }
+
+    return {
+      ...graph,
+      flow: {
+        ...graph.flow,
+        nodes: graph.flow.nodes.map((node) => {
+          const createdPage = createdPages.get(node.id)
+          if (!createdPage) {
+            return node
+          }
+          const nodeData = (node.data ?? {}) as ForgeNode
+          return {
+            ...node,
+            data: {
+              ...nodeData,
+              pageId: createdPage.id,
+            },
+          }
+        }),
+      },
+    }
+  }
+
   return createDraftSlice<ForgeDraftSlice, ForgeGraphDoc, ForgeDraftDelta, GraphValidationResult>(set, get, {
     initialGraph: initialGraph ?? null,
     validateDraft: (draft) => validateNarrativeGraph(draft),
+    onCommitDraft: async (draft, deltas) => {
+      const dataAdapter = get().dataAdapter
+      if (!dataAdapter) {
+        return draft
+      }
+
+      const pendingPageCreations = resolvePendingPageCreations(deltas)
+      const createdPages = new Map<string, ForgePage>()
+      const pageTypeOrder = [PAGE_TYPE.ACT, PAGE_TYPE.CHAPTER, PAGE_TYPE.PAGE]
+
+      for (const pageType of pageTypeOrder) {
+        const creations = pendingPageCreations.filter((creation) => creation.pageType === pageType)
+        for (const creation of creations) {
+          const parentId =
+            creation.parentPageId ??
+            (creation.parentNodeId ? createdPages.get(creation.parentNodeId)?.id ?? null : null)
+
+          const page = await dataAdapter.createPage({
+            projectId: creation.projectId,
+            pageType: creation.pageType,
+            title: creation.title,
+            order: creation.order,
+            parent: parentId ?? null,
+          })
+          createdPages.set(creation.nodeId, page)
+        }
+      }
+
+      const nextDraft = patchGraphWithPageIds(draft, createdPages)
+
+      const persistedGraph = await dataAdapter.updateGraph(nextDraft.id, {
+        title: nextDraft.title,
+        flow: nextDraft.flow,
+        startNodeId: nextDraft.startNodeId,
+        endNodeIds: nextDraft.endNodeIds,
+        compiledYarn: nextDraft.compiledYarn ?? null,
+      })
+
+      return persistedGraph
+    },
   })
 }


### PR DESCRIPTION
### Motivation
- Defer creating ACT/CHAPTER/PAGE backend pages from immediate node creation to the draft commit workflow so page creation is atomic and tied to commits.
- Ensure newly added narrative nodes are represented as `pendingPageCreations` in the draft delta and created in a deterministic order during commit.

### Description
- Added `onCommitDraft` hook to the Forge draft slice to process pending page creations found in the latest draft deltas.  The hook is wired via `createDraftSlice` configuration. 
- Implemented `resolvePendingPageCreations` to read pending creations from deltas and `patchGraphWithPageIds` to update draft nodes with created `pageId`s. 
- During commit, the code creates pages via the workspace `dataAdapter.createPage` in the order `ACT`, `CHAPTER`, `PAGE`, patches the draft nodes with resulting `pageId`s, and then persists the graph via `dataAdapter.updateGraph`.
- Added necessary imports and types (`DraftPendingPageCreation`, `ForgeNode`, `PAGE_TYPE`, `ForgePage`) to `src/forge/components/ForgeWorkspace/store/slices/draft.slice.ts`.

### Testing
- Ran `npm run build` to validate the change; the build did not complete due to unrelated environment/missing dependency issues: missing `sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, and an export mismatch for `zustand/shallow`, so the change itself could not be fully end-to-end verified in this environment.  No unit tests were added or executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697676243138832db785f52da5268fbf)