### PR TITLE
Enhance narrative graph validation (node/edge-level issues & stable IDs)

### DIFF
--- a/src/shared/lib/graph-validation/narrative-graph-validator.ts
+++ b/src/shared/lib/graph-validation/narrative-graph-validator.ts
@@ -1,12 +1,23 @@
 import type { ForgeGraphDoc } from '@/shared/types/forge-graph';
-import { FORGE_NODE_TYPE } from '@/shared/types/forge-graph';
+import { FORGE_EDGE_KIND, FORGE_NODE_TYPE } from '@/shared/types/forge-graph';
 import { PAGE_TYPE, type PageType } from '@/shared/types/narrative';
 
+type GraphValidationIssueType =
+  | 'orphaned_node'
+  | 'missing_start'
+  | 'disconnected_subgraph'
+  | 'invalid_hierarchy'
+  | 'dangling_edge'
+  | 'invalid_edge_kind';
+
 export type GraphValidationError = {
-  type: 'orphaned_node' | 'missing_start' | 'disconnected_subgraph' | 'invalid_hierarchy';
+  id: string;
+  type: GraphValidationIssueType;
   message: string;
-  nodeIds?: string[];
   severity: 'error' | 'warning';
+  nodeId?: string;
+  edgeId?: string;
+  graphId?: number;
 };
 
 export type GraphValidationResult = {
@@ -15,86 +26,164 @@ export type GraphValidationResult = {
   warnings: GraphValidationError[];
 };
 
+const VALID_EDGE_KINDS = new Set(Object.values(FORGE_EDGE_KIND));
+
+const buildIssueId = (type: GraphValidationIssueType, subjectId: string) => `${type}:${subjectId}`;
+
+const buildFallbackEdgeId = (edge: { source: string; target: string; sourceHandle?: string | null }) => {
+  if (edge.sourceHandle) {
+    return `edge_${edge.source}_${edge.sourceHandle}_${edge.target}`;
+  }
+  return `edge_${edge.source}_${edge.target}`;
+};
+
 export function validateNarrativeGraph(graph: ForgeGraphDoc): GraphValidationResult {
   const errors: GraphValidationError[] = [];
   const warnings: GraphValidationError[] = [];
 
-  // Check 1: Must have at least one node or be explicitly empty
-  const nodes = graph.flow.nodes; // nodes is already an array
+  const nodes = graph.flow.nodes;
+  const edges = graph.flow.edges;
   const nodeCount = nodes.length;
 
   if (nodeCount === 0) {
-    return { valid: true, errors: [], warnings: [] }; // Empty is valid
+    return { valid: true, errors: [], warnings: [] };
   }
 
-  // Check 2: All nodes except start must have incoming edges (no orphans)
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  if (!graph.startNodeId || !nodeIds.has(graph.startNodeId)) {
+    const missingId = graph.startNodeId || `graph-${graph.id}`;
+    errors.push({
+      id: buildIssueId('missing_start', missingId),
+      type: 'missing_start',
+      message: 'Start node is missing or does not exist in the graph',
+      nodeId: graph.startNodeId || missingId,
+      graphId: graph.id,
+      severity: 'error',
+    });
+  }
+
   if (nodeCount > 1) {
-    const nodesWithIncoming = new Set(graph.flow.edges.map((edge) => edge.target));
-    const nodesWithOutgoing = new Set(graph.flow.edges.map((edge) => edge.source));
-    const orphanedNodes = nodes
-      .filter((node) => !nodesWithIncoming.has(node.id) && node.id !== graph.startNodeId)
-      .map((node) => node.id);
+    const nodesWithIncoming = new Set(edges.map((edge) => edge.target));
+    const nodesWithOutgoing = new Set(edges.map((edge) => edge.source));
 
-    if (orphanedNodes.length > 0) {
-      errors.push({
-        type: 'orphaned_node',
-        message: `Found ${orphanedNodes.length} disconnected node(s)`,
-        nodeIds: orphanedNodes,
-        severity: 'error',
-      });
-    }
+    nodes.forEach((node) => {
+      if (node.id === graph.startNodeId) {
+        return;
+      }
 
-    // Check for nodes with no edges at all (completely isolated)
-    const nodesWithNoEdges = nodes
-      .filter(
-        (node) =>
-          !nodesWithIncoming.has(node.id) &&
-          !nodesWithOutgoing.has(node.id) &&
-          node.id !== graph.startNodeId
-      )
-      .map((node) => node.id);
+      const hasIncoming = nodesWithIncoming.has(node.id);
+      const hasOutgoing = nodesWithOutgoing.has(node.id);
 
-    if (nodesWithNoEdges.length > 0) {
-      errors.push({
-        type: 'orphaned_node',
-        message: `Found ${nodesWithNoEdges.length} node(s) with no edges (completely isolated)`,
-        nodeIds: nodesWithNoEdges,
-        severity: 'error',
-      });
-    }
+      if (!hasIncoming && !hasOutgoing) {
+        errors.push({
+          id: buildIssueId('orphaned_node', node.id),
+          type: 'orphaned_node',
+          message: `Node "${node.data?.title || node.id}" is completely isolated`,
+          nodeId: node.id,
+          severity: 'error',
+        });
+      } else if (!hasIncoming) {
+        errors.push({
+          id: buildIssueId('orphaned_node', node.id),
+          type: 'orphaned_node',
+          message: `Node "${node.data?.title || node.id}" has no incoming edges`,
+          nodeId: node.id,
+          severity: 'error',
+        });
+      }
+    });
   }
 
-  // Check 3: Validate hierarchy (Acts → Chapters → Pages)
+  if (graph.startNodeId && nodeIds.has(graph.startNodeId)) {
+    const visited = new Set<string>();
+    const stack = [graph.startNodeId];
+
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current || visited.has(current)) {
+        continue;
+      }
+      visited.add(current);
+      edges
+        .filter((edge) => edge.source === current)
+        .forEach((edge) => {
+          if (nodeIds.has(edge.target)) {
+            stack.push(edge.target);
+          }
+        });
+    }
+
+    nodes.forEach((node) => {
+      if (!visited.has(node.id)) {
+        errors.push({
+          id: buildIssueId('disconnected_subgraph', node.id),
+          type: 'disconnected_subgraph',
+          message: `Node "${node.data?.title || node.id}" is disconnected from the start node`,
+          nodeId: node.id,
+          severity: 'error',
+        });
+      }
+    });
+  }
+
+  edges.forEach((edge) => {
+    const edgeId = edge.id ?? buildFallbackEdgeId(edge);
+    const hasSource = nodeIds.has(edge.source);
+    const hasTarget = nodeIds.has(edge.target);
+
+    if (!hasSource || !hasTarget) {
+      const missingSide = !hasSource ? edge.source : edge.target;
+      errors.push({
+        id: buildIssueId('dangling_edge', edgeId),
+        type: 'dangling_edge',
+        message: `Edge is dangling because node "${missingSide}" is missing`,
+        edgeId,
+        nodeId: missingSide,
+        severity: 'error',
+      });
+    }
+
+    if (!edge.kind || !VALID_EDGE_KINDS.has(edge.kind)) {
+      errors.push({
+        id: buildIssueId('invalid_edge_kind', edgeId),
+        type: 'invalid_edge_kind',
+        message: `Edge has invalid kind "${edge.kind ?? 'unknown'}"`,
+        edgeId,
+        severity: 'error',
+      });
+    }
+  });
+
   const acts = nodes.filter((node) => node.type === FORGE_NODE_TYPE.ACT);
   const chapters = nodes.filter((node) => node.type === FORGE_NODE_TYPE.CHAPTER);
   const pages = nodes.filter((node) => node.type === FORGE_NODE_TYPE.PAGE);
 
