### PR TITLE
Add copilot actions for video workspace layers and templates

### DIFF
--- a/app/(video)/video/copilot/actions.ts
+++ b/app/(video)/video/copilot/actions.ts
@@ -1,10 +1,18 @@
 import type { FrontendAction } from '@copilotkit/react-core';
 import type { Parameter } from '@copilotkit/shared';
+import { TEMPLATE_INPUT_KEY, type TemplateInputKey } from '@/shared/types/bindings';
 
 export const VIDEO_WORKSPACE_ACTION = {
   ADD_SCENE: 'video.workspace.addScene',
+  ADD_LAYER: 'video.workspace.addLayer',
+  DELETE_SCENE: 'video.workspace.deleteScene',
   DELETE_LAYER: 'video.workspace.deleteLayer',
+  DUPLICATE_SCENE: 'video.workspace.duplicateScene',
+  UPDATE_LAYER_TIMING: 'video.workspace.updateLayerTiming',
+  UPDATE_LAYER_OPACITY: 'video.workspace.updateLayerOpacity',
+  BIND_LAYER_INPUT: 'video.workspace.bindLayerInput',
   SET_DURATION: 'video.workspace.setDuration',
+  SET_TEMPLATE_METADATA: 'video.workspace.setTemplateMetadata',
   RENAME_TEMPLATE: 'video.workspace.renameTemplate',
   LOAD_PRESET: 'video.workspace.loadPreset',
   EXPORT: 'video.workspace.export',
@@ -16,16 +24,32 @@ export type VideoWorkspaceDurationTarget = 'scene' | 'layer';
 
 export interface VideoWorkspaceActionHandlers {
   addScene: (options?: { durationMs?: number }) => void;
+  addLayer: (options?: { sceneId?: string }) => void;
+  deleteScene: (sceneId: string) => void;
   deleteLayer: (layerId: string) => void;
+  duplicateScene: (sceneId: string) => void;
+  updateLayerTiming: (payload: { layerId?: string; startMs?: number; durationMs?: number }) => void;
+  updateLayerOpacity: (payload: { layerId?: string; opacity: number }) => void;
+  bindLayerInput: (payload: { layerId?: string; inputName: string; bindingKey: TemplateInputKey }) => void;
   setDuration: (payload: { durationMs: number; target?: VideoWorkspaceDurationTarget; id?: string }) => void;
+  setTemplateMetadata: (metadata: { name?: string; width?: number; height?: number; frameRate?: number }) => void;
   renameTemplate: (name: string) => void;
   loadPreset: (presetId: string) => void;
   exportVideo: () => void | Promise<void>;
 }
 
+const TEMPLATE_INPUT_KEYS = new Set<TemplateInputKey>(Object.values(TEMPLATE_INPUT_KEY));
+
 export function createVideoWorkspaceActions(
   handlers: VideoWorkspaceActionHandlers
 ): [
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
+  FrontendAction<Parameter[]>,
   FrontendAction<Parameter[]>,
   FrontendAction<Parameter[]>,
   FrontendAction<Parameter[]>,
@@ -51,6 +75,45 @@ export function createVideoWorkspaceActions(
     },
   };
 
+  const addLayerAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.ADD_LAYER,
+    description: 'Add a new layer to the current scene (or a specified scene) in the video template.',
+    parameters: [
+      {
+        name: 'sceneId',
+        type: 'string',
+        description: 'Optional scene ID to add the layer into. Uses the active scene if omitted.',
+        required: false,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const sceneId = typeof args.sceneId === 'string' && args.sceneId.trim().length > 0 ? args.sceneId : undefined;
+      handlers.addLayer({ sceneId });
+      return { success: true, sceneId };
+    },
+  };
+
+  const deleteSceneAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.DELETE_SCENE,
+    description: 'Delete a scene from the current template using the scene ID.',
+    parameters: [
+      {
+        name: 'sceneId',
+        type: 'string',
+        description: 'The ID of the scene to delete.',
+        required: true,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const sceneId = args.sceneId as string;
+      if (!sceneId) {
+        throw new Error('sceneId is required');
+      }
+      handlers.deleteScene(sceneId);
+      return { success: true, sceneId };
+    },
+  };
+
   const deleteLayerAction: FrontendAction<Parameter[]> = {
     name: VIDEO_WORKSPACE_ACTION.DELETE_LAYER,
     description: 'Delete a layer from the current template using the layer ID.',
@@ -69,6 +132,132 @@ export function createVideoWorkspaceActions(
       }
       handlers.deleteLayer(layerId);
       return { success: true, layerId };
+    },
+  };
+
+  const duplicateSceneAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.DUPLICATE_SCENE,
+    description: 'Duplicate a scene (including its layers) using the scene ID.',
+    parameters: [
+      {
+        name: 'sceneId',
+        type: 'string',
+        description: 'The ID of the scene to duplicate.',
+        required: true,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const sceneId = args.sceneId as string;
+      if (!sceneId) {
+        throw new Error('sceneId is required');
+      }
+      handlers.duplicateScene(sceneId);
+      return { success: true, sceneId };
+    },
+  };
+
+  const updateLayerTimingAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.UPDATE_LAYER_TIMING,
+    description: 'Update a layer start time and/or duration in milliseconds.',
+    parameters: [
+      {
+        name: 'layerId',
+        type: 'string',
+        description: 'Optional layer ID to update. Uses the active layer if omitted.',
+        required: false,
+      },
+      {
+        name: 'startMs',
+        type: 'number',
+        description: 'Optional start time in milliseconds.',
+        required: false,
+      },
+      {
+        name: 'durationMs',
+        type: 'number',
+        description: 'Optional duration in milliseconds.',
+        required: false,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const startMs = typeof args.startMs === 'number' ? args.startMs : undefined;
+      const durationMs = typeof args.durationMs === 'number' ? args.durationMs : undefined;
+      if (startMs === undefined && durationMs === undefined) {
+        throw new Error('startMs or durationMs is required');
+      }
+      const layerId = typeof args.layerId === 'string' && args.layerId.trim().length > 0 ? args.layerId : undefined;
+      handlers.updateLayerTiming({ layerId, startMs, durationMs });
+      return { success: true, layerId, startMs, durationMs };
+    },
+  };
+
+  const updateLayerOpacityAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.UPDATE_LAYER_OPACITY,
+    description: 'Update a layer opacity using a value from 0 to 1 (or 0 to 100 for percent).',
+    parameters: [
+      {
+        name: 'layerId',
+        type: 'string',
+        description: 'Optional layer ID to update. Uses the active layer if omitted.',
+        required: false,
+      },
+      {
+        name: 'opacity',
+        type: 'number',
+        description: 'Opacity between 0 and 1 (or 0 to 100 for percent).',
+        required: true,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const opacityValue = args.opacity as number;
+      if (opacityValue === undefined || Number.isNaN(opacityValue)) {
+        throw new Error('opacity is required');
+      }
+      const normalizedOpacity = opacityValue > 1 && opacityValue <= 100 ? opacityValue / 100 : opacityValue;
+      if (normalizedOpacity < 0 || normalizedOpacity > 1 || Number.isNaN(normalizedOpacity)) {
+        throw new Error('opacity must be between 0 and 1');
+      }
+      const layerId = typeof args.layerId === 'string' && args.layerId.trim().length > 0 ? args.layerId : undefined;
+      handlers.updateLayerOpacity({ layerId, opacity: normalizedOpacity });
+      return { success: true, layerId, opacity: normalizedOpacity };
+    },
+  };
+
+  const bindLayerInputAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.BIND_LAYER_INPUT,
+    description: 'Bind a layer input name to a template input key.',
+    parameters: [
+      {
+        name: 'layerId',
+        type: 'string',
+        description: 'Optional layer ID to update. Uses the active layer if omitted.',
+        required: false,
+      },
+      {
+        name: 'inputName',
+        type: 'string',
+        description: 'The layer input name to bind (e.g., "image" or "background").',
+        required: true,
+      },
+      {
+        name: 'bindingKey',
+        type: 'string',
+        description: 'The template input key to bind (e.g., "node.background").',
+        required: true,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const inputName = typeof args.inputName === 'string' ? args.inputName.trim() : '';
+      if (!inputName) {
+        throw new Error('inputName is required');
+      }
+      const bindingKey = args.bindingKey as TemplateInputKey;
+      if (!bindingKey || !TEMPLATE_INPUT_KEYS.has(bindingKey)) {
+        throw new Error('bindingKey must be a valid template input key');
+      }
+      const layerId = typeof args.layerId === 'string' && args.layerId.trim().length > 0 ? args.layerId : undefined;
+      handlers.bindLayerInput({ layerId, inputName, bindingKey });
+      return { success: true, layerId, inputName, bindingKey };
     },
   };
 
