### PR TITLE
Add writer narrative draft pipeline

### DIFF
--- a/src/writer/components/WriterWorkspace/store/slices/draft.slice.ts
+++ b/src/writer/components/WriterWorkspace/store/slices/draft.slice.ts
@@ -1,0 +1,102 @@
+import type { StateCreator } from 'zustand';
+
+import type { ForgeGraphDoc, ForgeNode } from '@/shared/types/forge-graph';
+import { validateNarrativeGraph, type GraphValidationResult } from '@/shared/lib/graph-validation';
+import { calculateDelta } from '@/shared/lib/draft/draft-helpers';
+import type { DraftPendingPageCreation } from '@/shared/types/draft';
+import { PAGE_TYPE, type ForgePage } from '@/shared/types/narrative';
+import { createDraftSlice, type DraftSlice } from '@/shared/store/draft-slice';
+import type { WriterWorkspaceState } from '../writer-workspace-store';
+
+export type WriterDraftDelta = ReturnType<typeof calculateDelta>;
+
+export type WriterDraftSlice = DraftSlice<ForgeGraphDoc, WriterDraftDelta, GraphValidationResult>;
+
+export function createWriterDraftSlice(
+  set: Parameters<StateCreator<WriterWorkspaceState, [], [], WriterWorkspaceState>>[0],
+  get: Parameters<StateCreator<WriterWorkspaceState, [], [], WriterWorkspaceState>>[1],
+  initialGraph?: ForgeGraphDoc | null
+): WriterDraftSlice {
+  const resolvePendingPageCreations = (deltas: WriterDraftDelta[]): DraftPendingPageCreation[] => {
+    const latestDelta = deltas[deltas.length - 1];
+    return latestDelta?.pendingPageCreations ?? [];
+  };
+
+  const patchGraphWithPageIds = (
+    graph: ForgeGraphDoc,
+    createdPages: Map<string, ForgePage>
+  ): ForgeGraphDoc => {
+    if (!createdPages.size) {
+      return graph;
+    }
+
+    return {
+      ...graph,
+      flow: {
+        ...graph.flow,
+        nodes: graph.flow.nodes.map((node) => {
+          const createdPage = createdPages.get(node.id);
+          if (!createdPage) {
+            return node;
+          }
+          const nodeData = (node.data ?? {}) as ForgeNode;
+          return {
+            ...node,
+            data: {
+              ...nodeData,
+              pageId: createdPage.id,
+            },
+          };
+        }),
+      },
+    };
+  };
+
+  return createDraftSlice<WriterDraftSlice, ForgeGraphDoc, WriterDraftDelta, GraphValidationResult>(set, get, {
+    initialGraph: initialGraph ?? null,
+    validateDraft: (draft) => validateNarrativeGraph(draft),
+    onCommitDraft: async (draft, deltas) => {
+      const dataAdapter = get().dataAdapter;
+      const forgeDataAdapter = get().forgeDataAdapter;
+      if (!forgeDataAdapter) {
+        return draft;
+      }
+
+      const pendingPageCreations = resolvePendingPageCreations(deltas);
+      const createdPages = new Map<string, ForgePage>();
+      const pageTypeOrder = [PAGE_TYPE.ACT, PAGE_TYPE.CHAPTER, PAGE_TYPE.PAGE];
+
+      if (dataAdapter && pendingPageCreations.length > 0) {
+        for (const pageType of pageTypeOrder) {
+          const creations = pendingPageCreations.filter((creation) => creation.pageType === pageType);
+          for (const creation of creations) {
+            const parentId =
+              creation.parentPageId ??
+              (creation.parentNodeId ? createdPages.get(creation.parentNodeId)?.id ?? null : null);
+
+            const page = await dataAdapter.createPage({
+              projectId: creation.projectId,
+              pageType: creation.pageType,
+              title: creation.title,
+              order: creation.order,
+              parent: parentId ?? null,
+            });
+            createdPages.set(creation.nodeId, page);
+          }
+        }
+      }
+
+      const nextDraft = patchGraphWithPageIds(draft, createdPages);
+
+      const persistedGraph = await forgeDataAdapter.updateGraph(nextDraft.id, {
+        title: nextDraft.title,
+        flow: nextDraft.flow,
+        startNodeId: nextDraft.startNodeId,
+        endNodeIds: nextDraft.endNodeIds,
+        compiledYarn: nextDraft.compiledYarn ?? null,
+      });
+
+      return persistedGraph;
+    },
+  });
+}

