### PR TITLE
Add minimal timeline grid visualization

### DIFF
--- a/src/video/workspace/components/Timeline.tsx
+++ b/src/video/workspace/components/Timeline.tsx
@@ -13,6 +13,14 @@ interface TimelineProps {
 
 export function Timeline({ scene, onSplitLayer, onZoomToFit }: TimelineProps) {
   const hasBinding = scene !== undefined;
+  const [zoom, setZoom] = React.useState(1);
+  const durationMs = scene?.durationMs ?? 0;
+  const timelineMarkers = React.useMemo(() => [0, 0.25, 0.5, 0.75, 1], []);
+
+  const handleZoomToFit = () => {
+    setZoom(1);
+    onZoomToFit?.();
+  };
 
   return (
     <Card className="h-full border-[var(--video-workspace-border)] bg-[var(--video-workspace-panel)]">
@@ -27,9 +35,14 @@ export function Timeline({ scene, onSplitLayer, onZoomToFit }: TimelineProps) {
           <Button size="sm" variant="secondary" onClick={onSplitLayer} disabled={!hasBinding}>
             Split
           </Button>
-          <Button size="sm" variant="secondary" onClick={onZoomToFit} disabled={!hasBinding}>
-            Fit
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="secondary" onClick={handleZoomToFit} disabled={!hasBinding}>
+              Fit
+            </Button>
+            <span className="text-[10px] text-[var(--video-workspace-text-muted)]">
+              Zoom {zoom.toFixed(1)}x
+            </span>
+          </div>
         </div>
       </CardHeader>
       <CardContent className="px-4 pb-4">
@@ -41,29 +54,82 @@ export function Timeline({ scene, onSplitLayer, onZoomToFit }: TimelineProps) {
           <div className="space-y-3">
             <div className="flex items-center justify-between text-[11px] text-[var(--video-workspace-text-muted)]">
               <span>Scene duration</span>
-              <span>{(scene.durationMs / 1000).toFixed(2)}s</span>
+              <span>{(durationMs / 1000).toFixed(2)}s</span>
             </div>
-            <div className="space-y-2">
-              {scene.layers.length === 0 ? (
-                <div className="rounded-md border border-dashed border-[var(--video-workspace-border)] bg-[var(--video-workspace-muted)] p-3 text-xs text-[var(--video-workspace-text-muted)]">
-                  No layers on the timeline.
+            <div className="rounded-md border border-[var(--video-workspace-border)] bg-[var(--video-workspace-muted)]">
+              <div className="flex border-b border-[var(--video-workspace-border)] text-[10px] text-[var(--video-workspace-text-muted)]">
+                <div className="w-32 border-r border-[var(--video-workspace-border)] px-3 py-2">
+                  Tracks
                 </div>
-              ) : (
-                scene.layers.map((layer: VideoLayer) => (
+                <div className="flex-1 overflow-x-auto">
                   <div
-                    key={layer.id}
-                    className="flex items-center justify-between rounded-md border border-[var(--video-workspace-border)] bg-[var(--video-workspace-muted)] px-3 py-2 text-xs"
+                    className="relative h-7 min-w-full"
+                    style={{ width: `calc(${zoom} * 100%)` }}
                   >
-                    <span className="text-[var(--video-workspace-text)]">
-                      {layer.name || 'Untitled layer'}
-                    </span>
-                    <span className="text-[10px] text-[var(--video-workspace-text-muted)]">
-                      {(layer.startMs / 1000).toFixed(2)}s →
-                      {layer.durationMs ? ` ${(layer.durationMs / 1000).toFixed(2)}s` : ' end'}
-                    </span>
+                    {timelineMarkers.map((marker) => (
+                      <div
+                        key={marker}
+                        className="absolute top-0 flex h-full -translate-x-1/2 items-center gap-2 text-[10px]"
+                        style={{ left: `${marker * 100}%` }}
+                      >
+                        <span className="h-3 w-px bg-[var(--video-workspace-border)]" />
+                        <span>{(durationMs * marker / 1000).toFixed(1)}s</span>
+                      </div>
+                    ))}
                   </div>
-                ))
-              )}
+                </div>
+              </div>
+              <div className="divide-y divide-[var(--video-workspace-border)]">
+                {scene.layers.length === 0 ? (
+                  <div className="p-3 text-xs text-[var(--video-workspace-text-muted)]">
+                    No layers on the timeline.
+                  </div>
+                ) : (
+                  scene.layers.map((layer: VideoLayer) => {
+                    const startRatio = durationMs ? Math.max(0, layer.startMs / durationMs) : 0;
+                    const durationRatio = durationMs
+                      ? Math.max(0.02, (layer.durationMs ?? 0) / durationMs)
+                      : 0;
+                    const clipWidth = Math.min(1, startRatio + durationRatio) - startRatio;
+                    return (
+                      <div key={layer.id} className="flex items-stretch text-xs">
+                        <div className="w-32 border-r border-[var(--video-workspace-border)] px-3 py-2 text-[var(--video-workspace-text)]">
+                          {layer.name || 'Untitled layer'}
+                        </div>
+                        <div className="flex-1 overflow-x-auto">
+                          <div
+                            className="relative h-12 min-w-full"
+                            style={{ width: `calc(${zoom} * 100%)` }}
+                          >
+                            <div className="absolute inset-0 flex">
+                              {timelineMarkers.map((marker) => (
+                                <div
+                                  key={`grid-${layer.id}-${marker}`}
+                                  className="h-full w-px bg-[var(--video-workspace-border)]"
+                                  style={{ left: `${marker * 100}%`, position: 'absolute' }}
+                                />
+                              ))}
+                            </div>
+                            <div
+                              className="absolute inset-y-2 rounded-md border border-[var(--video-workspace-border)] bg-[var(--video-workspace-panel)] px-2 py-1 text-[10px] text-[var(--video-workspace-text)] shadow-sm"
+                              style={{
+                                left: `${startRatio * 100}%`,
+                                width: `${clipWidth * 100}%`,
+                              }}
+                            >
+                              {(layer.startMs / 1000).toFixed(2)}s →
+                              {layer.durationMs ? ` ${(layer.durationMs / 1000).toFixed(2)}s` : ' end'}
+                            </div>
+                            <div className="absolute inset-y-0 left-0 flex w-px flex-col">
+                              <div className="h-full bg-[var(--video-workspace-accent, #38bdf8)]" />
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
             </div>
           </div>
         ) : (


### PR DESCRIPTION
### Motivation
- Provide a visually-oriented, video-editing style timeline so scenes display tracks, clips and timing in the workspace.
- Make the existing `Fit` control meaningfully affect timeline scale so the control connects to visible timeline behavior.

### Description
- Implemented a timeline grid that renders track rows for `scene.layers` with a labeled left rail and a scrollable timeline area in `src/video/workspace/components/Timeline.tsx`.
- Rendered clip blocks positioned by `layer.startMs` and sized by `layer.durationMs` relative to `scene.durationMs`, and added a simple vertical playhead indicator and horizontal time markers (0 → scene duration).
- Added local zoom state and wired the `Fit` button to `handleZoomToFit` which resets zoom and calls the `onZoomToFit` prop, and exposed a small `Zoom X.x` indicator in the header.
- Kept empty / unbound states and preserved existing controls and styling via the shared UI primitives (`Badge`, `Button`, `Card`).

### Testing
- Ran `npm run build`, which failed due to missing optional environment dependencies (`sass`, `@ai-sdk/openai`, `@copilotkit/react-core`) and stopped the production build; this is unrelated to the timeline change.
- Started the dev server (`npm run dev`) and executed a Playwright smoke script that visited `/video` and produced a screenshot demonstrating the timeline UI (screenshot produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977aa59d9c0832d9551536b916c49c3)