### PR TITLE
Add draft tracking to Video Template Workspace

### DIFF
--- a/src/video/workspace/components/LayerList.tsx
+++ b/src/video/workspace/components/LayerList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { DraftDeltaIds } from '@/shared/types/draft';
 import type { VideoLayer } from '@/video/templates/types/video-layer';
 import { Badge } from '@/shared/ui/badge';
 import { Button } from '@/shared/ui/button';
@@ -8,13 +9,19 @@ import { cn } from '@/shared/lib/utils';
 interface LayerListProps {
   layers?: VideoLayer[];
   activeLayerId?: string;
+  draftLayerIds?: DraftDeltaIds;
   onSelectLayer?: (layerId: string) => void;
   onAddLayer?: () => void;
 }
 
-export function LayerList({ layers, activeLayerId, onSelectLayer, onAddLayer }: LayerListProps) {
+export function LayerList({ layers, activeLayerId, draftLayerIds, onSelectLayer, onAddLayer }: LayerListProps) {
   const hasBinding = layers !== undefined;
   const totalLayers = layers?.length ?? 0;
+  const draftIds = new Set<string>([
+    ...(draftLayerIds?.added ?? []),
+    ...(draftLayerIds?.updated ?? []),
+    ...(draftLayerIds?.removed ?? []),
+  ]);
 
   return (
     <Card className="h-full border-[var(--video-workspace-border)] bg-[var(--video-workspace-panel)]">
@@ -47,6 +54,7 @@ export function LayerList({ layers, activeLayerId, onSelectLayer, onAddLayer }: 
           <div className="flex flex-col gap-2">
             {layers?.map((layer, index) => {
               const isActive = layer.id === activeLayerId;
+              const isDraft = draftIds.has(layer.id);
               return (
                 <Button
                   key={layer.id}
@@ -61,7 +69,12 @@ export function LayerList({ layers, activeLayerId, onSelectLayer, onAddLayer }: 
                   <span className="truncate text-[var(--video-workspace-text)]">
                     {layer.name || `Layer ${index + 1}`}
                   </span>
-                  <span className="text-[10px] text-[var(--video-workspace-text-muted)]">
+                  <span className="flex items-center gap-2 text-[10px] text-[var(--video-workspace-text-muted)]">
+                    {isDraft ? (
+                      <Badge variant="secondary" className="px-1 text-[9px]">
+                        Draft
+                      </Badge>
+                    ) : null}
                     {layer.opacity !== undefined ? `${Math.round(layer.opacity * 100)}%` : '100%'}
                   </span>
                 </Button>

--- a/src/video/workspace/components/SceneList.tsx
+++ b/src/video/workspace/components/SceneList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { DraftDeltaIds } from '@/shared/types/draft';
 import type { VideoScene } from '@/video/templates/types/video-scene';
 import { Badge } from '@/shared/ui/badge';
 import { Button } from '@/shared/ui/button';
@@ -8,13 +9,19 @@ import { cn } from '@/shared/lib/utils';
 interface SceneListProps {
   scenes?: VideoScene[];
   activeSceneId?: string;
+  draftSceneIds?: DraftDeltaIds;
   onSelectScene?: (sceneId: string) => void;
   onAddScene?: () => void;
 }
 
-export function SceneList({ scenes, activeSceneId, onSelectScene, onAddScene }: SceneListProps) {
+export function SceneList({ scenes, activeSceneId, draftSceneIds, onSelectScene, onAddScene }: SceneListProps) {
   const hasBinding = scenes !== undefined;
   const totalScenes = scenes?.length ?? 0;
+  const draftIds = new Set<string>([
+    ...(draftSceneIds?.added ?? []),
+    ...(draftSceneIds?.updated ?? []),
+    ...(draftSceneIds?.removed ?? []),
+  ]);
 
   return (
     <Card className="h-full border-[var(--video-workspace-border)] bg-[var(--video-workspace-panel)]">
@@ -47,6 +54,7 @@ export function SceneList({ scenes, activeSceneId, onSelectScene, onAddScene }: 
           <div className="flex flex-col gap-2">
             {scenes?.map((scene, index) => {
               const isActive = scene.id === activeSceneId;
+              const isDraft = draftIds.has(scene.id);
               return (
                 <Button
                   key={scene.id}
@@ -61,7 +69,12 @@ export function SceneList({ scenes, activeSceneId, onSelectScene, onAddScene }: 
                   <span className="truncate text-[var(--video-workspace-text)]">
                     {scene.name || `Scene ${index + 1}`}
                   </span>
-                  <span className="text-[10px] text-[var(--video-workspace-text-muted)]">
+                  <span className="flex items-center gap-2 text-[10px] text-[var(--video-workspace-text-muted)]">
+                    {isDraft ? (
+                      <Badge variant="secondary" className="px-1 text-[9px]">
+                        Draft
+                      </Badge>
+                    ) : null}
                     {(scene.durationMs / 1000).toFixed(1)}s
                   </span>
                 </Button>

--- a/src/video/workspace/store/video-draft-slice.ts
+++ b/src/video/workspace/store/video-draft-slice.ts
@@ -1,0 +1,161 @@
+import type { StateCreator } from 'zustand';
+import { createStore } from 'zustand/vanilla';
+
+import type { DraftCollectionDelta, DraftDeltaIds } from '@/shared/types/draft';
+import { createDraftSlice, type DraftSlice } from '@/shared/store/draft-slice';
+import type { VideoLayer } from '@/video/templates/types/video-layer';
+import type { VideoScene } from '@/video/templates/types/video-scene';
+import type { VideoTemplate } from '@/video/templates/types/video-template';
+
+const hasSameValue = <T,>(left: T, right: T): boolean => JSON.stringify(left) === JSON.stringify(right);
+
+type EntityWithId = {
+  id?: string | null;
+};
+
+const buildCollectionDelta = <TItem extends EntityWithId>(
+  committed: TItem[],
+  draft: TItem[]
+): DraftCollectionDelta<TItem> => {
+  const committedMap = new Map<string, TItem>();
+  committed.forEach((item) => {
+    if (item.id) {
+      committedMap.set(item.id, item);
+    }
+  });
+
+  const draftMap = new Map<string, TItem>();
+  draft.forEach((item) => {
+    if (item.id) {
+      draftMap.set(item.id, item);
+    }
+  });
+
+  const added: TItem[] = [];
+  const updated: TItem[] = [];
+  const removed: TItem[] = [];
+
+  draftMap.forEach((draftItem, id) => {
+    const committedItem = committedMap.get(id);
+    if (!committedItem) {
+      added.push(draftItem);
+      return;
+    }
+    if (!hasSameValue(committedItem, draftItem)) {
+      updated.push(draftItem);
+    }
+  });
+
+  committedMap.forEach((committedItem, id) => {
+    if (!draftMap.has(id)) {
+      removed.push(committedItem);
+    }
+  });
+
+  return { added, updated, removed };
+};
+
+const buildDeltaIds = <TItem extends EntityWithId>(delta: DraftCollectionDelta<TItem>): DraftDeltaIds => ({
+  added: delta.added.map((item) => item.id ?? '').filter(Boolean),
+  updated: delta.updated.map((item) => item.id ?? '').filter(Boolean),
+  removed: delta.removed.map((item) => item.id ?? '').filter(Boolean),
+});
+
+const buildSceneMap = (scenes: VideoScene[]): Map<string, VideoScene> => {
+  const map = new Map<string, VideoScene>();
+  scenes.forEach((scene) => {
+    if (scene.id) {
+      map.set(scene.id, scene);
+    }
+  });
+  return map;
+};
+
+export type VideoTemplateDraftDelta = {
+  scenes: DraftCollectionDelta<VideoScene>;
+  layersByScene: Record<string, DraftCollectionDelta<VideoLayer>>;
+  sceneIds: DraftDeltaIds;
+  layerIdsByScene: Record<string, DraftDeltaIds>;
+};
+
+export const calculateVideoTemplateDelta = (committed: VideoTemplate, draft: VideoTemplate): VideoTemplateDraftDelta => {
+  const sceneDelta = buildCollectionDelta(committed.scenes, draft.scenes);
+  const sceneIds = buildDeltaIds(sceneDelta);
+
+  const committedSceneMap = buildSceneMap(committed.scenes);
+  const draftSceneMap = buildSceneMap(draft.scenes);
+  const layerIdsByScene: Record<string, DraftDeltaIds> = {};
+  const layersByScene: Record<string, DraftCollectionDelta<VideoLayer>> = {};
+  const allSceneIds = new Set<string>([...committedSceneMap.keys(), ...draftSceneMap.keys()]);
+
+  allSceneIds.forEach((sceneId) => {
+    const committedScene = committedSceneMap.get(sceneId);
+    const draftScene = draftSceneMap.get(sceneId);
+    const committedLayers = committedScene?.layers ?? [];
+    const draftLayers = draftScene?.layers ?? [];
+    const layerDelta = buildCollectionDelta(committedLayers, draftLayers);
+    layersByScene[sceneId] = layerDelta;
+    layerIdsByScene[sceneId] = buildDeltaIds(layerDelta);
+  });
+
+  return {
+    scenes: sceneDelta,
+    layersByScene,
+    sceneIds,
+    layerIdsByScene,
+  };
+};
+
+export type VideoTemplateDraftSlice = DraftSlice<VideoTemplate, VideoTemplateDraftDelta, null> & {
+  updateLayer: (
+    layerId: string,
+    updates: Partial<Pick<VideoLayer, 'startMs' | 'durationMs' | 'opacity'>>
+  ) => void;
+};
+
+export function createVideoDraftSlice(
+  set: Parameters<StateCreator<VideoTemplateDraftSlice, [], [], VideoTemplateDraftSlice>>[0],
+  get: Parameters<StateCreator<VideoTemplateDraftSlice, [], [], VideoTemplateDraftSlice>>[1],
+  initialTemplate?: VideoTemplate | null
+): VideoTemplateDraftSlice {
+  return {
+    ...createDraftSlice<VideoTemplateDraftSlice, VideoTemplate, VideoTemplateDraftDelta, null>(set, get, {
+      initialGraph: initialTemplate ?? null,
+      calculateDelta: calculateVideoTemplateDelta,
+    }),
+    updateLayer: (layerId, updates) => {
+      set((state) => {
+        if (!state.draftGraph || !state.committedGraph) {
+          return state;
+        }
+        const nextDraft: VideoTemplate = {
+          ...state.draftGraph,
+          scenes: state.draftGraph.scenes.map((scene) => {
+            if (!scene.layers.some((layer) => layer.id === layerId)) {
+              return scene;
+            }
+            return {
+              ...scene,
+              layers: scene.layers.map((layer) => (layer.id === layerId ? { ...layer, ...updates } : layer)),
+            };
+          }),
+        };
+
+        const nextDelta = calculateVideoTemplateDelta(state.committedGraph, nextDraft);
+
+        return {
+          draftGraph: nextDraft,
+          deltas: [...state.deltas, nextDelta],
+          hasUncommittedChanges: true,
+        };
+      });
+    },
+  };
+}
+
+export type VideoTemplateDraftStore = ReturnType<typeof createVideoDraftStore>;
+
+export const createVideoDraftStore = (initialTemplate?: VideoTemplate | null) =>
+  createStore<VideoTemplateDraftSlice>()((set, get) => ({
+    ...createVideoDraftSlice(set, get, initialTemplate ?? null),
+  }));


### PR DESCRIPTION
### Motivation
- Introduce local draft tracking for video templates so scene and layer edits can be staged, inspected, and either committed or discarded before persisting upstream.
- Surface visual indicators for draft changes in the UI and allow quick edits to layer timing/opacity without immediately mutating the host template.

### Description
- Add a dedicated draft slice `src/video/workspace/store/video-draft-slice.ts` that computes scene/layer deltas via `calculateVideoTemplateDelta` and exposes `createVideoDraftStore` and an `updateLayer` action.
- Wire the draft store into `src/video/workspace/VideoTemplateWorkspace.tsx` and use a draft-driven `resolvedTemplate` for preview/media resolution, lifecycle syncing when the outer `template` changes, and `commit`/`discard` actions.
- Add small UI integrations: `SceneList` and `LayerList` now accept draft id sets and render a `Draft` badge, and `LayerInspector` adds numeric inputs for `start`, `duration`, and `opacity` which drive `updateLayer` on the draft store.
- Implement `handleCommitDraft` to propagate staged layer edits to the host via the existing `onUpdateLayerStart`, `onUpdateLayerDuration`, and `onUpdateLayerOpacity` callbacks before committing the draft.

### Testing
- Ran `npm run build` to validate integration and bundling, but the build failed due to missing optional/dev environment dependencies (missing `sass`, `@ai-sdk/openai`, `@copilotkit/react-core`, and others), so UI runtime verification could not be completed.
- No new unit tests were added; the change reuses the existing `createDraftSlice` utilities in `src/shared/store/draft-slice.ts` and follows existing patterns used by the writer/forge workspaces, so the behavior should align with established draft handling when the demo app dependencies are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976aca51b3c832dbb3e3a636520ea6c)