### PR TITLE
Allow editing local video presets without a selected project (disable persistence actions)

### DIFF
--- a/src/video/workspace/VideoTemplateWorkspace.tsx
+++ b/src/video/workspace/VideoTemplateWorkspace.tsx
@@ -42,6 +42,7 @@ interface VideoTemplateWorkspaceProps {
   onTogglePlayback?: () => void;
   onSaveTemplate?: () => void;
   saveDisabled?: boolean;
+  headerNotice?: string;
 }
 
 export function VideoTemplateWorkspace({
@@ -63,6 +64,7 @@ export function VideoTemplateWorkspace({
   onTogglePlayback,
   onSaveTemplate,
   saveDisabled,
+  headerNotice,
 }: VideoTemplateWorkspaceProps) {
   const draftStoreRef = React.useRef<ReturnType<typeof createVideoDraftStore> | null>(null);
   if (!draftStoreRef.current) {
@@ -219,6 +221,11 @@ export function VideoTemplateWorkspace({
             {hasUncommittedChanges ? (
               <Badge variant="secondary" className="text-[11px]">
                 Draft changes
+              </Badge>
+            ) : null}
+            {headerNotice ? (
+              <Badge variant="secondary" className="text-[11px]">
+                {headerNotice}
               </Badge>
             ) : null}
           </div>


### PR DESCRIPTION
### Motivation

- Users should be able to browse and edit built-in/preset video templates even when no project is selected, and only persistence actions should be gated by project selection. 

### Description

- Removed the hard gating UI that returned a “No project selected” card and always render the templates list and `VideoTemplateWorkspace` so presets can be previewed and edited. 
- Kept `makePayloadVideoTemplateAdapter()` usage unchanged so `listTemplates()` still returns `VIDEO_TEMPLATE_PRESETS`. 
- Disabled persistence-related actions when no project is selected by: guarding `handleCreateFromPreset`, `handleDuplicateTemplate`, and `handleSaveTemplate`, and disabling the workspace buttons (`Save`, `New from preset`, `Duplicate template`) via `saveDisabled` and `disabled` props. 
- Added an optional `headerNotice` prop to `VideoTemplateWorkspace` and show a badge reading: “Editing local presets; select a project to save.” when no project is selected. 

### Testing

- Ran `npm run build`; the build step reported a TypeScript compilation failure unrelated to these changes in `src/forge/components/ForgeWorkspace/store/slices/draft.slice.ts` (failure still present). 
- Started the dev server with `npm run dev`; the app compiled and served the `/video` page successfully. 
- Captured a Playwright screenshot of `/video` to verify the workspace renders with the local-presets header badge (screenshot artifact created successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697793d04ea0832d953d6f99a8eb5749)