### PR TITLE
Preview: use null-safe template check and disable Play when unbound

### DIFF
--- a/src/video/workspace/components/Preview.tsx
+++ b/src/video/workspace/components/Preview.tsx
@@ -15,7 +15,7 @@ interface PreviewProps {
 }
 
 export function Preview({ template, isPlaying, onTogglePlayback, resolvedMedia, isMediaLoading }: PreviewProps) {
-  const hasBinding = template !== undefined;
+  const hasBinding = Boolean(template);
   const ratio = template ? `${template.width} / ${template.height}` : undefined;
   const hasTemplate = Boolean(template);
   const hasMedia = Boolean(resolvedMedia?.url);


### PR DESCRIPTION
### Motivation
- Treat a `null` template as unbound so the preview UI (badge and playback controls) accurately reflect when no template is available.

### Description
- Replace `const hasBinding = template !== undefined` with `const hasBinding = Boolean(template)` in `src/video/workspace/components/Preview.tsx`, and ensure the existing `hasBinding` guard is used to disable the Play `Button` and show `Unbound` in the `Badge` when appropriate.

### Testing
- Ran `npm run build`, which failed due to missing optional dependencies (`sass`, `@ai-sdk/openai`, `@copilotkit/react-core`), so the production build could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69779ac0759c832db33cbb76fb4c668e)