@@ -104,6 +293,57 @@ export function createVideoWorkspaceActions(
       const id = args.id as string | undefined;
       handlers.setDuration({ durationMs, target, id });
       return { success: true, durationMs, target, id };
+    },
+  };
+
+  const setTemplateMetadataAction: FrontendAction<Parameter[]> = {
+    name: VIDEO_WORKSPACE_ACTION.SET_TEMPLATE_METADATA,
+    description: 'Update template metadata such as name, width, height, or frame rate.',
+    parameters: [
+      {
+        name: 'name',
+        type: 'string',
+        description: 'Optional template name.',
+        required: false,
+      },
+      {
+        name: 'width',
+        type: 'number',
+        description: 'Optional template width in pixels.',
+        required: false,
+      },
+      {
+        name: 'height',
+        type: 'number',
+        description: 'Optional template height in pixels.',
+        required: false,
+      },
+      {
+        name: 'frameRate',
+        type: 'number',
+        description: 'Optional template frame rate.',
+        required: false,
+      },
+    ] as Parameter[],
+    handler: async (args: { [x: string]: unknown }) => {
+      const nextMetadata: { name?: string; width?: number; height?: number; frameRate?: number } = {};
+      if (typeof args.name === 'string' && args.name.trim().length > 0) {
+        nextMetadata.name = args.name.trim();
+      }
+      if (typeof args.width === 'number' && !Number.isNaN(args.width)) {
+        nextMetadata.width = Math.max(1, Math.round(args.width));
+      }
+      if (typeof args.height === 'number' && !Number.isNaN(args.height)) {
+        nextMetadata.height = Math.max(1, Math.round(args.height));
+      }
+      if (typeof args.frameRate === 'number' && !Number.isNaN(args.frameRate)) {
+        nextMetadata.frameRate = Math.max(1, args.frameRate);
+      }
+      if (Object.keys(nextMetadata).length === 0) {
+        throw new Error('At least one metadata field is required');
+      }
+      handlers.setTemplateMetadata(nextMetadata);
+      return { success: true, ...nextMetadata };
     },
   };
 