-  // Chapters should connect from Acts
   chapters.forEach((chapter) => {
-    const parentEdge = graph.flow.edges.find((edge) => edge.target === chapter.id);
+    const parentEdge = edges.find((edge) => edge.target === chapter.id);
     if (parentEdge) {
       const parent = nodes.find((node) => node.id === parentEdge.source);
       if (parent && parent.type !== FORGE_NODE_TYPE.ACT) {
         warnings.push({
+          id: buildIssueId('invalid_hierarchy', chapter.id),
           type: 'invalid_hierarchy',
           message: `Chapter "${chapter.data?.title || chapter.id}" is not connected to an Act`,
-          nodeIds: [chapter.id],
+          nodeId: chapter.id,
           severity: 'warning',
         });
       }
     }
   });
 
-  // Pages should connect from Chapters
   pages.forEach((page) => {
-    const parentEdge = graph.flow.edges.find((edge) => edge.target === page.id);
+    const parentEdge = edges.find((edge) => edge.target === page.id);
     if (parentEdge) {
       const parent = nodes.find((node) => node.id === parentEdge.source);
       if (parent && parent.type !== FORGE_NODE_TYPE.CHAPTER) {
         warnings.push({
+          id: buildIssueId('invalid_hierarchy', page.id),
           type: 'invalid_hierarchy',
           message: `Page "${page.data?.title || page.id}" is not connected to a Chapter`,
-          nodeIds: [page.id],
+          nodeId: page.id,
           severity: 'warning',
         });
       }
@@ -111,15 +200,14 @@ export function validateNarrativeGraph(graph: ForgeGraphDoc): GraphValidationRes
 export function findLastNodeInHierarchy(graph: ForgeGraphDoc, pageType: PageType): string | null {
   const nodes = Object.values(graph.flow.nodes);
 
-  // Find the deepest/last node to connect new nodes to
-  const targetType = pageType === PAGE_TYPE.ACT
-    ? null // New act connects to previous act or nothing
-    : pageType === PAGE_TYPE.CHAPTER
-    ? FORGE_NODE_TYPE.ACT // Chapters connect to acts
-    : FORGE_NODE_TYPE.CHAPTER; // Pages connect to chapters
+  const targetType =
+    pageType === PAGE_TYPE.ACT
+      ? null
+      : pageType === PAGE_TYPE.CHAPTER
+      ? FORGE_NODE_TYPE.ACT
+      : FORGE_NODE_TYPE.CHAPTER;
 
   if (!targetType) {
-    // For acts, find the last act node
     const acts = nodes.filter((node) => node.type === FORGE_NODE_TYPE.ACT);
     return acts[acts.length - 1]?.id || null;
   }
@@ -130,7 +218,6 @@ export function findLastNodeInHierarchy(graph: ForgeGraphDoc, pageType: PageType
     return null;
   }
 
-  // Find nodes with no outgoing edges of the target type
   const nodesWithChildren = new Set(
     graph.flow.edges
       .map((edge) => nodes.find((node) => node.id === edge.source))


### PR DESCRIPTION
### Motivation

- Improve diagnostic precision so each validation issue includes a stable identifier and a relevant `nodeId` and/or `edgeId` for editor focus actions.
- Add edge-level checks to detect dangling edges and invalid edge kinds so semantic/visual inconsistencies are surfaced earlier.
- Surface graph-level problems (like missing start node) with a stable identifier so draft-level validation can reference the graph itself.

### Description

- Expanded `GraphValidationError` to include `id`, `nodeId?`, `edgeId?`, and `graphId?` and introduced `GraphValidationIssueType` for typed issue kinds.
- Added edge-level validation that flags `dangling_edge` when an edge source/target node is missing and `invalid_edge_kind` when an edge's `kind` is not in `FORGE_EDGE_KIND`.
- Emit graph-level `missing_start` issues with a stable id (`missing_start:<startId|graph-<id>>`) and per-node `orphaned_node` / `disconnected_subgraph` issues with stable ids using `buildIssueId`.
- Kept/updated hierarchical checks (Acts → Chapters → Pages) to attach `nodeId` to warnings and made the validator operate over the graph passed in (works for draft graphs used by the draft slices).

### Testing

- Ran `npm run build` to validate compilation, but the build failed due to missing optional/workspace dependencies (`sass`, `@copilotkit/react-core`, `@ai-sdk/openai`) which are unrelated to the validator changes.
- No unit tests were added or run as part of this change; the validator logic was exercised locally via static inspection and repository-wide references to the validator were verified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976af48fc14832dab78666750405105)