--- a/src/writer/components/WriterWorkspace/store/slices/subscriptions.ts
+++ b/src/writer/components/WriterWorkspace/store/slices/subscriptions.ts
@@ -45,8 +45,8 @@ export function setupWriterWorkspaceSubscriptions(
   // Subscribe to narrative graph changes and sync hierarchy
   domainStore.subscribe(
     async (state, prevState) => {
-      const narrativeGraph = state.narrativeGraph;
-      const prevNarrativeGraph = prevState.narrativeGraph;
+      const narrativeGraph = state.draftGraph ?? state.narrativeGraph;
+      const prevNarrativeGraph = prevState.draftGraph ?? prevState.narrativeGraph;
       
       // Only process if graph actually changed
       if (narrativeGraph === prevNarrativeGraph) return;
@@ -75,7 +75,7 @@ export function setupWriterWorkspaceSubscriptions(
   // Subscribe to pages changes to rebuild hierarchy if graph exists
   domainStore.subscribe(
     async (state, prevState) => {
-      const narrativeGraph = state.narrativeGraph;
+      const narrativeGraph = state.draftGraph ?? state.narrativeGraph;
       if (!narrativeGraph || !dataAdapter) return;
       
       // Rebuild hierarchy when pages change

--- a/src/writer/components/WriterWorkspace/store/writer-workspace-types.ts
+++ b/src/writer/components/WriterWorkspace/store/writer-workspace-types.ts
@@ -116,5 +116,11 @@ export interface WriterWorkspaceState {
   selectedNarrativeGraphId: number | null;
   narrativeGraph: ForgeGraphDoc | null;
   narrativeHierarchy: NarrativeHierarchy | null;
+  committedGraph: ForgeGraphDoc | null;
+  draftGraph: ForgeGraphDoc | null;
+  deltas: unknown[];
+  validation: unknown | null;
+  hasUncommittedChanges: boolean;
+  lastCommittedAt: Date | null;
   actions: Record<string, unknown>;
 }


### PR DESCRIPTION
### Motivation

- Provide a unified draft pipeline for Writer narrative graphs by reusing the existing shared draft helpers to mirror Forge behavior. 
- Keep the Writer workspace graph state consistent with draft lifecycle so graph edits can be staged, validated, and committed atomically with page creation. 

### Description

- Add `src/writer/components/WriterWorkspace/store/slices/draft.slice.ts` implementing `createWriterDraftSlice` which wraps the shared `createDraftSlice` and commits pending page creations before persisting the graph via the forge adapter. 
- Wire the writer store to include draft state and actions by importing and composing `createWriterDraftSlice` in `src/writer/components/WriterWorkspace/store/writer-workspace-store.tsx`, exposing `committedGraph`, `draftGraph`, `applyDelta`, `commitDraft`, `discardDraft`, `resetDraft`, `getDraftGraph`, and `getCommittedGraph`, and resetting the draft when the active narrative graph changes or is created. 
- Route graph mutations through the draft pipeline by updating `useGraphPageSync` (`src/writer/hooks/use-graph-page-sync.ts`) to build an `updatedGraph` and either apply a draft delta + commit (if draft pipeline is present) or fallback to calling `forgeDataAdapter.updateGraph` directly. 
- Update the Writer UI sync points (`WriterTree.tsx` and `subscriptions.ts`) to use an `effectiveGraph` (preferring `draftGraph`), and to apply deltas + commit when renaming, deleting or creating nodes, ensuring the narrative hierarchy sync uses the draft state; also add type updates in `writer-workspace-types.ts`. 

### Testing

- Ran `npm run build` to validate changes, but the Next.js build failed due to unrelated environment/missing dependencies: missing `sass`, missing modules `@ai-sdk/openai` and `@copilotkit/react-core`, and a `zustand` import/export mismatch (`useShallow`), so the build could not complete. 
- No new unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a9705b60832dbb42935222934df1)