@@ -161,8 +401,15 @@ export function createVideoWorkspaceActions(
 
   return [
     addSceneAction,
+    addLayerAction,
+    deleteSceneAction,
     deleteLayerAction,
+    duplicateSceneAction,
+    updateLayerTimingAction,
+    updateLayerOpacityAction,
+    bindLayerInputAction,
     setDurationAction,
+    setTemplateMetadataAction,
     renameTemplateAction,
     loadPresetAction,
     exportAction,

--- a/app/(video)/video/copilot/useVideoWorkspaceActions.ts
+++ b/app/(video)/video/copilot/useVideoWorkspaceActions.ts
@@ -8,16 +8,30 @@ export function useVideoWorkspaceActions(handlers: VideoWorkspaceActionHandlers)
 
   const [
     addSceneAction,
+    addLayerAction,
+    deleteSceneAction,
     deleteLayerAction,
+    duplicateSceneAction,
+    updateLayerTimingAction,
+    updateLayerOpacityAction,
+    bindLayerInputAction,
     setDurationAction,
+    setTemplateMetadataAction,
     renameTemplateAction,
     loadPresetAction,
     exportAction,
   ] = actions;
 
   useCopilotAction(addSceneAction);
+  useCopilotAction(addLayerAction);
+  useCopilotAction(deleteSceneAction);
   useCopilotAction(deleteLayerAction);
+  useCopilotAction(duplicateSceneAction);
+  useCopilotAction(updateLayerTimingAction);
+  useCopilotAction(updateLayerOpacityAction);
+  useCopilotAction(bindLayerInputAction);
   useCopilotAction(setDurationAction);
+  useCopilotAction(setTemplateMetadataAction);
   useCopilotAction(renameTemplateAction);
   useCopilotAction(loadPresetAction);
   useCopilotAction(exportAction);


### PR DESCRIPTION
### Motivation

- Enable the Copilot/AI to manipulate video templates beyond scenes by adding actions for layers, scene duplication/deletion, timing/opacity updates, input bindings, and template metadata updates. 
- Keep action names aligned with the existing `VIDEO_WORKSPACE_ACTION` constants so external callers and the AI use consistent identifiers. 
- Validate parameters in each action handler to avoid unsafe or malformed updates from automated agents.

### Description

- Added new action constants and validated handlers in `app/(video)/video/copilot/actions.ts` for `ADD_LAYER`, `DELETE_SCENE`, `DUPLICATE_SCENE`, `UPDATE_LAYER_TIMING`, `UPDATE_LAYER_OPACITY`, `BIND_LAYER_INPUT`, and `SET_TEMPLATE_METADATA`, and wired input-key validation via `TEMPLATE_INPUT_KEY`.
- Exposed new handler types on `VideoWorkspaceActionHandlers` and updated `createVideoWorkspaceActions` to return and perform parameter validation for the new actions (`addLayer`, `deleteScene`, `duplicateScene`, `updateLayerTiming`, `updateLayerOpacity`, `bindLayerInput`, `setTemplateMetadata`).
- Registered the expanded action list in `app/(video)/video/copilot/useVideoWorkspaceActions.ts` so all new actions are registered with `useCopilotAction`.
- Wired the new handlers into the UI in `app/(video)/video/VideoStudio.tsx` by: changing `handleAddLayer` to accept an optional `sceneId`, adding `handleUpdateLayerTiming`, `handleUpdateLayerOpacity`, and `handleBindLayerInput`, and including them in the `copilotHandlers` mapping so AI actions mutate the current template state via existing persistence helpers.
- Committed the three modified files: `VideoStudio.tsx`, `copilot/actions.ts`, and `copilot/useVideoWorkspaceActions.ts`.

### Testing

- Ran the automated build with `npm run build`, which was attempted but failed due to missing optional environment dependencies (for example `sass`, `@ai-sdk/openai`, and `@copilotkit/react-core`) in this environment, so the production build did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977ab59a288832dbedb68ffd200caa8)